### PR TITLE
Fix loading of custom LEDs settings

### DIFF
--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -301,10 +301,10 @@ ConfigParseLEDSettings(
                     EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "OffPortionMultiplier", pPlayerSlots[playerIndex]->OffPortionMultiplier);
                 }
 
-                if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalPortionOn")))
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "OnPortionMultiplier")))
                 {
-                    pPlayerSlots[playerIndex]->IntervalPortionOn = (UCHAR)cJSON_GetNumberValue(pNode);
-                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalPortionOn", pPlayerSlots[playerIndex]->IntervalPortionOn);
+                    pPlayerSlots[playerIndex]->OnPortionMultiplier = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "OnPortionMultiplier", pPlayerSlots[playerIndex]->OnPortionMultiplier);
                 }
             }
 		}
@@ -955,7 +955,7 @@ ConfigSetDefaults(
 		pPlayerSlots[playerIndex]->BasePortionDuration1 = 0xFF;
 		pPlayerSlots[playerIndex]->BasePortionDuration0 = 0x10;
 		pPlayerSlots[playerIndex]->OffPortionMultiplier = 0x00;
-		pPlayerSlots[playerIndex]->IntervalPortionOn = 0xFF;
+		pPlayerSlots[playerIndex]->OnPortionMultiplier = 0xFF;
 	}
 
 	//

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -283,10 +283,10 @@ ConfigParseLEDSettings(
                     EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Duration", pPlayerSlots[playerIndex]->Duration);
                 }
 
-                if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalDuration")))
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "BasePortionDuration1")))
                 {
-                    pPlayerSlots[playerIndex]->IntervalDuration = (UCHAR)cJSON_GetNumberValue(pNode);
-                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalDuration", pPlayerSlots[playerIndex]->IntervalDuration);
+                    pPlayerSlots[playerIndex]->BasePortionDuration1 = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "BasePortionDuration1", pPlayerSlots[playerIndex]->BasePortionDuration1);
                 }
 
                 if ((pNode = cJSON_GetObjectItem(pPlayer, "Enabled")))
@@ -952,7 +952,7 @@ ConfigSetDefaults(
 	for (ULONGLONG playerIndex = 0; playerIndex < _countof(pPlayerSlots); playerIndex++)
 	{
 		pPlayerSlots[playerIndex]->Duration = 0xFF;
-		pPlayerSlots[playerIndex]->IntervalDuration = 0xFF;
+		pPlayerSlots[playerIndex]->BasePortionDuration1 = 0xFF;
 		pPlayerSlots[playerIndex]->EnabledFlags = 0x10;
 		pPlayerSlots[playerIndex]->IntervalPortionOff = 0x00;
 		pPlayerSlots[playerIndex]->IntervalPortionOn = 0xFF;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -295,10 +295,10 @@ ConfigParseLEDSettings(
                     EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Enabled", pPlayerSlots[playerIndex]->BasePortionDuration0);
                 }
 
-                if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalPortionOff")))
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "OffPortionMultiplier")))
                 {
-                    pPlayerSlots[playerIndex]->IntervalPortionOff = (UCHAR)cJSON_GetNumberValue(pNode);
-                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalPortionOff", pPlayerSlots[playerIndex]->IntervalPortionOff);
+                    pPlayerSlots[playerIndex]->OffPortionMultiplier = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "OffPortionMultiplier", pPlayerSlots[playerIndex]->OffPortionMultiplier);
                 }
 
                 if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalPortionOn")))
@@ -954,7 +954,7 @@ ConfigSetDefaults(
 		pPlayerSlots[playerIndex]->Duration = 0xFF;
 		pPlayerSlots[playerIndex]->BasePortionDuration1 = 0xFF;
 		pPlayerSlots[playerIndex]->BasePortionDuration0 = 0x10;
-		pPlayerSlots[playerIndex]->IntervalPortionOff = 0x00;
+		pPlayerSlots[playerIndex]->OffPortionMultiplier = 0x00;
 		pPlayerSlots[playerIndex]->IntervalPortionOn = 0xFF;
 	}
 

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -289,10 +289,10 @@ ConfigParseLEDSettings(
                     EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "BasePortionDuration1", pPlayerSlots[playerIndex]->BasePortionDuration1);
                 }
 
