### PR TITLE
Adds workarounds for wireless quirks of various controller models

### DIFF
--- a/dshidmini.sln.DotSettings
+++ b/dshidmini.sln.DotSettings
@@ -27,12 +27,14 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OTEL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=otlp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ourself/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PDEVICE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PXINPUT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SCPLIB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sdklogs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sdkresource/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sdktrace/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sixaxis/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=VHIDMINI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=WINERROR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=XBONE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=XBOX/@EntryIndexedValue">True</s:Boolean>

--- a/dshidmini.sln.DotSettings
+++ b/dshidmini.sln.DotSettings
@@ -18,6 +18,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=giphidgamepaddescriptor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Guids/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HIDAPI/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HRESULT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=jittering/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=libfmt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MSHIDUMDF/@EntryIndexedValue">True</s:Boolean>

--- a/sys/Device.c
+++ b/sys/Device.c
@@ -495,32 +495,59 @@ DsDevice_InitContext(
 		// 
 		DS3_BTH_SET_LED(outReportBuffer, DS3_LED_OFF);
 
-		//
-		// Output Report Delay
-		// 
+#pragma region StartupDelay
 
 		WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
 		attributes.ParentObject = Device;
 
 		WDF_TIMER_CONFIG_INIT(
 			&timerCfg,
-			DsBth_EvtControlWriteTimerFunc
+			DsBth_EvtStartupDelayTimerFunc
 		);
 
 		if (!NT_SUCCESS(status = WdfTimerCreate(
 			&timerCfg,
 			&attributes,
-			&pDevCtx->Connection.Bth.Timers.HidOutputReport
+			&pDevCtx->Connection.Bth.Timers.StartupDelay
 		)))
 		{
 			TraceError(
 				TRACE_DSBTH,
-				"WdfTimerCreate (HidOutputReport) failed with status %!STATUS!",
+				"WdfTimerCreate (StartupDelay) failed with status %!STATUS!",
 				status
 			);
-			EventWriteFailedWithNTStatus(__FUNCTION__, L"WdfTimerCreate", status);
+			EventWriteFailedWithNTStatus(__FUNCTION__, L"WdfTimerCreate (StartupDelay)", status);
 			break;
 		}
+
+#pragma endregion
+
+#pragma region PostStartupTasks
+
+		WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
+		attributes.ParentObject = Device;
+
+		WDF_TIMER_CONFIG_INIT(
+			&timerCfg,
+			DsBth_EvtPostStartupTimerFunc
+		);
+
+		if (!NT_SUCCESS(status = WdfTimerCreate(
+			&timerCfg,
+			&attributes,
+			&pDevCtx->Connection.Bth.Timers.PostStartupTasks
+		)))
+		{
+			TraceError(
+				TRACE_DSBTH,
+				"WdfTimerCreate (PostStartupTasks) failed with status %!STATUS!",
+				status
+			);
+			EventWriteFailedWithNTStatus(__FUNCTION__, L"WdfTimerCreate (PostStartupTasks)", status);
+			break;
+		}
+
+#pragma endregion
 
 		break;
 	}

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -69,6 +69,9 @@ struct BTH_DEVICE_CONTEXT
 		// 
 		WDFTIMER StartupDelay;
 
+		//
+		// Post-delayed start timer
+		// 
 		WDFTIMER PostStartupTasks;
 
 	} Timers;

--- a/sys/Device.h
+++ b/sys/Device.h
@@ -65,10 +65,12 @@ struct BTH_DEVICE_CONTEXT
 	struct
 	{
 		//
-		// Delayed Output Report Timer
+		// Delayed startup timer
 		// 
-		WDFTIMER HidOutputReport;
-				
+		WDFTIMER StartupDelay;
+
+		WDFTIMER PostStartupTasks;
+
 	} Timers;
 	
 	//

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -170,7 +170,7 @@ NTSTATUS DsUsb_Ds3Init(PDEVICE_CONTEXT Context)
 	// "Magic packet"
 	// 
 	UCHAR hidCommandEnable[] = {
-		0x42, 0x0C, 0x00, 0x00
+		DS3_USB_COMMON_ENABLE
 	};
 
 	status = USB_SendControlRequest(
@@ -496,7 +496,7 @@ NTSTATUS DsBth_Ds3Init(PDEVICE_CONTEXT Context)
 	// "Magic packet"
 	// 
 	BYTE hidCommandEnable[] = {
-		0x53, 0xF4, 0x42, 0x03, 0x00, 0x00
+		DS3_BTH_SIXAXIS_ENABLE
 	};
 
 	NTSTATUS status;

--- a/sys/Ds3.c
+++ b/sys/Ds3.c
@@ -488,7 +488,7 @@ NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device)
 //
 // Send magic packet over BTH
 // 
