### PR TITLE
Implement button combo for toggling alternative rumble mode

### DIFF
--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -948,6 +948,11 @@ ConfigSetDefaults(
 	Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = 242;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = FALSE;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.LightThreshold = 242;
+	Config->RumbleSettings.AlternativeMode.ToggleButtonCombo.IsEnabled = FALSE;
+	Config->RumbleSettings.AlternativeMode.ToggleButtonCombo.HoldTime = 1000;
+	Config->RumbleSettings.AlternativeMode.ToggleButtonCombo.Buttons[0] = 0; // Select
+	Config->RumbleSettings.AlternativeMode.ToggleButtonCombo.Buttons[1] = 0; // Select
+	Config->RumbleSettings.AlternativeMode.ToggleButtonCombo.Buttons[2] = 16; // PS
 
 	Config->LEDSettings.Mode = DsLEDModeBatteryIndicatorPlayerIndex;
 	Config->LEDSettings.CustomPatterns.LEDFlags = 0x02;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -496,46 +496,9 @@ static void ConfigNodeParse(
 	//
 	// Wireless quick disconnect combo
 	// 
-	const cJSON* pDisconnectCombo = cJSON_GetObjectItem(ParentNode, "QuickDisconnectCombo");
-
-	if (pDisconnectCombo)
+	if ((pNode = cJSON_GetObjectItem(ParentNode, "QuickDisconnectCombo")))
 	{
-		if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, "IsEnabled")))
-		{
-			pCfg->WirelessDisconnectButtonCombo.IsEnabled = (BOOLEAN)cJSON_IsTrue(pNode);
-			EventWriteOverrideSettingUInt(pDisconnectCombo->string, "WirelessDisconnectButtonCombo.IsEnabled",
-				pCfg->WirelessDisconnectButtonCombo.IsEnabled);
-		}
-
-		if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, "HoldTime")))
-		{
-			pCfg->WirelessDisconnectButtonCombo.HoldTime = (ULONG)cJSON_GetNumberValue(pNode);
-			EventWriteOverrideSettingUInt(pDisconnectCombo->string, "WirelessDisconnectButtonCombo.HoldTime",
-				pCfg->WirelessDisconnectButtonCombo.HoldTime);
-		}
-
-		for (ULONGLONG buttonIndex = 0; buttonIndex < _countof(pCfg->WirelessDisconnectButtonCombo.Buttons); buttonIndex++)
-		{
-			if ((pNode = cJSON_GetObjectItem(pDisconnectCombo, G_DS_BUTTON_COMBO_NAMES[buttonIndex])))
-			{
-				const UCHAR offset = (UCHAR)cJSON_GetNumberValue(pNode);
-				if (offset <= DS_BUTTON_COMBO_MAX_OFFSET)
-				{
-					pCfg->WirelessDisconnectButtonCombo.Buttons[buttonIndex] = (UCHAR)cJSON_GetNumberValue(pNode);
-					EventWriteOverrideSettingUInt(pDisconnectCombo->string, G_DS_BUTTON_COMBO_NAMES[buttonIndex],
-						pCfg->WirelessDisconnectButtonCombo.Buttons[buttonIndex]);
-				}
-				else
-				{
-					TraceError(
-						TRACE_CONFIG,
-						"Provided button offset %d for %s out of range, ignoring",
-						offset,
-						G_DS_BUTTON_COMBO_NAMES[buttonIndex]
-					);
-				}
-			}
-		}
+		ConfigParseButtonComboSettings(pNode, &pCfg->WirelessDisconnectButtonCombo);
 	}
 
 	//

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -243,6 +243,11 @@ ConfigParseRumbleSettings(
 			EventWriteOverrideSettingUInt(RumbleSettings->string, "RumbleSettings.AlternativeMode.MaxRange", Config->RumbleSettings.AlternativeMode.MaxRange);
 		}
 