-                if ((pNode = cJSON_GetObjectItem(pPlayer, "Enabled")))
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "BasePortionDuration0")))
                 {
                     pPlayerSlots[playerIndex]->BasePortionDuration0 = (UCHAR)cJSON_GetNumberValue(pNode);
-                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Enabled", pPlayerSlots[playerIndex]->BasePortionDuration0);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "BasePortionDuration0", pPlayerSlots[playerIndex]->BasePortionDuration0);
                 }
 
                 if ((pNode = cJSON_GetObjectItem(pPlayer, "OffPortionMultiplier")))

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -277,10 +277,10 @@ ConfigParseLEDSettings(
 		for (ULONGLONG playerIndex = 0; playerIndex < _countof(playerSlotNames); playerIndex++)
 		{
             if (pPlayer = cJSON_GetObjectItem(pCustomPatterns, playerSlotNames[playerIndex])) {
-                if ((pNode = cJSON_GetObjectItem(pPlayer, "Duration")))
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "TotalDuration")))
                 {
-                    pPlayerSlots[playerIndex]->Duration = (UCHAR)cJSON_GetNumberValue(pNode);
-                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Duration", pPlayerSlots[playerIndex]->Duration);
+                    pPlayerSlots[playerIndex]->TotalDuration = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "TotalDuration", pPlayerSlots[playerIndex]->TotalDuration);
                 }
 
                 if ((pNode = cJSON_GetObjectItem(pPlayer, "BasePortionDuration1")))
@@ -951,7 +951,7 @@ ConfigSetDefaults(
 
 	for (ULONGLONG playerIndex = 0; playerIndex < _countof(pPlayerSlots); playerIndex++)
 	{
-		pPlayerSlots[playerIndex]->Duration = 0xFF;
+		pPlayerSlots[playerIndex]->TotalDuration = 0xFF;
 		pPlayerSlots[playerIndex]->BasePortionDuration1 = 0xFF;
 		pPlayerSlots[playerIndex]->BasePortionDuration0 = 0x10;
 		pPlayerSlots[playerIndex]->OffPortionMultiplier = 0x00;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -291,8 +291,8 @@ ConfigParseLEDSettings(
 
                 if ((pNode = cJSON_GetObjectItem(pPlayer, "Enabled")))
                 {
-                    pPlayerSlots[playerIndex]->EnabledFlags = (UCHAR)cJSON_GetNumberValue(pNode);
-                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Enabled", pPlayerSlots[playerIndex]->EnabledFlags);
+                    pPlayerSlots[playerIndex]->BasePortionDuration0 = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Enabled", pPlayerSlots[playerIndex]->BasePortionDuration0);
                 }
 
                 if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalPortionOff")))
@@ -953,7 +953,7 @@ ConfigSetDefaults(
 	{
 		pPlayerSlots[playerIndex]->Duration = 0xFF;
 		pPlayerSlots[playerIndex]->BasePortionDuration1 = 0xFF;
-		pPlayerSlots[playerIndex]->EnabledFlags = 0x10;
+		pPlayerSlots[playerIndex]->BasePortionDuration0 = 0x10;
 		pPlayerSlots[playerIndex]->IntervalPortionOff = 0x00;
 		pPlayerSlots[playerIndex]->IntervalPortionOn = 0xFF;
 	}

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -273,37 +273,40 @@ ConfigParseLEDSettings(
 			&Config->LEDSettings.CustomPatterns.Player4,
 		};
 
+        cJSON* pPlayer = NULL;
 		for (ULONGLONG playerIndex = 0; playerIndex < _countof(playerSlotNames); playerIndex++)
 		{
-			if ((pNode = cJSON_GetObjectItem(pCustomPatterns, "Duration")))
-			{
-				pPlayerSlots[playerIndex]->Duration = (UCHAR)cJSON_GetNumberValue(pNode);
-				EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Duration", pPlayerSlots[playerIndex]->Duration);
-			}
+            if (pPlayer = cJSON_GetObjectItem(pCustomPatterns, playerSlotNames[playerIndex])) {
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "Duration")))
+                {
+                    pPlayerSlots[playerIndex]->Duration = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Duration", pPlayerSlots[playerIndex]->Duration);
+                }
 
-			if ((pNode = cJSON_GetObjectItem(pCustomPatterns, "IntervalDuration")))
-			{
-				pPlayerSlots[playerIndex]->IntervalDuration = (UCHAR)cJSON_GetNumberValue(pNode);
-				EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalDuration", pPlayerSlots[playerIndex]->IntervalDuration);
-			}
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalDuration")))
+                {
+                    pPlayerSlots[playerIndex]->IntervalDuration = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalDuration", pPlayerSlots[playerIndex]->IntervalDuration);
+                }
 
-			if ((pNode = cJSON_GetObjectItem(pCustomPatterns, "Enabled")))
-			{
-				pPlayerSlots[playerIndex]->EnabledFlags = (UCHAR)cJSON_GetNumberValue(pNode);
-				EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Enabled", pPlayerSlots[playerIndex]->EnabledFlags);
-			}
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "Enabled")))
+                {
+                    pPlayerSlots[playerIndex]->EnabledFlags = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "Enabled", pPlayerSlots[playerIndex]->EnabledFlags);
+                }
 
