### PR TITLE
Reworked rumble configuration and processing

### DIFF
--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -943,7 +943,7 @@ ConfigSetDefaults(
 	Config->RumbleSettings.HeavyRescaling.MaxRange = 255;
 	Config->RumbleSettings.AlternativeMode.IsEnabled = FALSE;
 	Config->RumbleSettings.AlternativeMode.MinRange = 1;
-	Config->RumbleSettings.AlternativeMode.MaxRange = 140;
+	Config->RumbleSettings.AlternativeMode.MaxRange = 110;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled = TRUE;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = 242;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = FALSE;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -134,99 +134,90 @@ ConfigParseRumbleSettings(
 {
 	cJSON* pNode = NULL;
 
-	if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableBM")))
+	if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableLeft")))
 	{
-		Config->RumbleSettings.DisableBM = (BOOLEAN)cJSON_IsTrue(pNode);
-		EventWriteOverrideSettingUInt(RumbleSettings->string, "DisableBM", Config->RumbleSettings.DisableBM);
+		Config->RumbleSettings.DisableLeft = (BOOLEAN)cJSON_IsTrue(pNode);
+		EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.DisableLeft", Config->RumbleSettings.DisableLeft);
 	}
 
-	if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableSM")))
+	if ((pNode = cJSON_GetObjectItem(RumbleSettings, "DisableRight")))
 	{
-		Config->RumbleSettings.DisableSM = (BOOLEAN)cJSON_IsTrue(pNode);
-		EventWriteOverrideSettingUInt(RumbleSettings->string, "DisableSM", Config->RumbleSettings.DisableSM);
+		Config->RumbleSettings.DisableRight = (BOOLEAN)cJSON_IsTrue(pNode);
+		EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.DisableRight", Config->RumbleSettings.DisableRight);
 	}
 
-	const cJSON* pBMStrRescale = cJSON_GetObjectItem(RumbleSettings, "BMStrRescale");
+	const cJSON* pHeavyRescale = cJSON_GetObjectItem(RumbleSettings, "HeavyRescale");
 
-	if (pBMStrRescale)
+	if (pHeavyRescale)
 	{
-		if ((pNode = cJSON_GetObjectItem(pBMStrRescale, "Enabled")))
+		if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "IsEnabled")))
 		{
-			Config->RumbleSettings.BMStrRescale.Enabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "BMStrRescale.Enabled", Config->RumbleSettings.BMStrRescale.Enabled);
+			Config->RumbleSettings.HeavyRescaling.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+			EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescaling.IsEnabled", Config->RumbleSettings.HeavyRescaling.IsEnabled);
 		}
 
-		if ((pNode = cJSON_GetObjectItem(pBMStrRescale, "MinValue")))
+		if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "RescaleMinRange")))
 		{
-			Config->RumbleSettings.BMStrRescale.MinValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "BMStrRescale.MinValue",
-				Config->RumbleSettings.BMStrRescale.MinValue);
+			Config->RumbleSettings.HeavyRescaling.MinRange = (UCHAR)cJSON_GetNumberValue(pNode);
+			EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescaling.MinRange", Config->RumbleSettings.HeavyRescaling.MinRange);
 		}
 
-		if ((pNode = cJSON_GetObjectItem(pBMStrRescale, "MaxValue")))
+		if ((pNode = cJSON_GetObjectItem(pHeavyRescale, "RescaleMaxRange")))
 		{
-			Config->RumbleSettings.BMStrRescale.MaxValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "BMStrRescale.MaxValue",
-				Config->RumbleSettings.BMStrRescale.MaxValue);
-		}
-	}
-
-	const cJSON* pSMToBMConversion = cJSON_GetObjectItem(RumbleSettings, "SMToBMConversion");
-
-	if (pSMToBMConversion)
-	{
-		if ((pNode = cJSON_GetObjectItem(pSMToBMConversion, "Enabled")))
-		{
-			Config->RumbleSettings.SMToBMConversion.Enabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "SMToBMConversion.Enabled",
-				Config->RumbleSettings.SMToBMConversion.Enabled);
-		}
-
-		if ((pNode = cJSON_GetObjectItem(pSMToBMConversion, "RescaleMinValue")))
-		{
-			Config->RumbleSettings.SMToBMConversion.RescaleMinValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "SMToBMConversion.RescaleMinValue",
-				Config->RumbleSettings.SMToBMConversion.RescaleMinValue);
-		}
-
-		if ((pNode = cJSON_GetObjectItem(pSMToBMConversion, "RescaleMaxValue")))
-		{
-			Config->RumbleSettings.SMToBMConversion.RescaleMaxValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "SMToBMConversion.RescaleMaxValue",
-				Config->RumbleSettings.SMToBMConversion.RescaleMaxValue);
+			Config->RumbleSettings.HeavyRescaling.MaxRange = (UCHAR)cJSON_GetNumberValue(pNode);
+			EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.HeavyRescaling.MaxRange", Config->RumbleSettings.HeavyRescaling.MaxRange);
 		}
 	}
 