+		if ((pNode = cJSON_GetObjectItem(pAlternativeMode, "ToggleCombo")))
+		{
+			ConfigParseButtonComboSettings(pNode, &Config->RumbleSettings.AlternativeMode.ToggleButtonCombo);
+		}
+
 		const cJSON* pForced = cJSON_GetObjectItem(pAlternativeMode, "ForcedRight");
 
 		if (pForced)

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -825,7 +825,7 @@ ConfigLoadForDevice(
 		&& rumbSet->AlternativeMode.MinRange > 0
 		)
 	{
-		Context->RumbleControlState.AltMode.AltModeEnabled = rumbSet->AlternativeMode.IsEnabled;
+		Context->RumbleControlState.AltMode.IsEnabled = rumbSet->AlternativeMode.IsEnabled;
 
 		DOUBLE LConstA = (DOUBLE)(rumbSet->AlternativeMode.MaxRange - rumbSet->AlternativeMode.MinRange) / (254);
 		DOUBLE LConstB = rumbSet->AlternativeMode.MaxRange - LConstA * 255;

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -825,20 +825,20 @@ ConfigLoadForDevice(
 		&& rumbSet->AlternativeMode.MinRange > 0
 		)
 	{
-		Context->RumbleControlState.AltModeEnabled = rumbSet->AlternativeMode.IsEnabled;
+		Context->RumbleControlState.AltMode.AltModeEnabled = rumbSet->AlternativeMode.IsEnabled;
 
 		DOUBLE LConstA = (DOUBLE)(rumbSet->AlternativeMode.MaxRange - rumbSet->AlternativeMode.MinRange) / (254);
 		DOUBLE LConstB = rumbSet->AlternativeMode.MaxRange - LConstA * 255;
 
-		Context->RumbleControlState.LightRescale.ConstA = LConstA;
-		Context->RumbleControlState.LightRescale.ConstB = LConstB;
-		Context->RumbleControlState.LightRescale.IsAllowed = TRUE;
+		Context->RumbleControlState.AltMode.LightRescale.ConstA = LConstA;
+		Context->RumbleControlState.AltMode.LightRescale.ConstB = LConstB;
+		Context->RumbleControlState.AltMode.LightRescale.IsAllowed = TRUE;
 
 		TraceVerbose(
 			TRACE_CONFIG,
 			"Light rumble rescaling constants: A = %f and B = %f.",
-			Context->RumbleControlState.LightRescale.ConstA,
-			Context->RumbleControlState.LightRescale.ConstB
+			Context->RumbleControlState.AltMode.LightRescale.ConstA,
+			Context->RumbleControlState.AltMode.LightRescale.ConstB
 		);
 
 	}
@@ -848,7 +848,7 @@ ConfigLoadForDevice(
 			TRACE_CONFIG,
 			"Disallowing light rumble rescalling because an invalid range was defined"
 		);
-		Context->RumbleControlState.LightRescale.IsAllowed = FALSE;
+		Context->RumbleControlState.AltMode.LightRescale.IsAllowed = FALSE;
 	}
 
 	//

--- a/sys/Configuration.c
+++ b/sys/Configuration.c
@@ -963,7 +963,7 @@ ConfigSetDefaults(
 	Config->RumbleSettings.HeavyRescaling.MaxRange = 255;
 	Config->RumbleSettings.AlternativeMode.IsEnabled = FALSE;
 	Config->RumbleSettings.AlternativeMode.MinRange = 1;
-	Config->RumbleSettings.AlternativeMode.MaxRange = 110;
+	Config->RumbleSettings.AlternativeMode.MaxRange = 90;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.IsHeavyThresholdEnabled = TRUE;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.HeavyThreshold = 242;
 	Config->RumbleSettings.AlternativeMode.ForcedRight.IsLightThresholdEnabled = FALSE;

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -333,6 +333,16 @@ typedef struct _DEVICE_CONTEXT
 			//
 			DS_RESCALE_STATE LightRescale;
 
+			//
+			// Allows toggling to occur if the button combo conditions are satisfied
+			//
+			BOOLEAN IsToggleAllowed;
+
+			//
+			// Timestamp to calculate alt mode toggle combo detection
+			//
+			LARGE_INTEGER QuickToggleTimestamp;
+
 		} AltMode;
 
 		//

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -321,20 +321,24 @@ typedef struct _DEVICE_CONTEXT
 		//
 		BOOLEAN HeavyRescaleEnabled;
 
-		//
-		// Defines if alternative rumble mode is enabled
-		//
-		BOOLEAN AltModeEnabled;
+		struct {
+
+			//
+			// Defines if alternative rumble mode is enabled
+			//
+			BOOLEAN AltModeEnabled;
+
+			//
+			// Current state of light rumble rescaling parameters
+			//
+			DS_RESCALE_STATE LightRescale;
+
+		} AltMode;
 
 		//
 		// Current state of heavy rumble rescaling parameters
 		//
 		DS_RESCALE_STATE HeavyRescale;
