### PR TITLE
Allow customization of the quick disconnect combo

### DIFF
--- a/DvlErrLog.txt
+++ b/DvlErrLog.txt
@@ -1,0 +1,3 @@
+System.Exception: Driver Verification Log needs to be created on a 'Release' configuration. The current selected configuration is 'Debug'.
+   at Microsoft.SdvMenuCommand.DriverVerificationLicense..ctor()
+   at Microsoft.SdvMenuCommand.SdvMenuCommandPackage.StaticToolsLogoMenuItemCallback(Object sender, EventArgs e)

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -454,7 +454,7 @@ static void ConfigNodeParse(
         if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, "HoldTime")))
         {
             pCfg->WirelessDisconnectButtonCombo.HoldTime = (ULONG)cJSON_GetNumberValue(pNode);
-            EventWriteOverrideSettingDouble(pDisconnectCombo->string, "WirelessDisconnectButtonCombo.HoldTime", pCfg->WirelessDisconnectButtonCombo.HoldTime);
+            EventWriteOverrideSettingUInt(pDisconnectCombo->string, "WirelessDisconnectButtonCombo.HoldTime", pCfg->WirelessDisconnectButtonCombo.HoldTime);
         }
 
         const PSTR comboButtonsNames[] =

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -870,7 +870,7 @@ ConfigSetDefaults(
 	Config->DisableWirelessIdleTimeout = FALSE;
 
     Config->WirelessDisconnectButtonCombo.IsEnabled = TRUE;
-    Config->WirelessDisconnectButtonCombo.HoldTime = 3000;
+    Config->WirelessDisconnectButtonCombo.HoldTime = 1000;
     Config->WirelessDisconnectButtonCombo.Buttons[0] = 10;
     Config->WirelessDisconnectButtonCombo.Buttons[1] = 11;
     Config->WirelessDisconnectButtonCombo.Buttons[2] = 16;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -469,7 +469,7 @@ static void ConfigNodeParse(
             if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, comboButtonsNames[buttonIndex])))
             {
                 pCfg->WirelessDisconnectButtonCombo.Buttons[buttonIndex] = (UCHAR)cJSON_GetNumberValue(pNode);
-                //EventWriteOverrideSettingUInt(pDisconnectCombo->string, comboButtonsNames[buttonIndex], pCfg->WirelessDisconnectButtonCombo.Buttons[buttonIndex]);
+                EventWriteOverrideSettingUInt(pDisconnectCombo->string, comboButtonsNames[buttonIndex], pCfg->WirelessDisconnectButtonCombo.Buttons[buttonIndex]);
             }
         }
     }

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -438,6 +438,42 @@ static void ConfigNodeParse(
 		EventWriteOverrideSettingUInt(ParentNode->string, "DisableWirelessIdleTimeout", pCfg->DisableWirelessIdleTimeout);
 	}
 