-	const cJSON* pForcedSM = cJSON_GetObjectItem(RumbleSettings, "ForcedSM");
+	const cJSON* pAlternativeMode = cJSON_GetObjectItem(RumbleSettings, "AlternativeMode");
 
-	if (pForcedSM)
+	if (pAlternativeMode)
 	{
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "BMThresholdEnabled")))
+		if ((pNode = cJSON_GetObjectItem(pAlternativeMode, "IsEnabled")))
 		{
-			Config->RumbleSettings.ForcedSM.BMThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.BMThresholdEnabled",
-				Config->RumbleSettings.ForcedSM.BMThresholdEnabled);
+			Config->RumbleSettings.AlternativeMode.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+			EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.IsEnabled", Config->RumbleSettings.AlternativeMode.IsEnabled);
 		}
 
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "BMThresholdValue")))
+		if ((pNode = cJSON_GetObjectItem(pAlternativeMode, "RescaleMinRange")))
 		{
-			Config->RumbleSettings.ForcedSM.BMThresholdValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.BMThresholdValue",
-				Config->RumbleSettings.ForcedSM.BMThresholdValue);
+			Config->RumbleSettings.AlternativeMode.MinRange = (UCHAR)cJSON_GetNumberValue(pNode);
+			EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.MinRange", Config->RumbleSettings.AlternativeMode.MinRange);
 		}
 
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "SMThresholdEnabled")))
+		if ((pNode = cJSON_GetObjectItem(pAlternativeMode, "RescaleMaxRange")))
 		{
-			Config->RumbleSettings.ForcedSM.SMThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.SMThresholdEnabled",
-				Config->RumbleSettings.ForcedSM.SMThresholdEnabled);
+			Config->RumbleSettings.AlternativeMode.MaxRange = (UCHAR)cJSON_GetNumberValue(pNode);
+			EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.MaxRange", Config->RumbleSettings.AlternativeMode.MaxRange);
 		}
 