-NTSTATUS DsBth_Ds3Init(PDEVICE_CONTEXT Context)
+NTSTATUS DsBth_Ds3SixaxisInit(PDEVICE_CONTEXT Context)
 {
 	FuncEntry(TRACE_DS3);
 

--- a/sys/Ds3.h
+++ b/sys/Ds3.h
@@ -152,6 +152,6 @@ NTSTATUS DS3_GetActiveRadioAddress(BD_ADDR* Address);
 
 NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device);
 
-NTSTATUS DsBth_Ds3Init(PDEVICE_CONTEXT Context);
+NTSTATUS DsBth_Ds3SixaxisInit(PDEVICE_CONTEXT Context);
 
 NTSTATUS DsUsb_Ds3RequestHostAddress(WDFDEVICE Device);

--- a/sys/Ds3.h
+++ b/sys/Ds3.h
@@ -33,6 +33,9 @@ extern const UCHAR G_Ds3BthHidOutputReport[];
 #define DS3_BTH_SET_SMALL_RUMBLE_STRENGTH(_buf_, _str_)  ((_buf_)[4] = (_str_) > 0 ? 0x01 : 0x00)
 #define DS3_BTH_SET_LARGE_RUMBLE_STRENGTH(_buf_, _str_)  ((_buf_)[6] = (_str_))
 
+#define DS3_USB_COMMON_ENABLE		0x42, 0x0C, 0x00, 0x00
+#define DS3_BTH_SIXAXIS_ENABLE		0x53, 0xF4, 0x42, 0x03, 0x00, 0x00
+
 
 VOID DS3_SET_LED_DURATION(
 	PDEVICE_CONTEXT Context,

--- a/sys/DsBth.Timers.c
+++ b/sys/DsBth.Timers.c
@@ -1,0 +1,131 @@
+﻿#include "Driver.h"
+#include "DsBth.Timers.tmh"
+
+//
+// Called once delayed after power-up
+// 
+_Use_decl_annotations_
+VOID
+DsBth_EvtStartupDelayTimerFunc(
+	WDFTIMER  Timer
+)
+{
+	NTSTATUS status;
+
+	FuncEntry(TRACE_DSBTH);
+
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(WdfTimerGetParentObject(Timer));
+
+	//
+	// We have not yet received an input report from the remote device
+	// 
+	if (pDevCtx->BatteryStatus == DsBatteryStatusNone)
+	{
+		DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_OFF);
+	}
+	else
+	{
+		switch (pDevCtx->BatteryStatus)
+		{
+		case DsBatteryStatusCharged:
+		case DsBatteryStatusFull:
+			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_4);
+			break;
+		case DsBatteryStatusHigh:
+			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_3);
+			break;
+		case DsBatteryStatusMedium:
+			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_2);
+			break;
+		case DsBatteryStatusLow:
+		case DsBatteryStatusDying:
+			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
+			DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
+			break;
+		default:
+			break;
+		}
+	}
+		
+	DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0xFE);
+	DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0xFE);
+	DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0x00);
+
+	if (!NT_SUCCESS(status = Ds_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverHighPriority)))
+	{
+		TraceError(
+			TRACE_DSBTH,
+			"Ds_SendOutputReport failed with status %!STATUS!",
+			status
+		);
+		EventWriteFailedWithNTStatus(__FUNCTION__, L"Ds_SendOutputReport", status);
+	}
+	
+	//
+	// Start consuming input packets
+	// 
+	if (!NT_SUCCESS(status = DMF_DefaultTarget_StreamStart(pDevCtx->Connection.Bth.HidInterrupt.InputStreamerModule)))
+	{
+		TraceError(
+			TRACE_DSBTH,
+			"DMF_DefaultTarget_StreamStart failed with status %!STATUS!",
+			status
+		);
+		EventWriteFailedWithNTStatus(__FUNCTION__, L"DMF_DefaultTarget_StreamStart", status);
+	}
+
+	//
+	// Send delayed initialization packets
+	// Required for compatibility with some SIXAXIS models
+	// 
+	WdfTimerStart(
+		pDevCtx->Connection.Bth.Timers.PostStartupTasks,
+		WDF_REL_TIMEOUT_IN_SEC(1)
+	);
+	
+	FuncExitNoReturn(TRACE_DSBTH);
+}
+
+//
+// Invoked after startup delay to apply workarounds
+// 
+_Use_decl_annotations_
+VOID
+DsBth_EvtPostStartupTimerFunc(
+	WDFTIMER  Timer
+)
+{
+	NTSTATUS status;
+
+	FuncEntry(TRACE_DSBTH);
+
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(WdfTimerGetParentObject(Timer));
+
+	//
+	// We have not yet received an input report from the remote device
+	// 
+	if (pDevCtx->BatteryStatus == DsBatteryStatusNone)
+	{
+		TraceWarning(
+			TRACE_DSBTH,
+			"Battery status still unknown, applying workarounds"
+		);
+
+		//
+		// Send magic packet, starts input report sending
+		// NOTE: this is only required on certain models like the OG SIXAXIS
+		// It must not be issued on e.g. the Defender BTH or it disconnects
+		// 
+		if (!NT_SUCCESS(status = DsBth_Ds3SixaxisInit(pDevCtx)))
+		{
+			TraceError(
+				TRACE_DSBTH,
+				"DsBth_Ds3Init failed with status %!STATUS!",
+				status
+			);
+			EventWriteFailedWithNTStatus(__FUNCTION__, L"DsBth_Ds3Init", status);
+		} 
+	}
+
+	FuncExitNoReturn(TRACE_DSBTH);
+}