+    //
+    // Wireless quick disconnect combo
+    // 
+    const cJSON* pDisconnectCombo = cJSON_GetObjectItem(ParentNode, "QuickDisconnectCombo");
+
+    if (pDisconnectCombo)
+    {
+        if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, "IsEnabled")))
+        {
+            pCfg->WirelessDisconnectButtonCombo.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+            EventWriteOverrideSettingUInt(pDisconnectCombo->string, "WirelessDisconnectButtonCombo.IsEnabled", pCfg->WirelessDisconnectButtonCombo.IsEnabled);
+        }
+
+        if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, "HoldTime")))
+        {
+            pCfg->WirelessDisconnectButtonCombo.HoldTime = (ULONG)cJSON_GetNumberValue(pNode);
+            EventWriteOverrideSettingDouble(pDisconnectCombo->string, "WirelessDisconnectButtonCombo.HoldTime", pCfg->WirelessDisconnectButtonCombo.HoldTime);
+        }
+
+        const PSTR comboButtonsNames[] =
+        {
+            "Button1",
+            "Button2",
+            "Button3",
+        };
+
+        for (ULONGLONG buttonIndex = 0; buttonIndex < _countof(pCfg->WirelessDisconnectButtonCombo.Buttons); buttonIndex++)
+        {
+            if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, comboButtonsNames[buttonIndex])))
+            {
+                pCfg->WirelessDisconnectButtonCombo.Buttons[buttonIndex] = (UCHAR)cJSON_GetNumberValue(pNode);
+                //EventWriteOverrideSettingUInt(pDisconnectCombo->string, comboButtonsNames[buttonIndex], pCfg->WirelessDisconnectButtonCombo.Buttons[buttonIndex]);
+            }
+        }
+    }
+
 	//
 	// Every mode can have the same properties configured independently
 	// 

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -869,6 +869,12 @@ ConfigSetDefaults(
 	Config->WirelessIdleTimeoutPeriodMs = 300000;
 	Config->DisableWirelessIdleTimeout = FALSE;
 
+    Config->WirelessDisconnectButtonCombo.IsEnabled = TRUE;
+    Config->WirelessDisconnectButtonCombo.HoldTime = 3000;
+    Config->WirelessDisconnectButtonCombo.Buttons[0] = 10;
+    Config->WirelessDisconnectButtonCombo.Buttons[1] = 11;
+    Config->WirelessDisconnectButtonCombo.Buttons[2] = 16;
+
 	Config->ThumbSettings.DeadZoneLeft.Apply = TRUE;
 	Config->ThumbSettings.DeadZoneLeft.PolarValue = 3.0;
 	Config->ThumbSettings.DeadZoneRight.Apply = TRUE;

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -515,6 +515,11 @@ typedef struct _DS_DRIVER_CONFIGURATION
 	// 
 	BOOLEAN DisableWirelessIdleTimeout;
 
+    //
+    // Wireless disconnect buttom combo customizing
+    //
+    DS_BUTTON_COMBO WirelessDisconnectButtonCombo;
+
 	//
 	// Thumb stick specific settings
 	// 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -302,7 +302,7 @@ typedef struct _DS_BUTTON_COMBO
     //
     // Activates the combination
     // 
-    BOOL IsEnabled;
+    BOOLEAN IsEnabled;
 
     //
     // How long the combination must be held

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -295,6 +295,28 @@ static CONST PSTR G_DS_LED_AUTHORITY_NAMES[] =
 };
 
 //
+// Button combinations
+// 
+typedef struct _DS_BUTTON_COMBO
+{
+    //
+    // Activates the combination
+    // 
+    BOOL IsEnabled;
+
+    //
+    // How long the combination must be held
+    // 
+    ULONG HoldTime;
+
+    //
+    // The buttons that need to be held
+    // 
+    UCHAR Buttons[3];
+
+} DS_BUTTON_COMBO, * PDS_BUTTON_COMBO;
+
+//
 // Axis dead-zone settings
 // 
 typedef struct _DS_AXIS_DEADZONE

--- a/sys/DsHidMini.json
+++ b/sys/DsHidMini.json
@@ -6,6 +6,13 @@
     "OutputRateControlPeriodMs": 150,
     "IsOutputDeduplicatorEnabled": false,
     "WirelessIdleTimeoutPeriodMs": 300000,