-		if ((pNode = cJSON_GetObjectItem(pForcedSM, "SMThresholdValue")))
+		const cJSON* pForced = cJSON_GetObjectItem(pAlternativeMode, "ForcedRight");
+
+		if (pForced)
 		{
-			Config->RumbleSettings.ForcedSM.SMThresholdValue = (UCHAR)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(RumbleSettings->string, "ForcedSM.SMThresholdValue",
-				Config->RumbleSettings.ForcedSM.SMThresholdValue);
+			if ((pNode = cJSON_GetObjectItem(pForced, "IsHeavyThresholdEnabled")))
+			{
+				Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+				EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled);
+			}
+
+			if ((pNode = cJSON_GetObjectItem(pForced, "IsLightThresholdEnabled")))
+			{
+				Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
+				EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled", Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled);
+			}
+
+			if ((pNode = cJSON_GetObjectItem(pForced, "HeavyThreshold")))
+			{
+				Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = (UCHAR)cJSON_GetNumberValue(pNode);
+				EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold", Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold);
+			}
+
+			if ((pNode = cJSON_GetObjectItem(pForced, "LightThreshold")))
+			{
+				Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold = (UCHAR)cJSON_GetNumberValue(pNode);
+				EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.ForcedRight.LightThreshold", Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold);
+			}
 		}
 	}
 }

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -945,9 +945,9 @@ ConfigSetDefaults(
 	Config->RumbleSettings.AlternativeMode.MinRange = 1;
 	Config->RumbleSettings.AlternativeMode.MaxRange = 140;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled = TRUE;
-	Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = 230;
+	Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = 242;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = FALSE;
-	Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold = 230;
+	Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold = 242;
 
 	Config->LEDSettings.Mode = DsLEDModeBatteryIndicatorPlayerIndex;
 	Config->LEDSettings.CustomPatterns.LEDFlags = 0x02;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -943,18 +943,18 @@ ConfigSetDefaults(
 	Config->ThumbSettings.DeadZoneRight.Apply = TRUE;
 	Config->ThumbSettings.DeadZoneRight.PolarValue = 3.0;
 
-	Config->RumbleSettings.DisableBM = FALSE;
-	Config->RumbleSettings.DisableSM = FALSE;
-	Config->RumbleSettings.BMStrRescale.Enabled = TRUE;
-	Config->RumbleSettings.BMStrRescale.MinValue = 64;
-	Config->RumbleSettings.BMStrRescale.MaxValue = 255;
-	Config->RumbleSettings.SMToBMConversion.Enabled = FALSE;
-	Config->RumbleSettings.SMToBMConversion.RescaleMinValue = 1;
-	Config->RumbleSettings.SMToBMConversion.RescaleMaxValue = 140;
-	Config->RumbleSettings.ForcedSM.BMThresholdEnabled = TRUE;
-	Config->RumbleSettings.ForcedSM.BMThresholdValue = 230;
-	Config->RumbleSettings.ForcedSM.SMThresholdEnabled = FALSE;
-	Config->RumbleSettings.ForcedSM.SMThresholdValue = 230;
+	Config->RumbleSettings.DisableLeft = FALSE;
+	Config->RumbleSettings.DisableRight = FALSE;
+	Config->RumbleSettings.HeavyRescaling.IsEnabled = TRUE;
+	Config->RumbleSettings.HeavyRescaling.MinRange = 64;
+	Config->RumbleSettings.HeavyRescaling.MaxRange = 255;
+	Config->RumbleSettings.AlternativeMode.IsEnabled = FALSE;
+	Config->RumbleSettings.AlternativeMode.MinRange = 1;
+	Config->RumbleSettings.AlternativeMode.MaxRange = 140;
+	Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled = TRUE;
+	Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = 230;
+	Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = FALSE;
+	Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold = 230;
 
 	Config->LEDSettings.Mode = DsLEDModeBatteryIndicatorPlayerIndex;
 	Config->LEDSettings.CustomPatterns.LEDFlags = 0x02;

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -309,14 +309,14 @@ typedef struct _DEVICE_CONTEXT
 		//
 		// Cache for last received Small Motor Strength value
 		// 
-		UCHAR Small;
+		UCHAR LightCache;
 
 		//
 		// Cache for last received Big Motor Strength value
 		// 
-		UCHAR Big;
+		UCHAR HeavyCache;
 
-	} MotorStrCache;
+	} RumbleControlState;
 
 } DEVICE_CONTEXT, * PDEVICE_CONTEXT;
 

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -316,6 +316,26 @@ typedef struct _DEVICE_CONTEXT
 		// 
 		UCHAR HeavyCache;
 
+		//
+		// Defines if heavy rumble strength rescaling is requested
+		//
+		BOOLEAN HeavyRescaleEnabled;
+
+		//
+		// Defines if alternative rumble mode is enabled
+		//
+		BOOLEAN AltModeEnabled;
+
+		//
+		// Current state of heavy rumble rescaling parameters
+		//
+		DS_RESCALE_STATE HeavyRescale;
+
+		//
+		// Current state of light rumble rescaling parameters
+		//
+		DS_RESCALE_STATE LightRescale;
+
 	} RumbleControlState;
 
 } DEVICE_CONTEXT, * PDEVICE_CONTEXT;

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -176,6 +176,19 @@ typedef struct _DS_OUTPUT_REPORT_CACHE
 	
 } DS_OUTPUT_REPORT_CACHE, *PDS_OUTPUT_REPORT_CACHE;
 
