### PR TITLE
Reworked rumble configuration and processing

### DIFF
--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -922,18 +922,18 @@ ConfigSetDefaults(
 	Config->ThumbSettings.DeadZoneRight.Apply = TRUE;
 	Config->ThumbSettings.DeadZoneRight.PolarValue = 3.0;
 
-	Config->RumbleSettings.DisableBM = FALSE;
-	Config->RumbleSettings.DisableSM = FALSE;
-	Config->RumbleSettings.BMStrRescale.Enabled = TRUE;
-	Config->RumbleSettings.BMStrRescale.MinValue = 64;
-	Config->RumbleSettings.BMStrRescale.MaxValue = 255;
-	Config->RumbleSettings.SMToBMConversion.Enabled = FALSE;
-	Config->RumbleSettings.SMToBMConversion.RescaleMinValue = 1;
-	Config->RumbleSettings.SMToBMConversion.RescaleMaxValue = 140;
-	Config->RumbleSettings.ForcedSM.BMThresholdEnabled = TRUE;
-	Config->RumbleSettings.ForcedSM.BMThresholdValue = 230;
-	Config->RumbleSettings.ForcedSM.SMThresholdEnabled = FALSE;
-	Config->RumbleSettings.ForcedSM.SMThresholdValue = 230;
+    Config->RumbleSettings.DisableLeft = FALSE;
+    Config->RumbleSettings.DisableRight = FALSE;
+    Config->RumbleSettings.HeavyRescalling.IsEnabled = TRUE;
+    Config->RumbleSettings.HeavyRescalling.MinRange = 64;
+    Config->RumbleSettings.HeavyRescalling.MaxRange = 255;
+    Config->RumbleSettings.AlternativeMode.IsEnabled = FALSE;
+    Config->RumbleSettings.AlternativeMode.MinRange = 1;
+    Config->RumbleSettings.AlternativeMode.MaxRange = 140;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled = TRUE;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue = 230;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled = FALSE;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue = 230;
 
 	Config->LEDSettings.Mode = DsLEDModeBatteryIndicatorPlayerIndex;
 	Config->LEDSettings.CustomPatterns.LEDFlags = 0x02;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -817,6 +817,8 @@ ConfigLoadForDevice(
         && rumbSet->AlternativeMode.MinRange > 0
         )
     {
+        Context->RumbleControlState.AltModeEnabled = rumbSet->AlternativeMode.IsEnabled;
+
         DOUBLE LConstA = (DOUBLE)(rumbSet->AlternativeMode.MaxRange - rumbSet->AlternativeMode.MinRange) / (254);
         DOUBLE LConstB = rumbSet->AlternativeMode.MaxRange - LConstA * 255;
 
@@ -849,6 +851,8 @@ ConfigLoadForDevice(
         && rumbSet->HeavyRescalling.MinRange > 0
         )
     {
+        Context->RumbleControlState.HeavyRescaleEnabled = rumbSet->HeavyRescalling.IsEnabled;
+
         DOUBLE HConstA = (DOUBLE)(rumbSet->AlternativeMode.MaxRange - rumbSet->AlternativeMode.MinRange) / (254);
         DOUBLE HConstB = rumbSet->AlternativeMode.MaxRange - HConstA * 255;
 

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -809,7 +809,7 @@ ConfigLoadForDevice(
 	} while (FALSE);
 
     //
-    // Verify if SMtoBMConversion values are valid and attempt to calculate rescaling constants in case they are
+    // Verify if desired new range for heavy rumbling rescale is valid and attempt to calculate rescaling constants if so
     // 
     DS_RUMBLE_SETTINGS* rumbSet = &Context->Configuration.RumbleSettings;
     if (
@@ -844,7 +844,7 @@ ConfigLoadForDevice(
     }
 
     //
-    // Verify if BMStrRescale values are valid and attempt to calculate rescaling constants in case they are
+    // Verify if desired new range for light rumbling rescale when in alternative mode is valid and attempt to calculate rescaling constants if so
     // 
     if (
         rumbSet->HeavyRescalling.MaxRange > rumbSet->HeavyRescalling.MinRange

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -853,11 +853,11 @@ ConfigLoadForDevice(
     {
         Context->RumbleControlState.HeavyRescaleEnabled = rumbSet->HeavyRescalling.IsEnabled;
 
-        DOUBLE HConstA = (DOUBLE)(rumbSet->AlternativeMode.MaxRange - rumbSet->AlternativeMode.MinRange) / (254);
-        DOUBLE HConstB = rumbSet->AlternativeMode.MaxRange - HConstA * 255;
+        DOUBLE HConstA = (DOUBLE)(rumbSet->HeavyRescalling.MaxRange - rumbSet->HeavyRescalling.MinRange) / (254);
+        DOUBLE HConstB = rumbSet->HeavyRescalling.MaxRange - HConstA * 255;
 
         Context->RumbleControlState.HeavyRescale.ConstA = HConstA;
-        Context->RumbleControlState.HeavyRescale.ConstA = HConstB;
+        Context->RumbleControlState.HeavyRescale.ConstB = HConstB;
         Context->RumbleControlState.HeavyRescale.IsAllowed = TRUE;
 
         TraceVerbose(

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -870,6 +870,7 @@ ConfigLoadForDevice(
             "Invalid values found for HeavyRescalling.Parameters. Setting disabled."
         );
         Context->RumbleControlState.HeavyRescale.IsAllowed = FALSE;
+    }
 
 	if (config_json)
 	{

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -195,28 +195,28 @@ ConfigParseRumbleSettings(
 
         if (pForced)
         {
-            if ((pNode = cJSON_GetObjectItem(pForced, "HeavyThresholdEnabled")))
+            if ((pNode = cJSON_GetObjectItem(pForced, "IsHeavyThresholdEnabled")))
             {
-                Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
-                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled);
+                Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled);
             }
 
-            if ((pNode = cJSON_GetObjectItem(pForced, "LightThresholdEnabled")))
+            if ((pNode = cJSON_GetObjectItem(pForced, "IsLightThresholdEnabled")))
             {
-                Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled = (UCHAR)cJSON_GetNumberValue(pNode);
-                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled);
+                Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = (UCHAR)cJSON_GetNumberValue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled);
             }
 
-            if ((pNode = cJSON_GetObjectItem(pForced, "HeavyThresholdValue")))
+            if ((pNode = cJSON_GetObjectItem(pForced, "HeavyThreshold")))
             {
-                Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue = (BOOLEAN)cJSON_IsTrue(pNode);
-                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue", Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue);
+                Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = (BOOLEAN)cJSON_IsTrue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold", Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold);
             }
 
-            if ((pNode = cJSON_GetObjectItem(pForced, "LightThresholdValue")))
+            if ((pNode = cJSON_GetObjectItem(pForced, "LightThreshold")))
             {
-                Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue = (UCHAR)cJSON_GetNumberValue(pNode);
-                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue", Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue);
+                Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold = (UCHAR)cJSON_GetNumberValue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.LightThreshold", Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold);
             }
         }
     }
@@ -936,10 +936,10 @@ ConfigSetDefaults(
     Config->RumbleSettings.AlternativeMode.IsEnabled = FALSE;
     Config->RumbleSettings.AlternativeMode.MinRange = 1;
     Config->RumbleSettings.AlternativeMode.MaxRange = 140;
-    Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled = TRUE;
-    Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue = 230;
-    Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled = FALSE;
-    Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue = 230;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled = TRUE;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = 230;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = FALSE;
+    Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold = 230;
 
 	Config->LEDSettings.Mode = DsLEDModeBatteryIndicatorPlayerIndex;
 	Config->LEDSettings.CustomPatterns.LEDFlags = 0x02;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -146,7 +146,7 @@ ConfigParseRumbleSettings(
         EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.DisableRight", Config->RumbleSettings.DisableRight);
     }
 
-    const cJSON* pHeavyRescale = cJSON_GetObjectItem(RumbleSettings, "BMStrRescale");
+    const cJSON* pHeavyRescale = cJSON_GetObjectItem(RumbleSettings, "HeavyRescale");
 
     if (pHeavyRescale)
     {

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -203,13 +203,13 @@ ConfigParseRumbleSettings(
 
             if ((pNode = cJSON_GetObjectItem(pForced, "IsLightThresholdEnabled")))
             {
-                Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = (UCHAR)cJSON_GetNumberValue(pNode);
+                Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
                 EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled);
             }
 
             if ((pNode = cJSON_GetObjectItem(pForced, "HeavyThreshold")))
             {
-                Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = (BOOLEAN)cJSON_IsTrue(pNode);
+                Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = (UCHAR)cJSON_GetNumberValue(pNode);
                 EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold", Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold);
             }
 

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -128,98 +128,98 @@ static DS_LED_AUTHORITY DS_LED_AUTHORITY_FROM_NAME(PSTR AuthorityName)
 #pragma warning( disable : 4706 )
 static void
 ConfigParseRumbleSettings(
-	_In_ const cJSON* RumbleSettings,
-	_Inout_ PDS_DRIVER_CONFIGURATION Config
+    _In_ const cJSON* RumbleSettings,
+    _Inout_ PDS_DRIVER_CONFIGURATION Config
 )
 {
-	cJSON* pNode = NULL;
+    cJSON* pNode = NULL;
 
-	if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableBM")))
-	{
-		Config->RumbleSettings.DisableBM = (BOOLEAN)cJSON_IsTrue(pNode);
-		EventWriteOverrideSettingUInt(RumbleSettings->string, "DisableBM", Config->RumbleSettings.DisableBM);
-	}
+    if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableLeft")))
+    {
+        Config->RumbleSettings.DisableLeft = (BOOLEAN)cJSON_IsTrue(pNode);
+        EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.DisableLeft", Config->RumbleSettings.DisableLeft);
+    }
 
-	if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableSM")))
-	{
-		Config->RumbleSettings.DisableSM = (BOOLEAN)cJSON_IsTrue(pNode);
-		EventWriteOverrideSettingUInt(RumbleSettings->string, "DisableSM", Config->RumbleSettings.DisableSM);
-	}
+    if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableRight")))
+    {
+        Config->RumbleSettings.DisableRight = (BOOLEAN)cJSON_IsTrue(pNode);
+        EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.DisableRight", Config->RumbleSettings.DisableRight);
+    }
 
-	const cJSON* pBMStrRescale = cJSON_GetObjectItem(RumbleSettings, "BMStrRescale");
+    const cJSON* pHeavyRescale = cJSON_GetObjectItem(RumbleSettings, "BMStrRescale");
 
-	if (pBMStrRescale)
-	{
-		if ((pNode = cJSON_GetObjectItem(pBMStrRescale, "Enabled")))
-		{
-			Config->RumbleSettings.BMStrRescale.Enabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "BMStrRescale.Enabled", Config->RumbleSettings.BMStrRescale.Enabled);
-		}
+    if (pHeavyRescale)
+    {
+        if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "IsEnabled")))
+        {
+            Config->RumbleSettings.HeavyRescalling.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescalling.IsEnabled", Config->RumbleSettings.HeavyRescalling.IsEnabled);
+        }
 
-		if ((pNode = cJSON_GetObjectItem(pBMStrRescale, "MinValue")))
-		{
-			Config->RumbleSettings.BMStrRescale.MinValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "BMStrRescale.MinValue", Config->RumbleSettings.BMStrRescale.MinValue);
-		}
+        if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "RescaleMinRange")))
+        {
+            Config->RumbleSettings.HeavyRescalling.MinRange = (UCHAR)cJSON_GetNumberValue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescalling.MinRange", Config->RumbleSettings.HeavyRescalling.MinRange);
+        }
 
-		if ((pNode = cJSON_GetObjectItem(pBMStrRescale, "MaxValue")))
-		{
-			Config->RumbleSettings.BMStrRescale.MaxValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "BMStrRescale.MaxValue", Config->RumbleSettings.BMStrRescale.MaxValue);
-		}
-	}
+        if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "RescaleMaxRange")))
+        {
+            Config->RumbleSettings.HeavyRescalling.MaxRange = (UCHAR)cJSON_GetNumberValue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescalling.MaxRange", Config->RumbleSettings.HeavyRescalling.MaxRange);
+        }
+    }
 