-
-		//
-		// Current state of light rumble rescaling parameters
-		//
-		DS_RESCALE_STATE LightRescale;
 
 	} RumbleControlState;
 

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -326,7 +326,7 @@ typedef struct _DEVICE_CONTEXT
 			//
 			// Defines if alternative rumble mode is enabled
 			//
-			BOOLEAN AltModeEnabled;
+			BOOLEAN IsEnabled;
 
 			//
 			// Current state of light rumble rescaling parameters

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -602,7 +602,7 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	//
 	// constants a and b are calculated on configuration (re-)loading
 
-	if (Context->RumbleControlState.AltMode.AltModeEnabled && lightResc->IsAllowed)
+	if (Context->RumbleControlState.AltMode.IsEnabled && lightResc->IsAllowed)
 	{
 		if (lightRumble > 0) {
 

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -580,7 +580,7 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	DS_RUMBLE_SETTINGS* rumbSet = &Context->Configuration.RumbleSettings;
 
 	DS_RESCALE_STATE* heavyResc = &Context->RumbleControlState.HeavyRescale;
-	DS_RESCALE_STATE* lightResc = &Context->RumbleControlState.LightRescale;
+	DS_RESCALE_STATE* lightResc = &Context->RumbleControlState.AltMode.LightRescale;
 
 	// Get last received rumble values so they can be processed
 	DOUBLE heavyRumble = Context->RumbleControlState.HeavyCache;
@@ -602,7 +602,7 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	//
 	// constants a and b are calculated on configuration (re-)loading
 
-	if (Context->RumbleControlState.AltModeEnabled && lightResc->IsAllowed)
+	if (Context->RumbleControlState.AltMode.AltModeEnabled && lightResc->IsAllowed)
 	{
 		if (lightRumble > 0) {
 

--- a/sys/DsCommon.h
+++ b/sys/DsCommon.h
@@ -410,6 +410,11 @@ typedef struct _DS_RUMBLE_SETTINGS
 		UCHAR MaxRange;
 
 		//
+		// Button combo for toggling alternative mode
+		//
+		DS_BUTTON_COMBO ToggleButtonCombo;
+
+		//
 		// Parameters used for the force activation of the right motor when in alternative rumble mode
 		// 
 		//

--- a/sys/DsHidMini.json
+++ b/sys/DsHidMini.json
@@ -41,6 +41,13 @@
             "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
             "LightThreshold": 242
+          },
+          "ToggleCombo": {
+            "IsEnabled": true,
+            "HoldTime": 1000,
+            "Button1": 16,
+            "Button2": 0,
+            "Button3": 0
           }
         }
       },
@@ -110,6 +117,13 @@
             "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
             "LightThreshold": 242
+          },
+          "ToggleCombo": {
+            "IsEnabled": true,
+            "HoldTime": 1000,
+            "Button1": 16,
+            "Button2": 0,
+            "Button3": 0
           }
         }
       },
@@ -170,6 +184,13 @@
             "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
             "LightThreshold": 242
+          },
+          "ToggleCombo": {
+            "IsEnabled": true,
+            "HoldTime": 1000,
+            "Button1": 16,
+            "Button2": 0,
+            "Button3": 0
           }
         }
       },
@@ -230,6 +251,13 @@
             "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
             "LightThreshold": 242
+          },
+          "ToggleCombo": {
+            "IsEnabled": true,
+            "HoldTime": 1000,
+            "Button1": 16,
+            "Button2": 0,
+            "Button3": 0
           }
         }
       },
@@ -290,6 +318,13 @@
             "HeavyThreshold": 242,
             "IsLightThresholdEnabled": false,
             "LightThreshold": 242
+          },
+          "ToggleCombo": {
+            "IsEnabled": true,
+            "HoldTime": 1000,
+            "Button1": 16,
+            "Button2": 0,
+            "Button3": 0
           }
         }
       },

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -1998,6 +1998,105 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 	}
 
 	//
