### PR TITLE
Wpfui numberbox workaround

### DIFF
--- a/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
+++ b/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
@@ -81,7 +81,7 @@
                     ClearButtonEnabled="False"
                     Maximum="5"
                     Minimum="{Binding MinHoldTime}"
-                    Value="{Binding HoldTime}" />
+                    Value="{Binding HoldTime, UpdateSourceTrigger=PropertyChanged}" />
             </DockPanel>
         </DataTemplate>
         <Style x:Key="SetGroupItem" TargetType="ContentControl">
@@ -402,7 +402,7 @@
                         ClipToBounds="True"
                         Maximum="142"
                         Minimum="0"
-                        Value="{Binding LeftStickDeadZone}" />
+                        Value="{Binding LeftStickDeadZone, UpdateSourceTrigger=PropertyChanged}" />
                     <ui:NumberBox
                         Grid.Row="1"
                         Grid.Column="2"
@@ -410,7 +410,7 @@
                         ClipToBounds="True"
                         Maximum="142"
                         Minimum="0"
-                        Value="{Binding RightStickDeadZone}" />
+                        Value="{Binding RightStickDeadZone, UpdateSourceTrigger=PropertyChanged}" />
                     <!--  Row 2: Invert X  -->
                     <Label
                         Grid.Row="2"

--- a/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
+++ b/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
@@ -81,7 +81,6 @@
                     ClearButtonEnabled="False"
                     Maximum="5"
                     Minimum="{Binding MinHoldTime}"
-                    Text="{Binding HoldTime}"
                     Value="{Binding HoldTime}" />
             </DockPanel>
         </DataTemplate>


### PR DESCRIPTION
Related to https://github.com/lepoco/wpfui/issues/945

NumberBox requires losing focus twice to properly update the associated property when the value is changed by typing it instead of using the Up/Down buttons.

A workaround was applied until the issue is not properly fixed. It requires changing the `UpdateSourceTrigger` to `PropertyChanged` of the Value atribute binding