-			if ((pNode = cJSON_GetObjectItem(pCustomPatterns, "IntervalPortionOff")))
-			{
-				pPlayerSlots[playerIndex]->IntervalPortionOff = (UCHAR)cJSON_GetNumberValue(pNode);
-				EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalPortionOff", pPlayerSlots[playerIndex]->IntervalPortionOff);
-			}
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalPortionOff")))
+                {
+                    pPlayerSlots[playerIndex]->IntervalPortionOff = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalPortionOff", pPlayerSlots[playerIndex]->IntervalPortionOff);
+                }
 
-			if ((pNode = cJSON_GetObjectItem(pCustomPatterns, "IntervalPortionOn")))
-			{
-				pPlayerSlots[playerIndex]->IntervalPortionOn = (UCHAR)cJSON_GetNumberValue(pNode);
-				EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalPortionOn", pPlayerSlots[playerIndex]->IntervalPortionOn);
-			}
+                if ((pNode = cJSON_GetObjectItem(pPlayer, "IntervalPortionOn")))
+                {
+                    pPlayerSlots[playerIndex]->IntervalPortionOn = (UCHAR)cJSON_GetNumberValue(pNode);
+                    EventWriteOverrideSettingUInt(playerSlotNames[playerIndex], "IntervalPortionOn", pPlayerSlots[playerIndex]->IntervalPortionOn);
+                }
+            }
 		}
 	}
 }

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -327,9 +327,10 @@ VOID DS3_SET_LED_DURATION(
 	PDEVICE_CONTEXT Context,
 	UCHAR LedIndex,
 	UCHAR TotalDuration,
-	UCHAR Interval,
-	UCHAR OffInterval,
-	UCHAR OnInterval
+    UCHAR BasePortionDuration1,
+	UCHAR BasePortionDuration0,
+	UCHAR OffPortionMultiplier,
+	UCHAR OnPortionMultiplier
 )
 {
 	if (LedIndex > 3)
@@ -347,9 +348,10 @@ VOID DS3_SET_LED_DURATION(
 	);
 
 	buffer[10 + (LedIndex * 5)] = TotalDuration;
-	buffer[11 + (LedIndex * 5)] = Interval;
-	buffer[13 + (LedIndex * 5)] = OffInterval;
-	buffer[14 + (LedIndex * 5)] = OnInterval;
+	buffer[11 + (LedIndex * 5)] = BasePortionDuration1;
+    buffer[12 + (LedIndex * 5)] = BasePortionDuration0;
+	buffer[13 + (LedIndex * 5)] = OffPortionMultiplier;
+	buffer[14 + (LedIndex * 5)] = OnPortionMultiplier;
 }
 
 //