-	const cJSON* pSMToBMConversion = cJSON_GetObjectItem(RumbleSettings, "SMToBMConversion");
+    const cJSON* pAlternativeMode = cJSON_GetObjectItem(RumbleSettings, "AlternativeMode");
 
-	if (pSMToBMConversion)
-	{
-		if ((pNode = cJSON_GetObjectItem(pSMToBMConversion, "Enabled")))
-		{
-			Config->RumbleSettings.SMToBMConversion.Enabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "SMToBMConversion.Enabled", Config->RumbleSettings.SMToBMConversion.Enabled);
-		}
+    if (pAlternativeMode)
+    {
+        if ((pNode = cJSON_GetObjectItem(pAlternativeMode, "IsEnabled")))
+        {
+            Config->RumbleSettings.AlternativeMode.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.IsEnabled", Config->RumbleSettings.AlternativeMode.IsEnabled);
+        }
 
-		if ((pNode = cJSON_GetObjectItem(pSMToBMConversion, "RescaleMinValue")))
-		{
-			Config->RumbleSettings.SMToBMConversion.RescaleMinValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "SMToBMConversion.RescaleMinValue", Config->RumbleSettings.SMToBMConversion.RescaleMinValue);
-		}
+        if ((pNode = cJSON_GetObjectItem(pAlternativeMode, "RescaleMinRange")))
+        {
+            Config->RumbleSettings.AlternativeMode.MinRange = (UCHAR)cJSON_GetNumberValue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.MinRange", Config->RumbleSettings.AlternativeMode.MinRange);
+        }
 