+    "QuickDisconnectCombo": {
+      "IsEnabled": true,
+      "HoldTime": 1000,
+      "Button1": 16,
+      "Button2": 11,
+      "Button3": 10
+    },
     "SDF": {
       "PressureExposureMode": "Default",
       "DPadExposureMode": "Default",

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1922,7 +1922,7 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
     //
     // Quick disconnect combo detected
     // 
-    if (&pDevCtx->Configuration.WirelessDisconnectButtonCombo.IsEnabled)
+    if (pDevCtx->Configuration.WirelessDisconnectButtonCombo.IsEnabled)
     {
         int engagedCount = 0;
         for (int buttonIndex = 0; buttonIndex < 3; buttonIndex++)

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1952,7 +1952,7 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
         //
         // 1 second passed
         // 
-        if (ms > 1000)
+        if (ms > pDevCtx->Configuration.WirelessDisconnectButtonCombo.HoldTime)
         {
             TraceEvents(TRACE_LEVEL_INFORMATION,
                 TRACE_DSHIDMINIDRV,

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1933,59 +1933,59 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
     // 
     if (&pDevCtx->Configuration.WirelessDisconnectButtonCombo.IsEnabled)
     {
-    if (engagedCount == 3)
-    {
-        TraceEvents(TRACE_LEVEL_INFORMATION,
-            TRACE_DSHIDMINIDRV,
-            "!! Quick disconnect combination detected"
-        );
-
-        t1 = &pDevCtx->Connection.Bth.QuickDisconnectTimestamp;
-
-        if (pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart == 0)
-        {
-            QueryPerformanceCounter(t1);
-        }
-
-        QueryPerformanceCounter(&t2);
-
-        ms = (t2.QuadPart - t1->QuadPart) / (freq.QuadPart / 1000);
-
-        //
-        // 1 second passed
-        // 
-        if (ms > pDevCtx->Configuration.WirelessDisconnectButtonCombo.HoldTime)
+        if (engagedCount == 3)
         {
             TraceEvents(TRACE_LEVEL_INFORMATION,
                 TRACE_DSHIDMINIDRV,
-                "!! Sending disconnect request"
+                "!! Quick disconnect combination detected"
             );
 
-            //
-            // Send disconnect request
-            // 
-            status = DsBth_SendDisconnectRequest(pDevCtx);
+            t1 = &pDevCtx->Connection.Bth.QuickDisconnectTimestamp;
 
-            if (!NT_SUCCESS(status))
+            if (pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart == 0)
             {
-                TraceError(
-                    TRACE_DSHIDMINIDRV,
-                    "Sending disconnect request failed with status %!STATUS!",
-                    status
-                );
-                EventWriteFailedWithNTStatus(__FUNCTION__, L"DsBth_SendDisconnectRequest", status);
+                QueryPerformanceCounter(t1);
             }
 
+            QueryPerformanceCounter(&t2);
+
+            ms = (t2.QuadPart - t1->QuadPart) / (freq.QuadPart / 1000);
+
             //
-            // No further processing
+            // 1 second passed
             // 
-            return ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
+            if (ms > pDevCtx->Configuration.WirelessDisconnectButtonCombo.HoldTime)
+            {
+                TraceEvents(TRACE_LEVEL_INFORMATION,
+                    TRACE_DSHIDMINIDRV,
+                    "!! Sending disconnect request"
+                );
+
+                //
+                // Send disconnect request
+                // 
+                status = DsBth_SendDisconnectRequest(pDevCtx);
+
+                if (!NT_SUCCESS(status))
+                {
+                    TraceError(
+                        TRACE_DSHIDMINIDRV,
+                        "Sending disconnect request failed with status %!STATUS!",
+                        status
+                    );
+                    EventWriteFailedWithNTStatus(__FUNCTION__, L"DsBth_SendDisconnectRequest", status);
+                }
+
+                //
+                // No further processing
+                // 
+                return ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
+            }
         }
-    }
-    else
-    {
-        pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart = 0;
-    }
+        else
+        {
+            pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart = 0;
+        }
     }
 
 	//

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1931,6 +1931,8 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
     //
     // Quick disconnect combo detected
     // 
+    if (&pDevCtx->Configuration.WirelessDisconnectButtonCombo.IsEnabled)
+    {
     if (engagedCount == 3)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION,
@@ -1983,6 +1985,7 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
     else
     {
         pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart = 0;
+    }
     }
 
 	//

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1919,66 +1919,71 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 		}
 	}
 
-	//
-	// Quick disconnect combo (L1 + R1 + PS) detected
-	// 
-	if (
-		pInReport->Buttons.Individual.L1
-		&& pInReport->Buttons.Individual.R1
-		&& pInReport->Buttons.Individual.PS
-		)
-	{
-		TraceEvents(TRACE_LEVEL_INFORMATION,
-			TRACE_DSHIDMINIDRV,
-			"!! Quick disconnect combination detected"
-		);
+    int engagedCount = 0;
+    for (int buttonIndex = 0; buttonIndex < 3; buttonIndex++)
+    {
+        if ((pInReport->Buttons.lButtons >> pDevCtx->Configuration.WirelessDisconnectButtonCombo.Buttons[buttonIndex]) & 1)
+        {
+            engagedCount++;
+        }
+    }
 
-		t1 = &pDevCtx->Connection.Bth.QuickDisconnectTimestamp;
+    //
+    // Quick disconnect combo detected
+    // 
+    if (engagedCount == 3)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION,
+            TRACE_DSHIDMINIDRV,
+            "!! Quick disconnect combination detected"
+        );
 
-		if (pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart == 0)
-		{
-			QueryPerformanceCounter(t1);
-		}
+        t1 = &pDevCtx->Connection.Bth.QuickDisconnectTimestamp;
 
-		QueryPerformanceCounter(&t2);
+        if (pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart == 0)
+        {
+            QueryPerformanceCounter(t1);
+        }
 
-		ms = (t2.QuadPart - t1->QuadPart) / (freq.QuadPart / 1000);
+        QueryPerformanceCounter(&t2);
 
-		//
-		// 1 second passed
-		// 
-		if (ms > 1000)
-		{
-			TraceEvents(TRACE_LEVEL_INFORMATION,
-				TRACE_DSHIDMINIDRV,
-				"!! Sending disconnect request"
-			);
+        ms = (t2.QuadPart - t1->QuadPart) / (freq.QuadPart / 1000);
 
-			//
-			// Send disconnect request
-			// 
-			status = DsBth_SendDisconnectRequest(pDevCtx);
+        //
+        // 1 second passed
+        // 
+        if (ms > 1000)
+        {
+            TraceEvents(TRACE_LEVEL_INFORMATION,
+                TRACE_DSHIDMINIDRV,
+                "!! Sending disconnect request"
+            );
 
-			if (!NT_SUCCESS(status))
-			{
-				TraceError(
-					TRACE_DSHIDMINIDRV,
-					"Sending disconnect request failed with status %!STATUS!",
-					status
-				);
-				EventWriteFailedWithNTStatus(__FUNCTION__, L"DsBth_SendDisconnectRequest", status);
-			}
+            //
+            // Send disconnect request
+            // 
+            status = DsBth_SendDisconnectRequest(pDevCtx);
 
-			//
-			// No further processing
-			// 
-			return ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
-		}
-	}
-	else
-	{
-		pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart = 0;
-	}
+            if (!NT_SUCCESS(status))
+            {
+                TraceError(
+                    TRACE_DSHIDMINIDRV,
+                    "Sending disconnect request failed with status %!STATUS!",
+                    status
+                );
+                EventWriteFailedWithNTStatus(__FUNCTION__, L"DsBth_SendDisconnectRequest", status);
+            }
+
+            //
+            // No further processing
+            // 
+            return ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
+        }
+    }
+    else
+    {
+        pDevCtx->Connection.Bth.QuickDisconnectTimestamp.QuadPart = 0;
+    }
 
 	//
 	// Idle disconnect detection

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1919,20 +1919,20 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 		}
 	}
 
