### PR TITLE
Fix backing up current LED state when using driver LED authority in SXS processing

### DIFF
--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1062,7 +1062,7 @@ DsHidMini_WriteReport(
 			//
 			// Backup LED states
 			// 
-			RtlCopyMemory(ledBlock, &buffer[10], ARRAYSIZE(ledBlock));
+			RtlCopyMemory(ledBlock, &buffer[9], ARRAYSIZE(ledBlock));
 
 			//
 			// Overwrite with what we received
@@ -1076,7 +1076,7 @@ DsHidMini_WriteReport(
 			//
 			// Restore LED states
 			// 
-			RtlCopyMemory(&buffer[10], ledBlock, ARRAYSIZE(ledBlock));
+			RtlCopyMemory(&buffer[9], ledBlock, ARRAYSIZE(ledBlock));
 		}
 		else
 		{


### PR DESCRIPTION
It was backing up the correct length of 21 bytes that encompass all current LED info, but it was starting in the wrong offset (10 instead of 9)