--- a/sys/DsBth.Timers.c
+++ b/sys/DsBth.Timers.c
@@ -110,6 +110,7 @@ DsBth_EvtPostStartupTimerFunc(
 			TRACE_DSBTH,
 			"Battery status still unknown, applying workarounds"
 		);
+		EventWriteApplyingWirelessWorkarounds();
 
 		//
 		// Send magic packet, starts input report sending

--- a/sys/DsBth.c
+++ b/sys/DsBth.c
@@ -46,80 +46,6 @@ NTSTATUS DsBth_SendDisconnectRequest(PDEVICE_CONTEXT Context)
 }
 
 //
-// Called once 1 second after power-up
-// 
-_Use_decl_annotations_
-VOID
-DsBth_EvtControlWriteTimerFunc(
-	WDFTIMER  Timer
-)
-{
-	NTSTATUS status;
-	PDEVICE_CONTEXT pDevCtx;
-
-	FuncEntry(TRACE_DSBTH);
-
-	pDevCtx = DeviceGetContext(WdfTimerGetParentObject(Timer));
-	
-	if (pDevCtx->BatteryStatus == DsBatteryStatusNone)
-	{
-		DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_OFF);
-	}
-	else
-	{
-		switch (pDevCtx->BatteryStatus)
-		{
-		case DsBatteryStatusCharged:
-		case DsBatteryStatusFull:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_4);
-			break;
-		case DsBatteryStatusHigh:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_3);
-			break;
-		case DsBatteryStatusMedium:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_2);
-			break;
-		case DsBatteryStatusLow:
-		case DsBatteryStatusDying:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-			DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
-			break;
-		default:
-			break;
-		}
-	}
-		
-	DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0xFE);
-	DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0xFE);
-	DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0x00);
-
-	if (!NT_SUCCESS(status = Ds_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverHighPriority)))
-	{
-		TraceError(
-			TRACE_DSBTH,
-			"Ds_SendOutputReport failed with status %!STATUS!",
-			status
-		);
-		EventWriteFailedWithNTStatus(__FUNCTION__, L"Ds_SendOutputReport", status);
-	}
-	
-	//
-	// Start consuming input packets
-	// 
-	if (!NT_SUCCESS(status = DMF_DefaultTarget_StreamStart(pDevCtx->Connection.Bth.HidInterrupt.InputStreamerModule)))
-	{
-		TraceError(
-			TRACE_DSBTH,
-			"DMF_DefaultTarget_StreamStart failed with status %!STATUS!",
-			status
-		);
-		EventWriteFailedWithNTStatus(__FUNCTION__, L"DMF_DefaultTarget_StreamStart", status);
-	}
-	
-	FuncExitNoReturn(TRACE_DSBTH);
-}
-
-//
 // Invoked once the Bluetooth disconnect event got fired
 // 
 VOID CALLBACK