-		if ((pNode = cJSON_GetObjectItem(pSMToBMConversion, "RescaleMaxValue")))
-		{
-			Config->RumbleSettings.SMToBMConversion.RescaleMaxValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "SMToBMConversion.RescaleMaxValue", Config->RumbleSettings.SMToBMConversion.RescaleMaxValue);
-		}
-	}
+        if ((pNode = cJSON_GetObjectItem(pAlternativeMode, "RescaleMaxRange")))
+        {
+            Config->RumbleSettings.AlternativeMode.MaxRange = (UCHAR)cJSON_GetNumberValue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.MaxRange", Config->RumbleSettings.AlternativeMode.MaxRange);
+        }
 
-	const cJSON* pForcedSM = cJSON_GetObjectItem(RumbleSettings, "ForcedSM");
+        const cJSON* pForced = cJSON_GetObjectItem(pAlternativeMode->string, "ForcedRight");
 
-	if (pForcedSM)
-	{
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "BMThresholdEnabled")))
-		{
-			Config->RumbleSettings.ForcedSM.BMThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.BMThresholdEnabled", Config->RumbleSettings.ForcedSM.BMThresholdEnabled);
-		}
+        if (pForced)
+        {
+            if ((pNode = cJSON_GetObjectItem(pForced, "HeavyThresholdEnabled")))
+            {
+                Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdEnabled);
+            }
 
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "BMThresholdValue")))
-		{
-			Config->RumbleSettings.ForcedSM.BMThresholdValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.BMThresholdValue", Config->RumbleSettings.ForcedSM.BMThresholdValue);
-		}
+            if ((pNode = cJSON_GetObjectItem(pForced, "LightThresholdEnabled")))
+            {
+                Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled = (UCHAR)cJSON_GetNumberValue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdEnabled);
+            }
 
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "SMThresholdEnabled")))
-		{
-			Config->RumbleSettings.ForcedSM.SMThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.SMThresholdEnabled", Config->RumbleSettings.ForcedSM.SMThresholdEnabled);
-		}
+            if ((pNode = cJSON_GetObjectItem(pForced, "HeavyThresholdValue")))
+            {
+                Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue = (BOOLEAN)cJSON_IsTrue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue", Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThresholdValue);
+            }
 
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "SMThresholdValue")))
-		{
-			Config->RumbleSettings.ForcedSM.SMThresholdValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.SMThresholdValue", Config->RumbleSettings.ForcedSM.SMThresholdValue);
-		}
-	}
+            if ((pNode = cJSON_GetObjectItem(pForced, "LightThresholdValue")))
+            {
+                Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue = (UCHAR)cJSON_GetNumberValue(pNode);
+                EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue", Config->RumbleSettings.AlternativeMode.ForcedRight.LightThresholdValue);
+            }
+        }
+    }
 }
 #pragma warning(pop)
 

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -152,20 +152,20 @@ ConfigParseRumbleSettings(
     {
         if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "IsEnabled")))
         {
-            Config->RumbleSettings.HeavyRescalling.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
-            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescalling.IsEnabled", Config->RumbleSettings.HeavyRescalling.IsEnabled);
+            Config->RumbleSettings.HeavyRescaling.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescaling.IsEnabled", Config->RumbleSettings.HeavyRescaling.IsEnabled);
         }
 
         if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "RescaleMinRange")))
         {
-            Config->RumbleSettings.HeavyRescalling.MinRange = (UCHAR)cJSON_GetNumberValue(pNode);
-            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescalling.MinRange", Config->RumbleSettings.HeavyRescalling.MinRange);
+            Config->RumbleSettings.HeavyRescaling.MinRange = (UCHAR)cJSON_GetNumberValue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescaling.MinRange", Config->RumbleSettings.HeavyRescaling.MinRange);
         }
 
         if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "RescaleMaxRange")))
         {
-            Config->RumbleSettings.HeavyRescalling.MaxRange = (UCHAR)cJSON_GetNumberValue(pNode);
-            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescalling.MaxRange", Config->RumbleSettings.HeavyRescalling.MaxRange);
+            Config->RumbleSettings.HeavyRescaling.MaxRange = (UCHAR)cJSON_GetNumberValue(pNode);
+            EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescaling.MaxRange", Config->RumbleSettings.HeavyRescaling.MaxRange);
         }
     }
 