+//
+// Stores the constants used for rumble rescaling and if it is allowed
+//
+typedef struct _DS_RESCALE_STATE
+{
+	BOOLEAN IsAllowed;
+
+	DOUBLE ConstA;
+
+	DOUBLE ConstB;
+
+} DS_RESCALE_STATE, * PDS_RESCALE_STATE;
+
 typedef struct _DEVICE_CONTEXT
 {
 	//

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -586,6 +586,22 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	DOUBLE heavyRumble = Context->RumbleControlState.HeavyCache;
 	DOUBLE lightRumble = Context->RumbleControlState.LightCache;
 
+	// LINEAR RANGE RESCALLING
+	// 
+	// To rescale a value that exists in a range into a new range:
+	// newvalue = a * value + b
+	//
+	// a = (max'-min')/(max-min)
+	// b = max' - a * max
+	//
+	// In which max and min are the limits of the the original range
+	// For the DS3 rumble, it's max = 255 and min = 1 since 0 is not considered.
+	// 
+	// max' and min' are the limits of the new range
+	// 0 is not considered for the new range too regarding rumble
+	//
+	// constants a and b are calculated on configuration (re-)loading
+
 	if (Context->RumbleControlState.AltModeEnabled && lightResc->IsAllowed)
 	{
 		if (lightRumble > 0) {

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -522,7 +522,7 @@ VOID DS3_SET_SMALL_RUMBLE_STRENGTH(
 	UCHAR Value
 )
 {
-	Context->MotorStrCache.Small = Value;
+	Context->RumbleControlState.LightCache = Value;
 	DS3_PROCESS_RUMBLE_STRENGTH(Context);
 }
 
@@ -558,7 +558,7 @@ VOID DS3_SET_LARGE_RUMBLE_STRENGTH(
 	UCHAR Value
 )
 {
-	Context->MotorStrCache.Big = Value;
+	Context->RumbleControlState.HeavyCache = Value;
 	DS3_PROCESS_RUMBLE_STRENGTH(Context);
 }
 
@@ -568,8 +568,8 @@ VOID DS3_SET_BOTH_RUMBLE_STRENGTH(
 	UCHAR SmallValue
 )
 {
-	Context->MotorStrCache.Small = SmallValue;
-	Context->MotorStrCache.Big = LargeValue;
+	Context->RumbleControlState.LightCache = SmallValue;
+	Context->RumbleControlState.HeavyCache = LargeValue;
 	DS3_PROCESS_RUMBLE_STRENGTH(Context);
 }
 
@@ -578,8 +578,8 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 )
 {
 
-	DOUBLE LargeValue = Context->Configuration.RumbleSettings.DisableBM ? 0 : Context->MotorStrCache.Big;
-	DOUBLE SmallValue = Context->Configuration.RumbleSettings.DisableSM ? 0 : Context->MotorStrCache.Small;
+	DOUBLE LargeValue = Context->Configuration.RumbleSettings.DisableBM ? 0 : Context->RumbleControlState.HeavyCache;
+	DOUBLE SmallValue = Context->Configuration.RumbleSettings.DisableSM ? 0 : Context->RumbleControlState.LightCache;
 
 	if (
 		Context->Configuration.RumbleSettings.SMToBMConversion.Enabled
@@ -604,7 +604,7 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 			// Force Activate Small Motor if original SMALL Motor Strength is above certain level and related boolean is enabled
 			if (
 				Context->Configuration.RumbleSettings.ForcedSM.SMThresholdEnabled
-				&& Context->MotorStrCache.Small >= Context->Configuration.RumbleSettings.ForcedSM.SMThresholdValue
+				&& Context->RumbleControlState.LightCache >= Context->Configuration.RumbleSettings.ForcedSM.SMThresholdValue
 				)
 			{
 				SmallValue = 1;
@@ -616,7 +616,7 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 		// Force Activate Small Motor if original BIG Motor Strength is above certain level and related boolean is enabled
 		if (
 			Context->Configuration.RumbleSettings.ForcedSM.BMThresholdEnabled
-			&& Context->MotorStrCache.Big >= Context->Configuration.RumbleSettings.ForcedSM.BMThresholdValue
+			&& Context->RumbleControlState.HeavyCache >= Context->Configuration.RumbleSettings.ForcedSM.BMThresholdValue
 			)
 		{
 			SmallValue = 1;

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -359,51 +359,85 @@ typedef struct _DS_THUMB_SETTINGS
 typedef struct _DS_RUMBLE_SETTINGS
 {
 	//
-	// Disable Big Motor (left) entirely
+	// Disables Heavy Motor (left) when in normal mode
 	// 
-	BOOLEAN DisableBM;
+	BOOLEAN DisableLeft;
 
 	//
-	// Disable Small Motor (right) entirely
+	// Disables Light Motor (right) when in normal mode
 	// 
-	BOOLEAN DisableSM;
+	BOOLEAN DisableRight;
 
+	// Adjustments for heavy (left) motor rescaling
 	struct
 	{
-		BOOLEAN Enabled;
+		//
+		// Enables heavy rumble intensity rescaling if possible
+		//
+		BOOLEAN IsEnabled;
 
-		UCHAR MinValue;
+		//
+		// Desired new minimum range
+		//
+		UCHAR MinRange;
 
-		UCHAR MaxValue;
+		//
+		// Desired new maximum range
+		//
+		UCHAR MaxRange;
 
-		DOUBLE ConstA;
+	} HeavyRescaling;
 
-		DOUBLE ConstB;
-	} BMStrRescale;
 
+	//
+	// Alternative rumble mode user parameters
+	//
 	struct
 	{
-		BOOLEAN Enabled;
+		//
+		// Sets that alternative rumble mode should be enabled if possible
+		//
+		BOOLEAN IsEnabled;
 
-		UCHAR RescaleMinValue;
+		//
+		// Desired new minimun range when rescaling light rumble intensity
+		//
+		UCHAR MinRange;
 
-		UCHAR RescaleMaxValue;
+		//
+		// New maximum range desired when rescaling light rumble intensity
+		//
+		UCHAR MaxRange;
 
-		DOUBLE ConstA;
+		//
+		// Parameters used for the force activation of the right motor when in alternative rumble mode
+		// 
+		//
+		struct
+		{
+			//
+			// Enables the heavy rumble threshold
+			//
+			BOOLEAN IsHeavyThresholdEnabled;
 
-		DOUBLE ConstB;
-	} SMToBMConversion;
+			//
+			// Enables the light rumble threshold
+			//
+			BOOLEAN IsLightThresholdEnabled;
 
-	struct
-	{
-		BOOLEAN BMThresholdEnabled;
+			//
+			// Threshold received heavy rumble instructions must reach to force activate the right motor
+			//
+			UCHAR HeavyThreshold;
 
-		UCHAR BMThresholdValue;
+			//
+			// Threshold received light rumble instructions must reach to force activate the right motor
+			//
+			UCHAR LightThreshold;
 
-		BOOLEAN SMThresholdEnabled;
+		} ForcedRight;
 
-		UCHAR SMThresholdValue;
-	} ForcedSM;
+	} AlternativeMode;
 } DS_RUMBLE_SETTINGS, * PDS_RUMBLE_SETTINGS;
 
 //

--- a/sys/DsHidMini.json
+++ b/sys/DsHidMini.json
@@ -35,12 +35,12 @@
         "AlternativeMode": {
           "IsEnabled": false,
           "RescaleMinRange": 1,
-          "RescaleMaxRange": 140,
+          "RescaleMaxRange": 110,
           "ForcedRight": {
             "IsHeavyThresholdEnabled": true,
-            "HeavyThreshold": 230,
+            "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
-            "LightThreshold": 230
+            "LightThreshold": 242
           }
         }
       },
@@ -104,12 +104,12 @@
         "AlternativeMode": {
           "IsEnabled": false,
           "RescaleMinRange": 1,
-          "RescaleMaxRange": 140,
+          "RescaleMaxRange": 110,
           "ForcedRight": {
             "IsHeavyThresholdEnabled": true,
-            "HeavyThreshold": 230,
+            "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
-            "LightThreshold": 230
+            "LightThreshold": 242
           }
         }
       },
@@ -164,12 +164,12 @@
         "AlternativeMode": {
           "IsEnabled": false,
           "RescaleMinRange": 1,
-          "RescaleMaxRange": 140,
+          "RescaleMaxRange": 110,
           "ForcedRight": {
             "IsHeavyThresholdEnabled": true,
-            "HeavyThreshold": 230,
+            "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
-            "LightThreshold": 230
+            "LightThreshold": 242
           }
         }
       },
@@ -224,12 +224,12 @@
         "AlternativeMode": {
           "IsEnabled": false,
           "RescaleMinRange": 1,
-          "RescaleMaxRange": 140,
+          "RescaleMaxRange": 110,
           "ForcedRight": {
             "IsHeavyThresholdEnabled": true,
-            "HeavyThreshold": 230,
+            "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
-            "LightThreshold": 230
+            "LightThreshold": 242
           }
         }
       },