@@ -153,34 +79,16 @@ DsBth_DisconnectEventCallback(
 NTSTATUS DsBth_SelfManagedIoInit(WDFDEVICE Device)
 {
 	NTSTATUS status = STATUS_SUCCESS;
-	PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
 
 	FuncEntry(TRACE_DSBTH);
 	
 	//
-	// Send magic packet, starts input report sending
-	// 
-	if (!NT_SUCCESS(status = DsBth_Ds3Init(pDevCtx)))
-	{
-		TraceError(
-			TRACE_DSBTH,
-			"DsBth_Ds3Init failed with status %!STATUS!",
-			status
-		);
-		EventWriteFailedWithNTStatus(__FUNCTION__, L"DsBth_Ds3Init", status);
-	}
-	
-	//
-	// Send initial output report
-	// 
-	//status = Ds_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverHighPriority);
-
-	//
-	// Send preset output report (delayed)
+	// Send delayed initialization packets
 	// Required for compatibility with some SIXAXIS models
 	// 
 	WdfTimerStart(
-		pDevCtx->Connection.Bth.Timers.HidOutputReport,
+		pDevCtx->Connection.Bth.Timers.StartupDelay,
 		WDF_REL_TIMEOUT_IN_SEC(1)
 	);
 
@@ -196,7 +104,7 @@ NTSTATUS DsBth_SelfManagedIoSuspend(WDFDEVICE Device)
 
 	FuncEntry(TRACE_DSBTH);
 
-	WdfTimerStop(pDevCtx->Connection.Bth.Timers.HidOutputReport, FALSE);
+	WdfTimerStop(pDevCtx->Connection.Bth.Timers.StartupDelay, FALSE);
 
 	DMF_DefaultTarget_StreamStop(pDevCtx->Connection.Bth.HidInterrupt.InputStreamerModule);
 	DMF_DefaultTarget_StreamStop(pDevCtx->Connection.Bth.HidControl.OutputWriterModule);

--- a/sys/DsBth.h
+++ b/sys/DsBth.h
@@ -41,7 +41,8 @@ EVT_WDF_REQUEST_COMPLETION_ROUTINE DsBth_HidControlWriteRequestCompletionRoutine
 NTSTATUS DsBth_SendDisconnectRequest(PDEVICE_CONTEXT Context);
 
 EVT_WDF_TIMER DsBth_EvtControlReadTimerFunc;
-EVT_WDF_TIMER DsBth_EvtControlWriteTimerFunc;
+EVT_WDF_TIMER DsBth_EvtStartupDelayTimerFunc;
+EVT_WDF_TIMER DsBth_EvtPostStartupTimerFunc;
 
 VOID CALLBACK
 DsBth_DisconnectEventCallback(

--- a/sys/DsHidMini.man
+++ b/sys/DsHidMini.man
@@ -66,6 +66,7 @@
 					<event value="12" channel="SYSTEM" level="win:Informational" message="$(string.AlreadyPaired.EventMessage)" opcode="win:Info" symbol="AlreadyPaired" template="tid_device_address"/>
 					<event value="13" channel="SYSTEM" level="win:Informational" message="$(string.PairedSuccessfully.EventMessage)" opcode="win:Info" symbol="PairedSuccessfully" template="tid_device_address"/>
 					<event value="14" channel="SYSTEM" level="win:Informational" message="$(string.FFBNoFreeEffectBlockIndex.EventMessage)" opcode="win:Info" symbol="FFBNoFreeEffectBlockIndex" />
+					<event value="15" channel="SYSTEM" level="win:Informational" message="$(string.ApplyingWirelessWorkarounds.EventMessage)" opcode="win:Info" symbol="ApplyingWirelessWorkarounds" />
 				</events>
 			</provider>
 		</events>
@@ -87,6 +88,7 @@
 				<string id="AlreadyPaired.EventMessage" value="Device %1 already paired to this machine's host radio, skipping"/>
 				<string id="PairedSuccessfully.EventMessage" value="Device %1 paired successfully"/>
 				<string id="FFBNoFreeEffectBlockIndex.EventMessage" value="No free effect block index, can't create Force-Feedback Effect"/>
+				<string id="ApplyingWirelessWorkarounds.EventMessage" value="Battery status still unknown, applying workarounds"/>
 			</stringTable>
 		</resources>
 	</localization>

--- a/sys/Power.c
+++ b/sys/Power.c
@@ -13,13 +13,12 @@ DsHidMini_EvtWdfDeviceSelfManagedIoInit(
 )
 {
 	NTSTATUS status = STATUS_SUCCESS;
-	PDEVICE_CONTEXT pDevCtx;
 
 	PAGED_CODE();
 
 	FuncEntry(TRACE_POWER);
 
-	pDevCtx = DeviceGetContext(Device);
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
 
 	if (pDevCtx->ConnectionType == DsDeviceConnectionTypeBth)
 	{
@@ -41,7 +40,7 @@ DsHidMini_EvtWdfDeviceSelfManagedIoSuspend(
 )
 {
 	NTSTATUS status = STATUS_SUCCESS;
-	PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
 
 	FuncEntry(TRACE_POWER);
 
@@ -67,14 +66,13 @@ DsHidMini_EvtDevicePrepareHardware(
 )
 {
 	NTSTATUS status = STATUS_SUCCESS;
-	PDEVICE_CONTEXT pDevCtx;
-		
+
 	UNREFERENCED_PARAMETER(ResourcesRaw);
 	UNREFERENCED_PARAMETER(ResourcesTranslated);
 
 	FuncEntry(TRACE_POWER);
 
-	pDevCtx = DeviceGetContext(Device);
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
 
 	//
 	// Initialize USB
@@ -102,10 +100,9 @@ NTSTATUS DsHidMini_EvtDeviceD0Entry(
 	_In_ WDF_POWER_DEVICE_STATE PreviousState
 )
 {
-	PDEVICE_CONTEXT pDevCtx;
 	NTSTATUS status = STATUS_SUCCESS;
 
-	pDevCtx = DeviceGetContext(Device);
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
 
 	FuncEntry(TRACE_POWER);
 
@@ -138,13 +135,12 @@ NTSTATUS DsHidMini_EvtDeviceD0Exit(
 )
 {
 	NTSTATUS status = STATUS_SUCCESS;
-	PDEVICE_CONTEXT pDevCtx;
 
 	UNREFERENCED_PARAMETER(TargetState);
 
 	FuncEntry(TRACE_POWER);
 
-	pDevCtx = DeviceGetContext(Device);
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
 
 	//
 	// Stop processing received output report packets

--- a/sys/dshidmini.vcxproj
+++ b/sys/dshidmini.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="Driver.c" />
     <ClCompile Include="Ds3.c" />
     <ClCompile Include="DsBth.c" />
+    <ClCompile Include="DsBth.Timers.c" />
     <ClCompile Include="DsHid.c" />
     <ClCompile Include="DsHidMiniDrv.c" />
     <ClCompile Include="DsUsb.c" />

--- a/sys/dshidmini.vcxproj.filters
+++ b/sys/dshidmini.vcxproj.filters
@@ -206,6 +206,9 @@
     <ClCompile Include="Configuration.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DsBth.Timers.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="dshidmini.rc">


### PR DESCRIPTION
These changes fix compatibility with certain aftermarket models like the Retro Fighters Defender BT Edition that would otherwise drop connection if the SIXAXIS "magic packet" feature report is sent to them.

The way this is achieved is by first setting up the HID Interrupt IN reader, send an initial output report over HID Control, then way a second, check if at least one input report made it in by checking the battery state and if not, send the SET_REPORT, otherwise omit it.

This is not enough to make all devices in my new stash stay connected but it sure is a big step in the right direction 😁 