+	// Alternative rumble toggle combo detected
+	// 
+	if (pDevCtx->Configuration.RumbleSettings.AlternativeMode.ToggleButtonCombo.IsEnabled)
+	{
+		int engagedCount = 0;
+		for (int buttonIndex = 0; buttonIndex < 3; buttonIndex++)
+		{
+			if ((pInReport->Buttons.lButtons >> pDevCtx->Configuration.RumbleSettings.AlternativeMode.ToggleButtonCombo.Buttons[buttonIndex]) & 1)
+			{
+				engagedCount++;
+			}
+		}
+
+		if (engagedCount == 3)
+		{
+			TraceEvents(TRACE_LEVEL_INFORMATION,
+				TRACE_DSHIDMINIDRV,
+				"!! Alternative mode toggle combination detected"
+			);
+			if (pDevCtx->RumbleControlState.AltMode.IsToggleAllowed)
+			{
+				t1 = &pDevCtx->RumbleControlState.AltMode.QuickToggleTimestamp;
+
+				if (pDevCtx->RumbleControlState.AltMode.QuickToggleTimestamp.QuadPart == 0)
+				{
+					QueryPerformanceCounter(t1);
+				}
+
+				QueryPerformanceCounter(&t2);
+
+				ms = (t2.QuadPart - t1->QuadPart) / (freq.QuadPart / 1000);
+
+				//
+				// Combo was held for the user defined time period
+				// 
+				if (ms > pDevCtx->Configuration.WirelessDisconnectButtonCombo.HoldTime)
+				{
+					TraceEvents(TRACE_LEVEL_INFORMATION,
+						TRACE_DSHIDMINIDRV,
+						"!! Toggling alternative rumble mode"
+					);
+					pDevCtx->RumbleControlState.AltMode.IsEnabled = !pDevCtx->RumbleControlState.AltMode.IsEnabled;
+
+					//
+					// Send rumble feedback to indicate change in rumble mode
+					//
+					DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0x0F);
+					DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0x0F);
+					DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0xFF);
+					(void)Ds_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
+
+					//
+					// Restore default rumble duration
+					//
+					DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0xFF);
+					DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0xFF);
+
+
+					//
+					// Register the time the toggle was triggered
+					// Disallow toggling again while combo is being held
+					//
+					t1->QuadPart = t2.QuadPart;
+					pDevCtx->RumbleControlState.AltMode.IsToggleAllowed = FALSE;
+				}
+			}
+			else
+			{
+				TraceEvents(TRACE_LEVEL_INFORMATION,
+					TRACE_DSHIDMINIDRV,
+					"!! Alternative rumble mode toggling prevented"
+				);
+			}
+		}
+		else
+		{
+			if (pDevCtx->RumbleControlState.AltMode.IsToggleAllowed)
+			{
+				pDevCtx->RumbleControlState.AltMode.QuickToggleTimestamp.QuadPart = 0;
+			}
+			else
+			{
+				t1 = &pDevCtx->RumbleControlState.AltMode.QuickToggleTimestamp;
+				QueryPerformanceCounter(&t2);
+				ms = (t2.QuadPart - t1->QuadPart) / (freq.QuadPart / 1000);
+				if (ms > 1000) // wait 1 second before re-enabling toggle combo after releasing it
+				{
+					TraceEvents(TRACE_LEVEL_INFORMATION,
+						TRACE_DSHIDMINIDRV,
+						"!! Prevention time after releasing alt mode toggle combo has passed. Allowing combo again"
+					);
+					pDevCtx->RumbleControlState.AltMode.IsToggleAllowed = TRUE;
+					pDevCtx->RumbleControlState.AltMode.QuickToggleTimestamp.QuadPart = 0;
+				}
+			}
+		}
+	}
+
+	//
 	// Idle disconnect detection
 	// 
 	if (!pDevCtx->Configuration.DisableWirelessIdleTimeout && DS3_RAW_IS_IDLE(pInReport))

--- a/sys/DsHidMiniDrv.c
+++ b/sys/DsHidMiniDrv.c
@@ -2044,8 +2044,8 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 					//
 					// Send rumble feedback to indicate change in rumble mode
 					//
-					DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0x0F);
-					DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0x0F);
+					DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0x30);
+					DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0x20);
 					DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0xFF);
 					(void)Ds_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
 


### PR DESCRIPTION
- By holding a 3 button combination it's now possible to toggle alternative rumble mode on and off
- Customizations include:
    - which buttons must be held
    - how long the combo must be held before it is effective
    - Disabling the combo
- When toggling occurs a right rumble command is sent to the controller as feedback