@@ -284,12 +284,12 @@
         "AlternativeMode": {
           "IsEnabled": false,
           "RescaleMinRange": 1,
-          "RescaleMaxRange": 140,
+          "RescaleMaxRange": 110,
           "ForcedRight": {
             "IsHeavyThresholdEnabled": true,
-            "HeavyThreshold": 230,
+            "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
-            "LightThreshold": 230
+            "LightThreshold": 242
           }
         }
       },

--- a/sys/DsHidMini.json
+++ b/sys/DsHidMini.json
@@ -25,23 +25,23 @@
         "PolarValue": 10.0
       },
       "RumbleSettings": {
-        "DisableBM": false,
-        "DisableSM": false,
-        "BMStrRescale": {
-          "Enabled": true,
-          "MinValue": 64,
-          "MaxValue": 255
+        "DisableLeft": false,
+        "DisableRight": false,
+        "HeavyRescale": {
+          "IsEnabled": true,
+          "RescaleMinRange": 64,
+          "RescaleMaxRange": 255
         },
-        "SMToBMConversion": {
-          "Enabled": false,
-          "RescaleMinValue": 0,
-          "RescaleMaxValue": 160
-        },
-        "ForcedSM": {
-          "BMThresholdEnabled": true,
-          "BMThresholdValue": 230,
-          "SMThresholdEnabled": false,
-          "SMThresholdValue": 230
+        "AlternativeMode": {
+          "IsEnabled": false,
+          "RescaleMinRange": 1,
+          "RescaleMaxRange": 140,
+          "ForcedRight": {
+            "IsHeavyThresholdEnabled": true,
+            "HeavyThreshold": 230,
+            "IsLightThresholdEnabled": false,
+            "LightThreshold": 230
+          }
         }
       },
       "LEDSettings": {
@@ -94,23 +94,23 @@
         "PolarValue": 10.0
       },
       "RumbleSettings": {
-        "DisableBM": false,
-        "DisableSM": false,
-        "BMStrRescale": {
-          "Enabled": true,
-          "MinValue": 64,
-          "MaxValue": 255
+        "DisableLeft": false,
+        "DisableRight": false,
+        "HeavyRescale": {
+          "IsEnabled": true,
+          "RescaleMinRange": 64,
+          "RescaleMaxRange": 255
         },
-        "SMToBMConversion": {
-          "Enabled": false,
-          "RescaleMinValue": 0,
-          "RescaleMaxValue": 160
-        },
-        "ForcedSM": {
-          "BMThresholdEnabled": true,
-          "BMThresholdValue": 230,
-          "SMThresholdEnabled": false,
-          "SMThresholdValue": 230
+        "AlternativeMode": {
+          "IsEnabled": false,
+          "RescaleMinRange": 1,
+          "RescaleMaxRange": 140,
+          "ForcedRight": {
+            "IsHeavyThresholdEnabled": true,
+            "HeavyThreshold": 230,
+            "IsLightThresholdEnabled": false,
+            "LightThreshold": 230
+          }
         }
       },
       "LEDSettings": {
@@ -154,23 +154,23 @@
         "PolarValue": 10.0
       },
       "RumbleSettings": {
-        "DisableBM": false,
-        "DisableSM": false,
-        "BMStrRescale": {
-          "Enabled": true,
-          "MinValue": 64,
-          "MaxValue": 255
+        "DisableLeft": false,
+        "DisableRight": false,
+        "HeavyRescale": {
+          "IsEnabled": true,
+          "RescaleMinRange": 64,
+          "RescaleMaxRange": 255
         },
-        "SMToBMConversion": {
-          "Enabled": false,
-          "RescaleMinValue": 0,
-          "RescaleMaxValue": 160
-        },
-        "ForcedSM": {
-          "BMThresholdEnabled": true,
-          "BMThresholdValue": 230,
-          "SMThresholdEnabled": false,
-          "SMThresholdValue": 230
+        "AlternativeMode": {
+          "IsEnabled": false,
+          "RescaleMinRange": 1,
+          "RescaleMaxRange": 140,
+          "ForcedRight": {
+            "IsHeavyThresholdEnabled": true,
+            "HeavyThreshold": 230,
+            "IsLightThresholdEnabled": false,
+            "LightThreshold": 230
+          }
         }
       },
       "LEDSettings": {
@@ -214,23 +214,23 @@
         "PolarValue": 10.0
       },
       "RumbleSettings": {
-        "DisableBM": false,
-        "DisableSM": false,
-        "BMStrRescale": {
-          "Enabled": true,
-          "MinValue": 64,
-          "MaxValue": 255
+        "DisableLeft": false,
+        "DisableRight": false,
+        "HeavyRescale": {
+          "IsEnabled": true,
+          "RescaleMinRange": 64,
+          "RescaleMaxRange": 255
         },
-        "SMToBMConversion": {
-          "Enabled": false,
-          "RescaleMinValue": 0,
-          "RescaleMaxValue": 160
-        },
-        "ForcedSM": {
-          "BMThresholdEnabled": true,
-          "BMThresholdValue": 230,
-          "SMThresholdEnabled": false,
-          "SMThresholdValue": 230
+        "AlternativeMode": {
+          "IsEnabled": false,
+          "RescaleMinRange": 1,
+          "RescaleMaxRange": 140,
+          "ForcedRight": {
+            "IsHeavyThresholdEnabled": true,
+            "HeavyThreshold": 230,
+            "IsLightThresholdEnabled": false,
+            "LightThreshold": 230
+          }
         }
       },
       "LEDSettings": {
@@ -274,23 +274,23 @@
         "PolarValue": 10.0
       },
       "RumbleSettings": {
-        "DisableBM": false,
-        "DisableSM": false,
-        "BMStrRescale": {
-          "Enabled": true,
-          "MinValue": 64,
-          "MaxValue": 255
+        "DisableLeft": false,
+        "DisableRight": false,
+        "HeavyRescale": {
+          "IsEnabled": true,
+          "RescaleMinRange": 64,
+          "RescaleMaxRange": 255
         },
-        "SMToBMConversion": {
-          "Enabled": false,
-          "RescaleMinValue": 1,
-          "RescaleMaxValue": 140
-        },
-        "ForcedSM": {
-          "BMThresholdEnabled": true,
-          "BMThresholdValue": 230,
-          "SMThresholdEnabled": false,
-          "SMThresholdValue": 230
+        "AlternativeMode": {
+          "IsEnabled": false,
+          "RescaleMinRange": 1,
+          "RescaleMaxRange": 140,
+          "ForcedRight": {
+            "IsHeavyThresholdEnabled": true,
+            "HeavyThreshold": 230,
+            "IsLightThresholdEnabled": false,
+            "LightThreshold": 230
+          }
         }
       },
       "LEDSettings": {


### PR DESCRIPTION
- Changed the structure of user defined rumble configurations
- Updated rumble configuration loading from disk to fit changes
- Re-purposed structure that store last received rumble intensities to also store current state of rumble rescaling
    - Before the current state was read/write directly to the user configurations
- Added a IsAllowed property for the current state of rumble rescalers so rescaling can be "blocked" even if it's enabled
    - Set to false if user-defined rescaling ranges are invalid
- Reworked rumble processing to reflect changes above
    - Rescaling constants, if they are enabled and if they are allowed are now fetched from the re-purposed struct commented above
- Changed rumble processing logic so motors can only be disabled while in normal mode