### PR TITLE
ControlApp:  Leave LED settings unlocked in SXS mode

### DIFF
--- a/ControlApp/ViewModels/UserControls/DeviceSettingsEditorViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceSettingsEditorViewModel.cs
@@ -54,11 +54,9 @@ namespace Nefarius.DsHidMini.ControlApp.ViewModels.UserControls
 
             if (HidModeVM.Context == SettingsContext.SXS)
             {
-                //SticksSettingsVM.IsGroupLocked = HidModeVM.PreventRemappingConflictsInSXSMode;
-                // Currently, OutReps being sent in SXS modes are passed-thru directly to the controller so
-                // Leds and rumble manipulations aren't applied
+                // Rumble related settings currently don't matter in SXS mode
+                // rumble instructions are directly passthru to the controller
                 GeneralRumbleSettingsVM.IsGroupLocked = true;
-                LedsSettingsVM.IsGroupLocked = true;
                 LeftMotorRescaleSettingsVM.IsGroupLocked = true;
                 AltRumbleSettingsVM.IsGroupLocked = true;
             }


### PR DESCRIPTION
Previously I thought DsHidMini didn't touch the output reports being repassed to the controller when in SXS mode, but it actually process the current LED effects depending on the settings