-    int engagedCount = 0;
-    for (int buttonIndex = 0; buttonIndex < 3; buttonIndex++)
-    {
-        if ((pInReport->Buttons.lButtons >> pDevCtx->Configuration.WirelessDisconnectButtonCombo.Buttons[buttonIndex]) & 1)
-        {
-            engagedCount++;
-        }
-    }
-
     //
     // Quick disconnect combo detected
     // 
     if (&pDevCtx->Configuration.WirelessDisconnectButtonCombo.IsEnabled)
     {
+        int engagedCount = 0;
+        for (int buttonIndex = 0; buttonIndex < 3; buttonIndex++)
+        {
+            if ((pInReport->Buttons.lButtons >> pDevCtx->Configuration.WirelessDisconnectButtonCombo.Buttons[buttonIndex]) & 1)
+            {
+                engagedCount++;
+            }
+        }
+
         if (engagedCount == 3)
         {
             TraceEvents(TRACE_LEVEL_INFORMATION,


### PR DESCRIPTION
Allows customization of the wireless disconnect button combo and hold time, with up to 3 different buttons to be chosen for the combo.

Implements #261 

I'm not entirely sure if I done the following line correctly though:

https://github.com/Kanuan/DsHidMini/blob/customize-wireless-disconnect/sys/Configuration.c#L472