@@ -847,14 +847,14 @@ ConfigLoadForDevice(
     // Verify if desired new range for light rumbling rescale when in alternative mode is valid and attempt to calculate rescaling constants if so
     // 
     if (
-        rumbSet->HeavyRescalling.MaxRange > rumbSet->HeavyRescalling.MinRange
-        && rumbSet->HeavyRescalling.MinRange > 0
+        rumbSet->HeavyRescaling.MaxRange > rumbSet->HeavyRescaling.MinRange
+        && rumbSet->HeavyRescaling.MinRange > 0
         )
     {
-        Context->RumbleControlState.HeavyRescaleEnabled = rumbSet->HeavyRescalling.IsEnabled;
+        Context->RumbleControlState.HeavyRescaleEnabled = rumbSet->HeavyRescaling.IsEnabled;
 
-        DOUBLE HConstA = (DOUBLE)(rumbSet->HeavyRescalling.MaxRange - rumbSet->HeavyRescalling.MinRange) / (254);
-        DOUBLE HConstB = rumbSet->HeavyRescalling.MaxRange - HConstA * 255;
+        DOUBLE HConstA = (DOUBLE)(rumbSet->HeavyRescaling.MaxRange - rumbSet->HeavyRescaling.MinRange) / (254);
+        DOUBLE HConstB = rumbSet->HeavyRescaling.MaxRange - HConstA * 255;
 
         Context->RumbleControlState.HeavyRescale.ConstA = HConstA;
         Context->RumbleControlState.HeavyRescale.ConstB = HConstB;
@@ -862,7 +862,7 @@ ConfigLoadForDevice(
 
         TraceVerbose(
             TRACE_CONFIG,
-            "HeavyRescalling.Parameters rescaling constants: A = %f and B = %f.",
+            "HeavyRescaling.Parameters rescaling constants: A = %f and B = %f.",
             Context->RumbleControlState.HeavyRescale.ConstA,
             Context->RumbleControlState.HeavyRescale.ConstB
         );
@@ -871,7 +871,7 @@ ConfigLoadForDevice(
     {
         TraceVerbose(
             TRACE_CONFIG,
-            "Invalid values found for HeavyRescalling.Parameters. Setting disabled."
+            "Invalid values found for HeavyRescaling.Parameters. Setting disabled."
         );
         Context->RumbleControlState.HeavyRescale.IsAllowed = FALSE;
     }
@@ -930,9 +930,9 @@ ConfigSetDefaults(
 
     Config->RumbleSettings.DisableLeft = FALSE;
     Config->RumbleSettings.DisableRight = FALSE;
-    Config->RumbleSettings.HeavyRescalling.IsEnabled = TRUE;
-    Config->RumbleSettings.HeavyRescalling.MinRange = 64;
-    Config->RumbleSettings.HeavyRescalling.MaxRange = 255;
+    Config->RumbleSettings.HeavyRescaling.IsEnabled = TRUE;
+    Config->RumbleSettings.HeavyRescaling.MinRange = 64;
+    Config->RumbleSettings.HeavyRescaling.MaxRange = 255;
     Config->RumbleSettings.AlternativeMode.IsEnabled = FALSE;
     Config->RumbleSettings.AlternativeMode.MinRange = 1;
     Config->RumbleSettings.AlternativeMode.MaxRange = 140;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -191,7 +191,7 @@ ConfigParseRumbleSettings(
             EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.MaxRange", Config->RumbleSettings.AlternativeMode.MaxRange);
         }
 
-        const cJSON* pForced = cJSON_GetObjectItem(pAlternativeMode->string, "ForcedRight");
+        const cJSON* pForced = cJSON_GetObjectItem(pAlternativeMode, "ForcedRight");
 
         if (pForced)
         {

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -828,7 +828,7 @@ ConfigLoadForDevice(
 
         TraceVerbose(
             TRACE_CONFIG,
-            "AlternativeMode.Parameters rescaling constants: A = %f and B = %f.",
+            "Light rumble rescaling constants: A = %f and B = %f.",
             Context->RumbleControlState.LightRescale.ConstA,
             Context->RumbleControlState.LightRescale.ConstB
         );
@@ -838,7 +838,7 @@ ConfigLoadForDevice(
     {
         TraceVerbose(
             TRACE_CONFIG,
-            "Invalid values found for AlternativeMode.Parameters. Setting range as invalid."
+            "Disallowing light rumble rescalling because an invalid range was defined"
         );
         Context->RumbleControlState.LightRescale.IsAllowed = FALSE;
     }
@@ -862,7 +862,7 @@ ConfigLoadForDevice(
 
         TraceVerbose(
             TRACE_CONFIG,
-            "HeavyRescaling.Parameters rescaling constants: A = %f and B = %f.",
+            "Heavy rumble rescaling constants:  A = %f and B = %f.",
             Context->RumbleControlState.HeavyRescale.ConstA,
             Context->RumbleControlState.HeavyRescale.ConstB
         );
@@ -871,7 +871,7 @@ ConfigLoadForDevice(
     {
         TraceVerbose(
             TRACE_CONFIG,
-            "Invalid values found for HeavyRescaling.Parameters. Setting disabled."
+            "Disallowing heavy rumble rescalling because an invalid range was defined"
         );
         Context->RumbleControlState.HeavyRescale.IsAllowed = FALSE;
     }

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -808,67 +808,68 @@ ConfigLoadForDevice(
 
 	} while (FALSE);
 
-	//
-	// Verify if SMtoBMConversion values are valid and attempt to calculate rescaling constants in case they are
-	// 
-	if (
-		Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue > Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue
-		&& Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue > 0
-		)
-	{
-		Context->Configuration.RumbleSettings.SMToBMConversion.ConstA =
-			(DOUBLE)(Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue - Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMinValue) / (254);
+    //
+    // Verify if SMtoBMConversion values are valid and attempt to calculate rescaling constants in case they are
+    // 
+    DS_RUMBLE_SETTINGS* rumbSet = &Context->Configuration.RumbleSettings;
+    if (
+        rumbSet->AlternativeMode.MaxRange > rumbSet->AlternativeMode.MinRange
+        && rumbSet->AlternativeMode.MinRange > 0
+        )
+    {
+        DOUBLE LConstA = (DOUBLE)(rumbSet->AlternativeMode.MaxRange - rumbSet->AlternativeMode.MinRange) / (254);
+        DOUBLE LConstB = rumbSet->AlternativeMode.MaxRange - LConstA * 255;
 
-		Context->Configuration.RumbleSettings.SMToBMConversion.ConstB =
-			Context->Configuration.RumbleSettings.SMToBMConversion.RescaleMaxValue - Context->Configuration.RumbleSettings.SMToBMConversion.ConstA * 255;
+        Context->RumbleControlState.LightRescale.ConstA = LConstA;
+        Context->RumbleControlState.LightRescale.ConstB = LConstB;
+        Context->RumbleControlState.LightRescale.IsAllowed = TRUE;
 
-		TraceVerbose(
-			TRACE_CONFIG,
-			"SMToBMConversion rescaling constants: A = %f and B = %f.",
-			Context->Configuration.RumbleSettings.SMToBMConversion.ConstA,
-			Context->Configuration.RumbleSettings.SMToBMConversion.ConstB
-		);
+        TraceVerbose(
+            TRACE_CONFIG,
+            "AlternativeMode.Parameters rescaling constants: A = %f and B = %f.",
+            Context->RumbleControlState.LightRescale.ConstA,
+            Context->RumbleControlState.LightRescale.ConstB
+        );
 
-	}
-	else
-	{
-		TraceVerbose(
-			TRACE_CONFIG,
-			"Invalid values found for SMToBMConversion. Setting disabled."
-		);
-		Context->Configuration.RumbleSettings.SMToBMConversion.Enabled = FALSE;
-	}
+    }
+    else
+    {
+        TraceVerbose(
+            TRACE_CONFIG,
+            "Invalid values found for AlternativeMode.Parameters. Setting range as invalid."
+        );
+        Context->RumbleControlState.LightRescale.IsAllowed = FALSE;
+    }
 
-	//
-	// Verify if BMStrRescale values are valid and attempt to calculate rescaling constants in case they are
-	// 
-	if (
-		Context->Configuration.RumbleSettings.BMStrRescale.MaxValue > Context->Configuration.RumbleSettings.BMStrRescale.MinValue
-		&& Context->Configuration.RumbleSettings.BMStrRescale.MinValue > 0
-		)
-	{
-		Context->Configuration.RumbleSettings.BMStrRescale.ConstA =
-			(DOUBLE)(Context->Configuration.RumbleSettings.BMStrRescale.MaxValue - Context->Configuration.RumbleSettings.BMStrRescale.MinValue) / (254);
+    //
+    // Verify if BMStrRescale values are valid and attempt to calculate rescaling constants in case they are
+    // 
+    if (
+        rumbSet->HeavyRescalling.MaxRange > rumbSet->HeavyRescalling.MinRange
+        && rumbSet->HeavyRescalling.MinRange > 0
+        )
+    {
+        DOUBLE HConstA = (DOUBLE)(rumbSet->AlternativeMode.MaxRange - rumbSet->AlternativeMode.MinRange) / (254);
+        DOUBLE HConstB = rumbSet->AlternativeMode.MaxRange - HConstA * 255;
 
-		Context->Configuration.RumbleSettings.BMStrRescale.ConstB =
-			Context->Configuration.RumbleSettings.BMStrRescale.MaxValue - Context->Configuration.RumbleSettings.BMStrRescale.ConstA * 255;
+        Context->RumbleControlState.HeavyRescale.ConstA = HConstA;
+        Context->RumbleControlState.HeavyRescale.ConstA = HConstB;
+        Context->RumbleControlState.HeavyRescale.IsAllowed = TRUE;
 
-		TraceVerbose(
-			TRACE_CONFIG,
-			"BMStrRescale rescaling constants: A = %f and B = %f.",
-			Context->Configuration.RumbleSettings.BMStrRescale.ConstA,
-			Context->Configuration.RumbleSettings.BMStrRescale.ConstB
-		);
-	}
-	else
-	{
-		TraceVerbose(
-			TRACE_CONFIG,
-			"Invalid values found for BMStrRescale. Setting disabled."
-		);
-
-		Context->Configuration.RumbleSettings.BMStrRescale.Enabled = FALSE;
-	}
+        TraceVerbose(
+            TRACE_CONFIG,
+            "HeavyRescalling.Parameters rescaling constants: A = %f and B = %f.",
+            Context->RumbleControlState.HeavyRescale.ConstA,
+            Context->RumbleControlState.HeavyRescale.ConstB
+        );
+    }
+    else
+    {
+        TraceVerbose(
+            TRACE_CONFIG,
+            "Invalid values found for HeavyRescalling.Parameters. Setting disabled."
+        );
+        Context->RumbleControlState.HeavyRescale.IsAllowed = FALSE;
 
 	if (config_json)
 	{

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -176,6 +176,19 @@ typedef struct _DS_OUTPUT_REPORT_CACHE
 	
 } DS_OUTPUT_REPORT_CACHE, *PDS_OUTPUT_REPORT_CACHE;
 
+/// <summary>
+/// Define the rescalling constants and if they are valid that rescalling is allowed
+/// </summary>
+typedef struct _DS_RESCALE_STATE
+{
+    BOOLEAN IsAllowed;
+
+    DOUBLE ConstA;
+
+    DOUBLE ConstB;
+
+} DS_RESCALE_STATE, * PDS_RESCALE_STATE;
+
 typedef struct _DEVICE_CONTEXT
 {
 	//
@@ -326,19 +339,6 @@ typedef struct _DEVICE_CONTEXT
 	} RumbleControlState;
 
 } DEVICE_CONTEXT, * PDEVICE_CONTEXT;
-
-/// <summary>
-/// Define the rescalling constants and if they are valid that rescalling is allowed
-/// </summary>
-typedef struct _DS_RESCALE_STATE
-{
-    BOOLEAN IsAllowed;
-
-    DOUBLE ConstA;
-
-    DOUBLE ConstB;
-
-} DS_RESCALE_STATE, * PDS_RESCALE_STATE;
 
 //
 // This macro will generate an inline function called DeviceGetContext

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -307,6 +307,19 @@ typedef struct _DEVICE_CONTEXT
 
 } DEVICE_CONTEXT, * PDEVICE_CONTEXT;
 
+/// <summary>
+/// Define how the rescalling of rumble values must be managed
+/// </summary>
+typedef struct _DS_RESCALE_STATE
+{
+    BOOLEAN IsAllowed;
+
+    DOUBLE ConstA;
+
+    DOUBLE ConstB;
+
+} DS_RESCALE_STATE, * PDS_RESCALE_STATE;
+
 //
 // This macro will generate an inline function called DeviceGetContext
 // which will be used to get a pointer to the device context memory

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -176,9 +176,9 @@ typedef struct _DS_OUTPUT_REPORT_CACHE
 	
 } DS_OUTPUT_REPORT_CACHE, *PDS_OUTPUT_REPORT_CACHE;
 
-/// <summary>
-/// Define the rescalling constants and if they are valid that rescalling is allowed
-/// </summary>
+//
+// Stores the constants used for rumble rescalling and if it is allowed
+//
 typedef struct _DS_RESCALE_STATE
 {
     BOOLEAN IsAllowed;

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -177,7 +177,7 @@ typedef struct _DS_OUTPUT_REPORT_CACHE
 } DS_OUTPUT_REPORT_CACHE, *PDS_OUTPUT_REPORT_CACHE;
 
 //
-// Stores the constants used for rumble rescalling and if it is allowed
+// Stores the constants used for rumble rescaling and if it is allowed
 //
 typedef struct _DS_RESCALE_STATE
 {
@@ -317,7 +317,7 @@ typedef struct _DEVICE_CONTEXT
 		UCHAR HeavyCache;
 
         //
-        // Defines if heavy rumble strength rescalling is requested
+        // Defines if heavy rumble strength rescaling is requested
         //
         BOOLEAN HeavyRescaleEnabled;
 

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -304,6 +304,16 @@ typedef struct _DEVICE_CONTEXT
 		UCHAR HeavyCache;
 
         //
+        // Defines if heavy rumble strength rescalling is requested
+        //
+        BOOLEAN HeavyRescaleEnabled;
+
+        //
+        // Defines if alternative rumble mode is enabled
+        //
+        BOOLEAN AltModeEnabled;
+
+        //
         // Current state of heavy rumble rescaling parameters
         //
         DS_RESCALE_STATE HeavyRescale;

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -303,6 +303,16 @@ typedef struct _DEVICE_CONTEXT
 		// 
 		UCHAR HeavyCache;
 
+        //
+        // Current state of heavy rumble rescaling parameters
+        //
+        DS_RESCALE_STATE HeavyRescale;
+
+        //
+        // Current state of light rumble rescaling parameters
+        //
+        DS_RESCALE_STATE LightRescale;
+
 	} RumbleControlState;
 
 } DEVICE_CONTEXT, * PDEVICE_CONTEXT;

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -328,7 +328,7 @@ typedef struct _DEVICE_CONTEXT
 } DEVICE_CONTEXT, * PDEVICE_CONTEXT;
 
 /// <summary>
-/// Define how the rescalling of rumble values must be managed
+/// Define the rescalling constants and if they are valid that rescalling is allowed
 /// </summary>
 typedef struct _DS_RESCALE_STATE
 {

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -296,14 +296,14 @@ typedef struct _DEVICE_CONTEXT
 		//
 		// Cache for last received Small Motor Strength value
 		// 
-		UCHAR Small;
+		UCHAR LightCache;
 
 		//
 		// Cache for last received Big Motor Strength value
 		// 
-		UCHAR Big;
+		UCHAR HeavyCache;
 
-	} MotorStrCache;
+	} RumbleControlState;
 
 } DEVICE_CONTEXT, * PDEVICE_CONTEXT;
 

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -598,10 +598,10 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 
                 // Force Activate right motor if original light rumble is above certain level and related boolean is enabled
                 if (
-                    (rumbSet->AlternativeMode.ForcedRight.LightThresholdEnabled
-                        && Context->RumbleControlState.LightCache >= rumbSet->AlternativeMode.ForcedRight.LightThresholdValue)
-                    || (rumbSet->AlternativeMode.ForcedRight.HeavyThresholdEnabled
-                        && Context->RumbleControlState.HeavyCache >= rumbSet->AlternativeMode.ForcedRight.HeavyThresholdValue)
+                    (rumbSet->AlternativeMode.ForcedRight.IsLightThresholdEnabled
+                        && Context->RumbleControlState.LightCache >= rumbSet->AlternativeMode.ForcedRight.LightThreshold)
+                    || (rumbSet->AlternativeMode.ForcedRight.IsHeavyThresholdEnabled
+                        && Context->RumbleControlState.HeavyCache >= rumbSet->AlternativeMode.ForcedRight.HeavyThreshold)
                     )
                 {
                     lightValue = 1;

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -581,20 +581,20 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
         DS_RESCALE_STATE* lightResc = &Context->RumbleControlState.LightRescale;
 
         // Get last received rumble values so they can be processed
-        DOUBLE heavyValue = Context->RumbleControlState.HeavyCache;
-        DOUBLE lightValue = Context->RumbleControlState.LightCache;
+        DOUBLE heavyRumble = Context->RumbleControlState.HeavyCache;
+        DOUBLE lightRumble = Context->RumbleControlState.LightCache;
 
         if (Context->RumbleControlState.AltModeEnabled && lightResc->IsAllowed)
         {
-            if (lightValue > 0) {
+            if (lightRumble > 0) {
 
                 // Light Motor Strength Rescale 
-                lightValue = lightResc->ConstA * lightValue + lightResc->ConstB;
-                if (lightValue > heavyValue)
+                lightRumble = lightResc->ConstA * lightRumble + lightResc->ConstB;
+                if (lightRumble > heavyRumble)
                 {
-                    heavyValue = lightValue;
+                    heavyRumble = lightRumble;
                 }
-                lightValue = 0; // Always disable Light Motor after the if statement above
+                lightRumble = 0; // Always disable Light Motor after the if statement above
             }
 
             // Force Activate right motor if original heavy or light values are above their respective thresholds
@@ -604,19 +604,19 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
                 (rumbSet->AlternativeMode.ForcedRight.IsLightThresholdEnabled && (Context->RumbleControlState.LightCache >= rumbSet->AlternativeMode.ForcedRight.LightThreshold))
                 )
             {
-                lightValue = 1;
+                lightRumble = 1;
             }
         }
         else
         {
-            if (rumbSet->DisableLeft) heavyValue = 0;
-            if (rumbSet->DisableRight) lightValue = 0;
+            if (rumbSet->DisableLeft) heavyRumble = 0;
+            if (rumbSet->DisableRight) lightRumble = 0;
         }
 
         // Heavy Motor Strength Rescale
-        if (heavyValue > 0 && Context->RumbleControlState.HeavyRescaleEnabled && heavyResc->IsAllowed)
+        if (heavyRumble > 0 && Context->RumbleControlState.HeavyRescaleEnabled && heavyResc->IsAllowed)
         {
-            heavyValue = heavyResc->ConstA * heavyValue + heavyResc->ConstB;
+            heavyRumble = heavyResc->ConstA * heavyRumble + heavyResc->ConstB;
         }
 
         switch (Context->ConnectionType)
@@ -627,12 +627,12 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
                 (PUCHAR)WdfMemoryGetBuffer(
                     Context->OutputReportMemory,
                     NULL
-                ), (UCHAR)heavyValue);
+                ), (UCHAR)heavyRumble);
             DS3_USB_SET_SMALL_RUMBLE_STRENGTH(
                 (PUCHAR)WdfMemoryGetBuffer(
                     Context->OutputReportMemory,
                     NULL
-                ), (UCHAR)lightValue);
+                ), (UCHAR)lightRumble);
             break;
 
         case DsDeviceConnectionTypeBth:
@@ -641,12 +641,12 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
                 (PUCHAR)WdfMemoryGetBuffer(
                     Context->OutputReportMemory,
                     NULL
-                ), (UCHAR)heavyValue);
+                ), (UCHAR)heavyRumble);
             DS3_BTH_SET_SMALL_RUMBLE_STRENGTH(
                 (PUCHAR)WdfMemoryGetBuffer(
                     Context->OutputReportMemory,
                     NULL
-                ), (UCHAR)lightValue);
+                ), (UCHAR)lightRumble);
             break;
         }
     }

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -575,7 +575,6 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	PDEVICE_CONTEXT Context
 ) 
 {
-    {
         DS_RUMBLE_SETTINGS* rumbSet = &Context->Configuration.RumbleSettings;
 
         DS_RESCALE_STATE* heavyResc = &Context->RumbleControlState.HeavyRescale;

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -520,7 +520,7 @@ VOID DS3_SET_SMALL_RUMBLE_STRENGTH(
 	UCHAR Value
 )
 {
-	Context->MotorStrCache.Small = Value;
+	Context->RumbleControlState.LightCache = Value;
 	DS3_PROCESS_RUMBLE_STRENGTH(Context);
 }
 
@@ -556,7 +556,7 @@ VOID DS3_SET_LARGE_RUMBLE_STRENGTH(
 	UCHAR Value
 )
 {
-	Context->MotorStrCache.Big = Value;
+	Context->RumbleControlState.HeavyCache = Value;
 	DS3_PROCESS_RUMBLE_STRENGTH(Context);
 }
 
@@ -566,8 +566,8 @@ VOID DS3_SET_BOTH_RUMBLE_STRENGTH(
 	UCHAR SmallValue
 )
 {
-	Context->MotorStrCache.Small = SmallValue;
-	Context->MotorStrCache.Big = LargeValue;
+	Context->RumbleControlState.LightCache = SmallValue;
+	Context->RumbleControlState.HeavyCache = LargeValue;
 	DS3_PROCESS_RUMBLE_STRENGTH(Context);
 }
 
@@ -576,8 +576,8 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 )
 {
 
-	DOUBLE LargeValue = Context->Configuration.RumbleSettings.DisableBM ? 0 : Context->MotorStrCache.Big;
-	DOUBLE SmallValue = Context->Configuration.RumbleSettings.DisableSM ? 0 : Context->MotorStrCache.Small;
+	DOUBLE LargeValue = Context->Configuration.RumbleSettings.DisableBM ? 0 : Context->RumbleControlState.HeavyCache;
+	DOUBLE SmallValue = Context->Configuration.RumbleSettings.DisableSM ? 0 : Context->RumbleControlState.LightCache;
 
 	if (
 		Context->Configuration.RumbleSettings.SMToBMConversion.Enabled
@@ -599,7 +599,7 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 			// Force Activate Small Motor if original SMALL Motor Strength is above certain level and related boolean is enabled
 			if (
 				Context->Configuration.RumbleSettings.ForcedSM.SMThresholdEnabled
-				&& Context->MotorStrCache.Small >= Context->Configuration.RumbleSettings.ForcedSM.SMThresholdValue
+				&& Context->RumbleControlState.LightCache >= Context->Configuration.RumbleSettings.ForcedSM.SMThresholdValue
 				)
 			{
 				SmallValue = 1;
@@ -611,7 +611,7 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 		// Force Activate Small Motor if original BIG Motor Strength is above certain level and related boolean is enabled
 		if (
 			Context->Configuration.RumbleSettings.ForcedSM.BMThresholdEnabled
-			&& Context->MotorStrCache.Big >= Context->Configuration.RumbleSettings.ForcedSM.BMThresholdValue
+			&& Context->RumbleControlState.HeavyCache >= Context->Configuration.RumbleSettings.ForcedSM.BMThresholdValue
 			)
 		{
 			SmallValue = 1;

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -595,18 +595,16 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
                     heavyValue = lightValue;
                 }
                 lightValue = 0; // Always disable Light Motor after the if statement above
+            }
 
-                // Force Activate right motor if original light rumble is above certain level and related boolean is enabled
-                if (
-                    (rumbSet->AlternativeMode.ForcedRight.IsLightThresholdEnabled
-                        && Context->RumbleControlState.LightCache >= rumbSet->AlternativeMode.ForcedRight.LightThreshold)
-                    || (rumbSet->AlternativeMode.ForcedRight.IsHeavyThresholdEnabled
-                        && Context->RumbleControlState.HeavyCache >= rumbSet->AlternativeMode.ForcedRight.HeavyThreshold)
-                    )
-                {
-                    lightValue = 1;
-                }
-
+            // Force Activate right motor if original heavy or light values are above their respective thresholds
+            if (
+                (rumbSet->AlternativeMode.ForcedRight.IsHeavyThresholdEnabled && (Context->RumbleControlState.HeavyCache >= rumbSet->AlternativeMode.ForcedRight.HeavyThreshold))
+                ||
+                (rumbSet->AlternativeMode.ForcedRight.IsLightThresholdEnabled && (Context->RumbleControlState.LightCache >= rumbSet->AlternativeMode.ForcedRight.LightThreshold))
+                )
+            {
+                lightValue = 1;
             }
         }
         else

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -380,11 +380,11 @@ typedef struct _DS_RUMBLE_SETTINGS
     // 
     BOOLEAN DisableRight;
 
-    // Adjustments for heavy (left) motor rescalling
+    // Adjustments for heavy (left) motor rescaling
     struct
     {
         //
-        // Enables heavy rumble intensity rescalling if possible
+        // Enables heavy rumble intensity rescaling if possible
         //
         BOOLEAN IsEnabled;
 
@@ -398,7 +398,7 @@ typedef struct _DS_RUMBLE_SETTINGS
         //
         UCHAR MaxRange;
 
-    } HeavyRescalling;
+    } HeavyRescaling;
 
 
     //
@@ -412,12 +412,12 @@ typedef struct _DS_RUMBLE_SETTINGS
         BOOLEAN IsEnabled;
 
         //
-        // Desired new minimun range when rescalling light rumble intensity
+        // Desired new minimun range when rescaling light rumble intensity
         //
         UCHAR MinRange;
 
         //
-        // New maximum range desired when rescalling light rumble intensity
+        // New maximum range desired when rescaling light rumble intensity
         //
         UCHAR MaxRange;
 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -371,42 +371,80 @@ typedef struct _DS_THUMB_SETTINGS
 typedef struct _DS_RUMBLE_SETTINGS
 {
     //
-    // Disable Heavy Motor (left) entirely
+    // Disables Heavy Motor (left) when in normal mode
     // 
     BOOLEAN DisableLeft;
 
     //
-    // Disable Light Motor (right) entirely
+    // Disables Light Motor (right) when in normal mode
     // 
     BOOLEAN DisableRight;
 
     // Adjustments for heavy (left) motor rescalling
     struct
     {
+        //
+        // Enables heavy rumble intensity rescalling if possible
+        //
         BOOLEAN IsEnabled;
 
+        //
+        // Desired new minimum range
+        //
         UCHAR MinRange;
 
+        //
+        // Desired new maximum range
+        //
         UCHAR MaxRange;
 
     } HeavyRescalling;
 
+
+    //
+    // Alternative rumble mode user parameters
+    //
     struct
     {
+        //
+        // Sets that alternative rumble mode should be enabled if possible
+        //
         BOOLEAN IsEnabled;
 
+        //
+        // Desired new minimun range when rescalling light rumble intensity
+        //
         UCHAR MinRange;
 
+        //
+        // New maximum range desired when rescalling light rumble intensity
+        //
         UCHAR MaxRange;
 
+        //
+        // Parameters used for the force activation of the right motor when in alternative rumble mode
+        // 
+        //
         struct
         {
+            //
+            // Enables the heavy rumble threshold
+            //
             BOOLEAN IsHeavyThresholdEnabled;
 
+            //
+            // Enables the light rumble threshold
+            //
             BOOLEAN IsLightThresholdEnabled;
 
+            //
+            // Threshold received heavy rumble instructions must reach to force activate the right motor
+            //
             UCHAR HeavyThreshold;
 
+            //
+            // Threshold received light rumble instructions must reach to force activate the right motor
+            //
             UCHAR LightThreshold;
 
         } ForcedRight;

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -401,13 +401,13 @@ typedef struct _DS_RUMBLE_SETTINGS
 
         struct
         {
-            BOOLEAN HeavyThresholdEnabled;
+            BOOLEAN IsHeavyThresholdEnabled;
 
-            BOOLEAN LightThresholdEnabled;
+            BOOLEAN IsLightThresholdEnabled;
 
-            UCHAR HeavyThresholdValue;
+            UCHAR HeavyThreshold;
 
-            UCHAR LightThresholdValue;
+            UCHAR LightThreshold;
 
         } ForcedRight;
 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -370,55 +370,48 @@ typedef struct _DS_THUMB_SETTINGS
 // 
 typedef struct _DS_RUMBLE_SETTINGS
 {
-	//
-	// Disable Big Motor (left) entirely
-	// 
-	BOOLEAN DisableBM;
+    //
+    // Disable Heavy Motor (left) entirely
+    // 
+    BOOLEAN DisableLeft;
 
-	//
-	// Disable Small Motor (right) entirely
-	// 
-	BOOLEAN DisableSM;
+    //
+    // Disable Light Motor (right) entirely
+    // 
+    BOOLEAN DisableRight;
 
-	struct
-	{
-		BOOLEAN Enabled;
+    // Adjustments for heavy (left) motor rescalling
+    struct
+    {
+        BOOLEAN IsEnabled;
 
-		UCHAR MinValue;
+        UCHAR MinRange;
 
-		UCHAR MaxValue;
+        UCHAR MaxRange;
 
-		DOUBLE ConstA;
+    } HeavyRescalling;
 
-		DOUBLE ConstB;
+    struct
+    {
+        BOOLEAN IsEnabled;
 
-	} BMStrRescale;
+        UCHAR MinRange;
 
-	struct
-	{
-		BOOLEAN Enabled;
+        UCHAR MaxRange;
 
-		UCHAR RescaleMinValue;
+        struct
+        {
+            BOOLEAN HeavyThresholdEnabled;
 
-		UCHAR RescaleMaxValue;
+            BOOLEAN LightThresholdEnabled;
 
-		DOUBLE ConstA;
+            UCHAR HeavyThresholdValue;
 
-		DOUBLE ConstB;
+            UCHAR LightThresholdValue;
 
-	} SMToBMConversion;
+        } ForcedRight;
 
-	struct
-	{
-		BOOLEAN BMThresholdEnabled;
-
-		UCHAR BMThresholdValue;
-
-		BOOLEAN SMThresholdEnabled;
-
-		UCHAR SMThresholdValue;
-
-	} ForcedSM;
+    } AlternativeMode;
 
 } DS_RUMBLE_SETTINGS, * PDS_RUMBLE_SETTINGS;
 


### PR DESCRIPTION
- Changed the structure of user defined rumble configurations
- Updated rumble configuration loading from disk to fit changes
- Re-purposed structure that store last received rumble intensities to also store current state of rumble rescaling
    - Before the current state was read/write directly to the user configurations
- Added a IsAllowed property for the current state of rumble rescalers so rescaling can be "blocked" even if it's enabled
    - Set to false if user-defined rescalling ranges are invalid
- Reworked rumble processing to reflect changes above
    - Rescaling constants, if they are enabled and if they are allowed are now fetched from the re-purposed struct commented above
- Changed rumble processing logic so motors can only be disabled while in normal mode