@@ -361,9 +363,10 @@ VOID DS3_SET_LED_DURATION_DEFAULT(PDEVICE_CONTEXT Context, UCHAR LedIndex)
 		Context,
 		LedIndex,
 		0xFF, // Interval repeat never ends
-		0x27, // Interval duration
+		0x27, // BasePortionDuration1
+        0x00, // BasePortionDuration0
 		0x00, // No OFF-portion
-		0x32 // Default ON-portion
+		0x32 // Default ON-portion multiplier
 	);
 }
 

--- a/sys/Ds3.h
+++ b/sys/Ds3.h
@@ -35,12 +35,13 @@ extern const UCHAR G_Ds3BthHidOutputReport[];
 
 
 VOID DS3_SET_LED_DURATION(
-	PDEVICE_CONTEXT Context,
-	UCHAR LedIndex,
-	UCHAR TotalDuration,
-	UCHAR Interval,
-	UCHAR OffInterval,
-	UCHAR OnInterval
+    PDEVICE_CONTEXT Context,
+    UCHAR LedIndex,
+    UCHAR TotalDuration,
+    UCHAR BasePortionDuration1,
+    UCHAR BasePortionDuration0,
+    UCHAR OffPortionMultiplier,
+    UCHAR OnPortionMultiplier
 );
 
 VOID DS3_SET_LED_DURATION_DEFAULT(

--- a/sys/DsBth.c
+++ b/sys/DsBth.c
@@ -82,7 +82,7 @@ DsBth_EvtControlWriteTimerFunc(
 		case DsBatteryStatusLow:
 		case DsBatteryStatusDying:
 			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-			DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
+			DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 00, 127, 127);
 			break;
 		default:
 			break;

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -431,7 +431,7 @@ typedef struct _DS_LED
 
 	UCHAR BasePortionDuration1;
 
-	UCHAR EnabledFlags;
+	UCHAR BasePortionDuration0;
 
 	UCHAR IntervalPortionOff;
 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -427,7 +427,7 @@ typedef struct _DS_RUMBLE_SETTINGS
 // 
 typedef struct _DS_LED
 {
-	UCHAR Duration;
+	UCHAR TotalDuration;
 
 	UCHAR BasePortionDuration1;
 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -429,7 +429,7 @@ typedef struct _DS_LED
 {
 	UCHAR Duration;
 
-	UCHAR IntervalDuration;
+	UCHAR BasePortionDuration1;
 
 	UCHAR EnabledFlags;
 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -433,7 +433,7 @@ typedef struct _DS_LED
 
 	UCHAR BasePortionDuration0;
 
-	UCHAR IntervalPortionOff;
+	UCHAR OffPortionMultiplier;
 
 	UCHAR IntervalPortionOn;
 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -435,7 +435,7 @@ typedef struct _DS_LED
 
 	UCHAR OffPortionMultiplier;
 
-	UCHAR IntervalPortionOn;
+	UCHAR OnPortionMultiplier;
 
 } DS_LED, * PDS_LED;
 

--- a/sys/DsHidMini.json
+++ b/sys/DsHidMini.json
@@ -122,32 +122,32 @@
         "CustomPatterns": {
           "LEDFlags": 2,
           "Player1": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 255,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 1,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 1
           },
           "Player2": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player3": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player4": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           }
         }
       }
@@ -186,32 +186,32 @@
         "CustomPatterns": {
           "LEDFlags": 2,
           "Player1": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 255,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 1,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 1
           },
           "Player2": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player3": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player4": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           }
         }
       }
@@ -250,32 +250,32 @@
         "CustomPatterns": {
           "LEDFlags": 2,
           "Player1": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 255,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 1,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 1
           },
           "Player2": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player3": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player4": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           }
         }
       }
@@ -314,32 +314,32 @@
         "CustomPatterns": {
           "LEDFlags": 2,
           "Player1": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 255,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 1,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 1
           },
           "Player2": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player3": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           },
           "Player4": {
-            "Duration": 255,
-            "IntervalDuration": 255,
-            "EnabledFlags": 16,
-            "IntervalPortionOff": 0,
-            "IntervalPortionOn": 255
+            "TotalDuration": 0,
+            "BasePortionDuration1": 0,
+            "BasePortionDuration0": 0,
+            "OffPortionMultiplier": 0,
+            "OnPortionMultiplier": 0
           }
         }
       }

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -909,7 +909,7 @@ DsHidMini_WriteReport(
 		pSetEffect = (PPID_SET_EFFECT_REPORT)Packet->reportBuffer;
 
 		TraceVerbose(TRACE_DSHIDMINIDRV, "!! SET_EFFECT_REPORT, EffectBlockIndex: %d, "
-			"EffectType: %d, Duration: %d, TriggerRepeatInterval: %d, "
+			"EffectType: %d, TotalDuration: %d, TriggerRepeatInterval: %d, "
 			"SamplePeriod: %d, Gain: %d, TriggerButton: %d, AxesEnableX: %d, AxesEnableY: %d, "
 			"DirectionEnable: %d, DirectionInstance1: %d, DirectionInstance2: %d, StartDelay: %d",
 			pSetEffect->EffectBlockIndex,
@@ -2401,7 +2401,7 @@ Ds_SendOutputReport(
 			DS3_SET_LED_DURATION(
 				Context,
 				0,
-				pConfig->LEDSettings.CustomPatterns.Player1.Duration,
+				pConfig->LEDSettings.CustomPatterns.Player1.TotalDuration,
 				pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration1,
                 pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player1.OffPortionMultiplier,
@@ -2410,7 +2410,7 @@ Ds_SendOutputReport(
 			DS3_SET_LED_DURATION(
 				Context,
 				1,
-				pConfig->LEDSettings.CustomPatterns.Player2.Duration,
+				pConfig->LEDSettings.CustomPatterns.Player2.TotalDuration,
 				pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration1,
                 pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player2.OffPortionMultiplier,
@@ -2419,7 +2419,7 @@ Ds_SendOutputReport(
 			DS3_SET_LED_DURATION(
 				Context,
 				2,
-				pConfig->LEDSettings.CustomPatterns.Player3.Duration,
+				pConfig->LEDSettings.CustomPatterns.Player3.TotalDuration,
 				pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration1,
                 pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player3.OffPortionMultiplier,
@@ -2428,7 +2428,7 @@ Ds_SendOutputReport(
 			DS3_SET_LED_DURATION(
 				Context,
 				3,
-				pConfig->LEDSettings.CustomPatterns.Player4.Duration,
+				pConfig->LEDSettings.CustomPatterns.Player4.TotalDuration,
 				pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration1,
                 pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player4.OffPortionMultiplier,

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1182,7 +1182,7 @@ DsHidMini_WriteReport(
 						DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
 					else {
 						DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-						DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
+						DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 00, 127, 127);
 					}
 				}
 				//
@@ -1200,7 +1200,7 @@ DsHidMini_WriteReport(
 						DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
 					else {
 						DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-						DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
+						DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 00, 127, 127);
 					}
 				}
 				//
@@ -1221,10 +1221,10 @@ DsHidMini_WriteReport(
 				// Set to rapidly flash all 4 LEDs
 				// 
 				DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
-				DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 3, 127, 127);
-				DS3_SET_LED_DURATION(pDevCtx, 1, 0xFF, 3, 127, 127);
-				DS3_SET_LED_DURATION(pDevCtx, 2, 0xFF, 3, 127, 127);
-				DS3_SET_LED_DURATION(pDevCtx, 3, 0xFF, 3, 127, 127);
+				DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 3, 00, 127, 127);
+				DS3_SET_LED_DURATION(pDevCtx, 1, 0xFF, 3, 00, 127, 127);
+				DS3_SET_LED_DURATION(pDevCtx, 2, 0xFF, 3, 00, 127, 127);
+				DS3_SET_LED_DURATION(pDevCtx, 3, 0xFF, 3, 00, 127, 127);
 			}
 		}
 
@@ -1882,7 +1882,7 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 						case DsBatteryStatusLow:
 						case DsBatteryStatusDying:
 							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-							DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
+							DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 00, 127, 127);
 							break;
 						default:
 							break;
@@ -1906,7 +1906,7 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 						case DsBatteryStatusLow:
 						case DsBatteryStatusDying:
 							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-							DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
+							DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 00, 127, 127);
 							break;
 						default:
 							break;
@@ -2403,6 +2403,7 @@ Ds_SendOutputReport(
 				0,
 				pConfig->LEDSettings.CustomPatterns.Player1.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration1,
+                pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player1.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player1.OnPortionMultiplier
 			);
@@ -2411,6 +2412,7 @@ Ds_SendOutputReport(
 				1,
 				pConfig->LEDSettings.CustomPatterns.Player2.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration1,
+                pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player2.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player2.OnPortionMultiplier
 			);
@@ -2419,6 +2421,7 @@ Ds_SendOutputReport(
 				2,
 				pConfig->LEDSettings.CustomPatterns.Player3.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration1,
+                pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player3.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player3.OnPortionMultiplier
 			);
@@ -2427,6 +2430,7 @@ Ds_SendOutputReport(
 				3,
 				pConfig->LEDSettings.CustomPatterns.Player4.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration1,
+                pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player4.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player4.OnPortionMultiplier
 			);

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -2412,7 +2412,7 @@ Ds_SendOutputReport(
 				1,
 				pConfig->LEDSettings.CustomPatterns.Player2.TotalDuration,
 				pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration1,
-                pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
+                pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player2.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player2.OnPortionMultiplier
 			);
@@ -2421,7 +2421,7 @@ Ds_SendOutputReport(
 				2,
 				pConfig->LEDSettings.CustomPatterns.Player3.TotalDuration,
 				pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration1,
-                pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
+                pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player3.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player3.OnPortionMultiplier
 			);
@@ -2430,7 +2430,7 @@ Ds_SendOutputReport(
 				3,
 				pConfig->LEDSettings.CustomPatterns.Player4.TotalDuration,
 				pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration1,
-                pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration0,
+                pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration0,
 				pConfig->LEDSettings.CustomPatterns.Player4.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player4.OnPortionMultiplier
 			);

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -2404,7 +2404,7 @@ Ds_SendOutputReport(
 				pConfig->LEDSettings.CustomPatterns.Player1.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player1.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player1.IntervalPortionOn
+				pConfig->LEDSettings.CustomPatterns.Player1.OnPortionMultiplier
 			);
 			DS3_SET_LED_DURATION(
 				Context,
@@ -2412,7 +2412,7 @@ Ds_SendOutputReport(
 				pConfig->LEDSettings.CustomPatterns.Player2.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player2.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player2.IntervalPortionOn
+				pConfig->LEDSettings.CustomPatterns.Player2.OnPortionMultiplier
 			);
 			DS3_SET_LED_DURATION(
 				Context,
@@ -2420,7 +2420,7 @@ Ds_SendOutputReport(
 				pConfig->LEDSettings.CustomPatterns.Player3.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player3.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player3.IntervalPortionOn
+				pConfig->LEDSettings.CustomPatterns.Player3.OnPortionMultiplier
 			);
 			DS3_SET_LED_DURATION(
 				Context,
@@ -2428,7 +2428,7 @@ Ds_SendOutputReport(
 				pConfig->LEDSettings.CustomPatterns.Player4.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player4.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player4.IntervalPortionOn
+				pConfig->LEDSettings.CustomPatterns.Player4.OnPortionMultiplier
 			);
 		}
 

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -2402,7 +2402,7 @@ Ds_SendOutputReport(
 				Context,
 				0,
 				pConfig->LEDSettings.CustomPatterns.Player1.Duration,
-				pConfig->LEDSettings.CustomPatterns.Player1.IntervalDuration,
+				pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player1.IntervalPortionOff,
 				pConfig->LEDSettings.CustomPatterns.Player1.IntervalPortionOn
 			);
@@ -2410,7 +2410,7 @@ Ds_SendOutputReport(
 				Context,
 				1,
 				pConfig->LEDSettings.CustomPatterns.Player2.Duration,
-				pConfig->LEDSettings.CustomPatterns.Player2.IntervalDuration,
+				pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player2.IntervalPortionOff,
 				pConfig->LEDSettings.CustomPatterns.Player2.IntervalPortionOn
 			);
@@ -2418,7 +2418,7 @@ Ds_SendOutputReport(
 				Context,
 				2,
 				pConfig->LEDSettings.CustomPatterns.Player3.Duration,
-				pConfig->LEDSettings.CustomPatterns.Player3.IntervalDuration,
+				pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player3.IntervalPortionOff,
 				pConfig->LEDSettings.CustomPatterns.Player3.IntervalPortionOn
 			);
@@ -2426,7 +2426,7 @@ Ds_SendOutputReport(
 				Context,
 				3,
 				pConfig->LEDSettings.CustomPatterns.Player4.Duration,
-				pConfig->LEDSettings.CustomPatterns.Player4.IntervalDuration,
+				pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration1,
 				pConfig->LEDSettings.CustomPatterns.Player4.IntervalPortionOff,
 				pConfig->LEDSettings.CustomPatterns.Player4.IntervalPortionOn
 			);

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -2403,7 +2403,7 @@ Ds_SendOutputReport(
 				0,
 				pConfig->LEDSettings.CustomPatterns.Player1.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration1,
-				pConfig->LEDSettings.CustomPatterns.Player1.IntervalPortionOff,
+				pConfig->LEDSettings.CustomPatterns.Player1.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player1.IntervalPortionOn
 			);
 			DS3_SET_LED_DURATION(
@@ -2411,7 +2411,7 @@ Ds_SendOutputReport(
 				1,
 				pConfig->LEDSettings.CustomPatterns.Player2.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration1,
-				pConfig->LEDSettings.CustomPatterns.Player2.IntervalPortionOff,
+				pConfig->LEDSettings.CustomPatterns.Player2.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player2.IntervalPortionOn
 			);
 			DS3_SET_LED_DURATION(
@@ -2419,7 +2419,7 @@ Ds_SendOutputReport(
 				2,
 				pConfig->LEDSettings.CustomPatterns.Player3.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration1,
-				pConfig->LEDSettings.CustomPatterns.Player3.IntervalPortionOff,
+				pConfig->LEDSettings.CustomPatterns.Player3.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player3.IntervalPortionOn
 			);
 			DS3_SET_LED_DURATION(
@@ -2427,7 +2427,7 @@ Ds_SendOutputReport(
 				3,
 				pConfig->LEDSettings.CustomPatterns.Player4.Duration,
 				pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration1,
-				pConfig->LEDSettings.CustomPatterns.Player4.IntervalPortionOff,
+				pConfig->LEDSettings.CustomPatterns.Player4.OffPortionMultiplier,
 				pConfig->LEDSettings.CustomPatterns.Player4.IntervalPortionOn
 			);
 		}


### PR DESCRIPTION
The logic used for loading each Player LED settings was incorrect. It is now fixed to properly fetch all settings.

Besides that, I've renamed some variables to reflect the actual functioning of the LED effects as discussed in #314 . The chosen names are:

- TotalDuration
- BasePortionDuration1
- BasePortionDuration0
- OffPortionMultiplier
- OnPortionMultiplier

Because the base portion duration is a 2 byte value represented by BasePortionDuration1 and BasePortionDuration0 I've considered turning it into an array BasePortionDuration[2]. Tell me if it would be better and I'll update the PR