### PR TITLE
Implement XInput user index resolution in device view

### DIFF
--- a/ControlApp/Models/DshmDevMan.cs
+++ b/ControlApp/Models/DshmDevMan.cs
@@ -1,4 +1,5 @@
-﻿using Nefarius.DsHidMini.IPC.Models.Drivers;
+﻿using Nefarius.DsHidMini.ControlApp.Models.Util;
+using Nefarius.DsHidMini.IPC.Models.Drivers;
 using Nefarius.Utilities.Bluetooth;
 using Nefarius.Utilities.DeviceManagement.Extensions;
 using Nefarius.Utilities.DeviceManagement.PnP;
@@ -45,6 +46,7 @@ public class DshmDevMan
 
     private void UpdateConnectedDshmDevicesList()
     {
+        XInputSlotResolver.InvalidateResolutionCache();
         Log.Logger.Debug("Rebuilding list of connected DsHidMini devices");
         Devices.Clear();
         int instance = 0;

--- a/ControlApp/Models/Util/SetupApiWrapper.cs
+++ b/ControlApp/Models/Util/SetupApiWrapper.cs
@@ -482,6 +482,28 @@ internal static class SetupApiWrapper
         CM_SETUP_DEVINST_FLAGS ulFlags
     );
 
+    /// <summary>
+    ///     Present devices only (same as default 0).
+    /// </summary>
+    internal const uint CM_GET_DEVICE_INTERFACE_LIST_PRESENT = 0;
+
+    [DllImport("Cfgmgr32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    internal static extern ConfigManagerResult CM_Get_Device_Interface_List_SizeW(
+        ref uint pulLen,
+        ref Guid interfaceClassGuid,
+        [MarshalAs(UnmanagedType.LPWStr)] string? pEnumerator,
+        uint ulFlags
+    );
+
+    [DllImport("Cfgmgr32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    internal static extern ConfigManagerResult CM_Get_Device_Interface_ListW(
+        ref Guid interfaceClassGuid,
+        [MarshalAs(UnmanagedType.LPWStr)] string? pEnumerator,
+        IntPtr buffer,
+        uint bufferLen,
+        uint ulFlags
+    );
+
     #endregion
 
     #region Newdev

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -1,13 +1,13 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
-
-using Nefarius.Utilities.DeviceManagement.PnP;
 
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Storage.FileSystem;
 
 using Microsoft.Win32.SafeHandles;
+
+using Nefarius.Utilities.DeviceManagement.PnP;
 
 namespace Nefarius.DsHidMini.ControlApp.Models.Util;
 
@@ -19,6 +19,14 @@ namespace Nefarius.DsHidMini.ControlApp.Models.Util;
 internal static class XInputSlotResolver
 {
     private const byte InvalidXInputUserId = 0xFF;
+
+    /// <summary>
+    ///     Win32 IOCTL to read Xbox 360 controller LED / ring-of-light state (<c>IOCTL_XUSB_GET_LED_STATE</c>).
+    /// </summary>
+    // Same IOCTL (0x8000E008) as XInputBridge GlobalState::SymlinkToUserIndex.
+    private const uint IoctlXusbGetLedState = 0x8000E008;
+
+    private static readonly ConcurrentDictionary<Guid, byte> ResolutionCacheByBaseContainer = new();
 
     /// <summary>
     ///     XUSB device interface class GUID (see XInputBridge/Macros.h).
@@ -37,8 +45,6 @@ internal static class XInputSlotResolver
     /// </summary>
     private static readonly SetupApiWrapper.DevPropKey DevpKeyDeviceBaseContainerId = new(
         0x80497100, 0x8c73, 0x48ea, 0x87, 0x08, 0x33, 0xa1, 0x6b, 0x18, 0x77, 0xfa, 2);
-
-    private const uint IoctlXusbGetLedState = 0x8000E008;
 
     /// <summary>
     ///     Mirrors XINPUT_LED_TO_PORT_MAP in XInputBridge/GlobalState.cpp.
@@ -65,6 +71,14 @@ internal static class XInputSlotResolver
     ];
 
     /// <summary>
+    ///     Clears cached XInput user-index lookups when device topology may have changed.
+    /// </summary>
+    public static void InvalidateResolutionCache()
+    {
+        ResolutionCacheByBaseContainer.Clear();
+    }
+
+    /// <summary>
     ///     Returns the XInput user index (0-3) for this DsHidMini device, or false if it cannot be determined.
     ///     Call only when the device is in XInput HID mode.
     /// </summary>
@@ -74,6 +88,17 @@ internal static class XInputSlotResolver
         if (!TryGetBaseContainerId(dshmDevice.InstanceId, out Guid dshmContainer))
         {
             return false;
+        }
+
+        if (ResolutionCacheByBaseContainer.TryGetValue(dshmContainer, out byte cached))
+        {
+            if (cached == InvalidXInputUserId)
+            {
+                return false;
+            }
+
+            userIndex = cached;
+            return true;
         }
 
         foreach (string xusbPath in EnumeratePresentXusbDeviceInterfacePaths())
@@ -91,13 +116,19 @@ internal static class XInputSlotResolver
             if (TrySymlinkToUserIndex(xusbPath, out byte idx) && idx != InvalidXInputUserId)
             {
                 userIndex = idx;
+                ResolutionCacheByBaseContainer[dshmContainer] = idx;
                 return true;
             }
         }
 
+        ResolutionCacheByBaseContainer[dshmContainer] = InvalidXInputUserId;
         return false;
     }
 
+    /// <summary>
+    ///     Yields symbolic link paths for all present device interfaces of class <see cref="XusbInterfaceClassGuid" />.
+    /// </summary>
+    /// <returns>Device interface paths (e.g. for use with <see cref="TrySymlinkToUserIndex" />).</returns>
     private static IEnumerable<string> EnumeratePresentXusbDeviceInterfacePaths()
     {
         uint lenChars = 0;
@@ -114,7 +145,14 @@ internal static class XInputSlotResolver
             yield break;
         }
 
-        IntPtr buffer = Marshal.AllocHGlobal((int)(lenChars * 2));
+        long byteCountLong = (long)lenChars * sizeof(char);
+        if (byteCountLong > int.MaxValue)
+        {
+            yield break;
+        }
+
+        int byteCount = (int)byteCountLong;
+        IntPtr buffer = Marshal.AllocHGlobal(byteCount);
         try
         {
             r = SetupApiWrapper.CM_Get_Device_Interface_ListW(
@@ -130,8 +168,7 @@ internal static class XInputSlotResolver
                 yield break;
             }
 
-            int byteLen = (int)(lenChars * 2);
-            foreach (string path in ParseDoubleNullTerminatedUnicode(buffer, byteLen))
+            foreach (string path in ParseDoubleNullTerminatedUnicode(buffer, byteCount))
             {
                 if (!string.IsNullOrEmpty(path))
                 {
@@ -145,6 +182,12 @@ internal static class XInputSlotResolver
         }
     }
 
+    /// <summary>
+    ///     Parses a CONFIGMG multi-string buffer (double-null-terminated UTF-16) into individual strings.
+    /// </summary>
+    /// <param name="buffer">Pointer to the buffer returned by <c>CM_Get_Device_Interface_ListW</c>.</param>
+    /// <param name="byteLength">Size of the buffer in bytes.</param>
+    /// <returns>Each non-empty string segment in order until a zero-length segment ends the list.</returns>
     private static IEnumerable<string> ParseDoubleNullTerminatedUnicode(IntPtr buffer, int byteLength)
     {
         int offset = 0;
@@ -157,7 +200,7 @@ internal static class XInputSlotResolver
             }
 
             yield return s;
-            offset += 2 * (s.Length + 1);
+            offset += sizeof(char) * (s.Length + 1);
         }
     }
 
@@ -270,14 +313,13 @@ internal static class XInputSlotResolver
     private static unsafe bool TrySymlinkToUserIndex(string symlink, out byte userIndex)
     {
         userIndex = InvalidXInputUserId;
-        using SafeFileHandle? handle = PInvoke.CreateFile(
+        using SafeFileHandle handle = PInvoke.CreateFile(
             symlink,
             (uint)(FILE_ACCESS_RIGHTS.FILE_GENERIC_READ | FILE_ACCESS_RIGHTS.FILE_GENERIC_WRITE),
             FILE_SHARE_MODE.FILE_SHARE_READ | FILE_SHARE_MODE.FILE_SHARE_WRITE,
             null,
             FILE_CREATION_DISPOSITION.OPEN_EXISTING,
-            FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_NORMAL,
-            null
+            FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_NORMAL
         );
 
         if (handle.IsInvalid)

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -37,6 +37,11 @@ internal static class XInputSlotResolver
     private static readonly ConcurrentDictionary<Guid, DateTime> NegativeResolutionExpiryByBaseContainer = new();
 
     /// <summary>
+    ///     Cache-generation token incremented when caches are invalidated to prevent stale writes after a clear.
+    /// </summary>
+    private static long _cacheGeneration;
+
+    /// <summary>
     ///     XUSB device interface class GUID (see XInputBridge/Macros.h).
     /// </summary>
     private static readonly Guid XusbInterfaceClassGuid =
@@ -74,6 +79,7 @@ internal static class XInputSlotResolver
     /// </summary>
     public static void InvalidateResolutionCache()
     {
+        Interlocked.Increment(ref _cacheGeneration);
         ResolutionCacheByBaseContainer.Clear();
         NegativeResolutionExpiryByBaseContainer.Clear();
     }
@@ -102,6 +108,9 @@ internal static class XInputSlotResolver
             return false;
         }
 
+        // Capture generation before resolving to prevent stale writes after InvalidateResolutionCache
+        long generationSnapshot = Interlocked.Read(ref _cacheGeneration);
+
         foreach (string xusbPath in EnumeratePresentXusbDeviceInterfacePaths())
         {
             if (!TryGetDeviceInstanceIdFromInterfacePath(xusbPath, out string? xusbInstanceId))
@@ -117,13 +126,21 @@ internal static class XInputSlotResolver
             if (TrySymlinkToUserIndex(xusbPath, out byte idx) && idx != InvalidXInputUserId)
             {
                 userIndex = idx;
-                NegativeResolutionExpiryByBaseContainer.TryRemove(dshmContainer, out _);
-                ResolutionCacheByBaseContainer[dshmContainer] = idx;
+                // Only write to cache if generation hasn't changed (no InvalidateResolutionCache since we started)
+                if (Interlocked.Read(ref _cacheGeneration) == generationSnapshot)
+                {
+                    NegativeResolutionExpiryByBaseContainer.TryRemove(dshmContainer, out _);
+                    ResolutionCacheByBaseContainer[dshmContainer] = idx;
+                }
                 return true;
             }
         }
 
-        NegativeResolutionExpiryByBaseContainer[dshmContainer] = DateTime.UtcNow.Add(NegativeResolutionCacheTtl);
+        // Only write negative cache if generation hasn't changed
+        if (Interlocked.Read(ref _cacheGeneration) == generationSnapshot)
+        {
+            NegativeResolutionExpiryByBaseContainer[dshmContainer] = DateTime.UtcNow.Add(NegativeResolutionCacheTtl);
+        }
         return false;
     }
 

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -42,17 +42,8 @@ internal static class XInputSlotResolver
     private static readonly Guid XusbInterfaceClassGuid =
         Guid.Parse("{EC87F1E3-C13B-4100-B5F7-8B84D54260CB}");
 
-    /// <summary>
-    ///     DEVPKEY_Device_InstanceId - used with CM_Get_Device_Interface_Property.
-    /// </summary>
-    private static readonly SetupApiWrapper.DevPropKey DevpKeyDeviceInstanceId = new(
-        0x78c34fc8, 0x104a, 0x4aca, 0x9e, 0xa4, 0x52, 0x4d, 0x52, 0x94, 0x39, 0x5d, 256);
-
-    /// <summary>
-    ///     DEVPKEY_Device_BaseContainerId - used with CM_Get_DevNode_Property.
-    /// </summary>
-    private static readonly SetupApiWrapper.DevPropKey DevpKeyDeviceBaseContainerId = new(
-        0x80497100, 0x8c73, 0x48ea, 0x87, 0x08, 0x33, 0xa1, 0x6b, 0x18, 0x77, 0xfa, 2);
+    private static SetupApiWrapper.DevPropKey ToDevPropKey(DevicePropertyKey key) =>
+        new(key.CategoryGuid, key.PropertyIdentifier);
 
     /// <summary>
     ///     Mirrors XINPUT_LED_TO_PORT_MAP in XInputBridge/GlobalState.cpp.
@@ -219,7 +210,7 @@ internal static class XInputSlotResolver
         [NotNullWhen(true)] out string? instanceId)
     {
         instanceId = null;
-        SetupApiWrapper.DevPropKey key = DevpKeyDeviceInstanceId;
+        SetupApiWrapper.DevPropKey key = ToDevPropKey(DevicePropertyKey.Device_InstanceId);
         uint bufferSize = 0;
         SetupApiWrapper.ConfigManagerResult r = SetupApiWrapper.CM_Get_Device_Interface_Property(
             deviceInterfacePath,
@@ -274,7 +265,7 @@ internal static class XInputSlotResolver
             return false;
         }
 
-        SetupApiWrapper.DevPropKey key = DevpKeyDeviceBaseContainerId;
+        SetupApiWrapper.DevPropKey key = ToDevPropKey(DevicePropertyKey.Device_BaseContainerId);
         uint size = 0;
         SetupApiWrapper.ConfigManagerResult r = SetupApiWrapper.CM_Get_DevNode_Property(
             devInst,

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -21,12 +21,20 @@ internal static class XInputSlotResolver
     private const byte InvalidXInputUserId = 0xFF;
 
     /// <summary>
+    ///     Short-lived negative cache to avoid hammering PnP/XUSB on repeated misses without permanently
+    ///     blocking resolution after transient enumeration or IOCTL races.
+    /// </summary>
+    private static readonly TimeSpan NegativeResolutionCacheTtl = TimeSpan.FromSeconds(3);
+
+    /// <summary>
     ///     Win32 IOCTL to read Xbox 360 controller LED / ring-of-light state (<c>IOCTL_XUSB_GET_LED_STATE</c>).
     /// </summary>
     // Same IOCTL (0x8000E008) as XInputBridge GlobalState::SymlinkToUserIndex.
     private const uint IoctlXusbGetLedState = 0x8000E008;
 
     private static readonly ConcurrentDictionary<Guid, byte> ResolutionCacheByBaseContainer = new();
+
+    private static readonly ConcurrentDictionary<Guid, DateTime> NegativeResolutionExpiryByBaseContainer = new();
 
     /// <summary>
     ///     XUSB device interface class GUID (see XInputBridge/Macros.h).
@@ -76,6 +84,7 @@ internal static class XInputSlotResolver
     public static void InvalidateResolutionCache()
     {
         ResolutionCacheByBaseContainer.Clear();
+        NegativeResolutionExpiryByBaseContainer.Clear();
     }
 
     /// <summary>
@@ -90,13 +99,14 @@ internal static class XInputSlotResolver
             return false;
         }
 
+        if (NegativeResolutionExpiryByBaseContainer.TryGetValue(dshmContainer, out DateTime negUntil)
+            && DateTime.UtcNow < negUntil)
+        {
+            return false;
+        }
+
         if (ResolutionCacheByBaseContainer.TryGetValue(dshmContainer, out byte cached))
         {
-            if (cached == InvalidXInputUserId)
-            {
-                return false;
-            }
-
             userIndex = cached;
             return true;
         }
@@ -116,12 +126,13 @@ internal static class XInputSlotResolver
             if (TrySymlinkToUserIndex(xusbPath, out byte idx) && idx != InvalidXInputUserId)
             {
                 userIndex = idx;
+                NegativeResolutionExpiryByBaseContainer.TryRemove(dshmContainer, out _);
                 ResolutionCacheByBaseContainer[dshmContainer] = idx;
                 return true;
             }
         }
 
-        ResolutionCacheByBaseContainer[dshmContainer] = InvalidXInputUserId;
+        NegativeResolutionExpiryByBaseContainer[dshmContainer] = DateTime.UtcNow.Add(NegativeResolutionCacheTtl);
         return false;
     }
 

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -1,0 +1,328 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+using Nefarius.Utilities.DeviceManagement.PnP;
+
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Storage.FileSystem;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Nefarius.DsHidMini.ControlApp.Models.Util;
+
+/// <summary>
+///     Resolves the Windows XInput user index (0-3) for a DsHidMini device in XInput HID mode by matching the
+///     controller's XUSB interface (via PnP base container ID) and issuing the same LED IOCTL as XInputBridge
+///     GlobalState::SymlinkToUserIndex.
+/// </summary>
+internal static class XInputSlotResolver
+{
+    private const byte InvalidXInputUserId = 0xFF;
+
+    /// <summary>
+    ///     XUSB device interface class GUID (see XInputBridge/Macros.h).
+    /// </summary>
+    private static readonly Guid XusbInterfaceClassGuid =
+        Guid.Parse("{EC87F1E3-C13B-4100-B5F7-8B84D54260CB}");
+
+    /// <summary>
+    ///     DEVPKEY_Device_InstanceId - used with CM_Get_Device_Interface_Property.
+    /// </summary>
+    private static readonly SetupApiWrapper.DevPropKey DevpKeyDeviceInstanceId = new(
+        0x78c34fc8, 0x104a, 0x4aca, 0x9e, 0xa4, 0x52, 0x4d, 0x52, 0x94, 0x39, 0x5d, 256);
+
+    /// <summary>
+    ///     DEVPKEY_Device_BaseContainerId - used with CM_Get_DevNode_Property.
+    /// </summary>
+    private static readonly SetupApiWrapper.DevPropKey DevpKeyDeviceBaseContainerId = new(
+        0x80497100, 0x8c73, 0x48ea, 0x87, 0x08, 0x33, 0xa1, 0x6b, 0x18, 0x77, 0xfa, 2);
+
+    private const uint IoctlXusbGetLedState = 0x8000E008;
+
+    /// <summary>
+    ///     Mirrors XINPUT_LED_TO_PORT_MAP in XInputBridge/GlobalState.cpp.
+    /// </summary>
+    private static readonly byte[] XinputLedToPortMap =
+    [
+        InvalidXInputUserId,
+        InvalidXInputUserId,
+        0,
+        1,
+        2,
+        3,
+        0,
+        1,
+        2,
+        3,
+        InvalidXInputUserId,
+        InvalidXInputUserId,
+        InvalidXInputUserId,
+        InvalidXInputUserId,
+        InvalidXInputUserId,
+        InvalidXInputUserId,
+        InvalidXInputUserId
+    ];
+
+    /// <summary>
+    ///     Returns the XInput user index (0-3) for this DsHidMini device, or false if it cannot be determined.
+    ///     Call only when the device is in XInput HID mode.
+    /// </summary>
+    internal static bool TryGetXInputUserIndex(PnPDevice dshmDevice, out byte userIndex)
+    {
+        userIndex = InvalidXInputUserId;
+        if (!TryGetBaseContainerId(dshmDevice.InstanceId, out Guid dshmContainer))
+        {
+            return false;
+        }
+
+        foreach (string xusbPath in EnumeratePresentXusbDeviceInterfacePaths())
+        {
+            if (!TryGetDeviceInstanceIdFromInterfacePath(xusbPath, out string? xusbInstanceId))
+            {
+                continue;
+            }
+
+            if (!TryGetBaseContainerId(xusbInstanceId, out Guid xusbContainer) || xusbContainer != dshmContainer)
+            {
+                continue;
+            }
+
+            if (TrySymlinkToUserIndex(xusbPath, out byte idx) && idx != InvalidXInputUserId)
+            {
+                userIndex = idx;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> EnumeratePresentXusbDeviceInterfacePaths()
+    {
+        uint lenChars = 0;
+        Guid g = XusbInterfaceClassGuid;
+        SetupApiWrapper.ConfigManagerResult r = SetupApiWrapper.CM_Get_Device_Interface_List_SizeW(
+            ref lenChars,
+            ref g,
+            null,
+            SetupApiWrapper.CM_GET_DEVICE_INTERFACE_LIST_PRESENT
+        );
+
+        if (r != SetupApiWrapper.ConfigManagerResult.Success || lenChars <= 1)
+        {
+            yield break;
+        }
+
+        IntPtr buffer = Marshal.AllocHGlobal((int)(lenChars * 2));
+        try
+        {
+            r = SetupApiWrapper.CM_Get_Device_Interface_ListW(
+                ref g,
+                null,
+                buffer,
+                lenChars,
+                SetupApiWrapper.CM_GET_DEVICE_INTERFACE_LIST_PRESENT
+            );
+
+            if (r != SetupApiWrapper.ConfigManagerResult.Success)
+            {
+                yield break;
+            }
+
+            int byteLen = (int)(lenChars * 2);
+            foreach (string path in ParseDoubleNullTerminatedUnicode(buffer, byteLen))
+            {
+                if (!string.IsNullOrEmpty(path))
+                {
+                    yield return path;
+                }
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static IEnumerable<string> ParseDoubleNullTerminatedUnicode(IntPtr buffer, int byteLength)
+    {
+        int offset = 0;
+        while (offset < byteLength)
+        {
+            string? s = Marshal.PtrToStringUni(IntPtr.Add(buffer, offset));
+            if (string.IsNullOrEmpty(s))
+            {
+                yield break;
+            }
+
+            yield return s;
+            offset += 2 * (s.Length + 1);
+        }
+    }
+
+    private static bool TryGetDeviceInstanceIdFromInterfacePath(string deviceInterfacePath,
+        [NotNullWhen(true)] out string? instanceId)
+    {
+        instanceId = null;
+        SetupApiWrapper.DevPropKey key = DevpKeyDeviceInstanceId;
+        uint bufferSize = 0;
+        SetupApiWrapper.ConfigManagerResult r = SetupApiWrapper.CM_Get_Device_Interface_Property(
+            deviceInterfacePath,
+            ref key,
+            out SetupApiWrapper.DevPropType _,
+            IntPtr.Zero,
+            ref bufferSize,
+            0
+        );
+
+        if (r != SetupApiWrapper.ConfigManagerResult.BufferSmall)
+        {
+            return false;
+        }
+
+        IntPtr buf = Marshal.AllocHGlobal((int)bufferSize);
+        try
+        {
+            r = SetupApiWrapper.CM_Get_Device_Interface_Property(
+                deviceInterfacePath,
+                ref key,
+                out _,
+                buf,
+                ref bufferSize,
+                0
+            );
+
+            if (r != SetupApiWrapper.ConfigManagerResult.Success)
+            {
+                return false;
+            }
+
+            instanceId = Marshal.PtrToStringUni(buf);
+            return !string.IsNullOrEmpty(instanceId);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buf);
+        }
+    }
+
+    private static bool TryGetBaseContainerId(string deviceInstanceId, out Guid containerId)
+    {
+        containerId = default;
+        uint devInst = 0;
+        if (SetupApiWrapper.CM_Locate_DevNode(
+                ref devInst,
+                deviceInstanceId,
+                SetupApiWrapper.CM_LOCATE_DEVNODE_FLAG.CM_LOCATE_DEVNODE_NORMAL
+            ) != SetupApiWrapper.ConfigManagerResult.Success)
+        {
+            return false;
+        }
+
+        SetupApiWrapper.DevPropKey key = DevpKeyDeviceBaseContainerId;
+        uint size = 0;
+        SetupApiWrapper.ConfigManagerResult r = SetupApiWrapper.CM_Get_DevNode_Property(
+            devInst,
+            ref key,
+            out SetupApiWrapper.DevPropType propType,
+            IntPtr.Zero,
+            ref size,
+            0
+        );
+
+        if (r != SetupApiWrapper.ConfigManagerResult.BufferSmall)
+        {
+            return false;
+        }
+
+        IntPtr buffer = Marshal.AllocHGlobal((int)size);
+        try
+        {
+            r = SetupApiWrapper.CM_Get_DevNode_Property(
+                devInst,
+                ref key,
+                out propType,
+                buffer,
+                ref size,
+                0
+            );
+
+            if (r != SetupApiWrapper.ConfigManagerResult.Success || propType != SetupApiWrapper.DevPropType.Guid)
+            {
+                return false;
+            }
+
+            byte[] guidBytes = new byte[16];
+            Marshal.Copy(buffer, guidBytes, 0, 16);
+            containerId = new Guid(guidBytes);
+            return true;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    /// <summary>
+    ///     Port of GlobalState::SymlinkToUserIndex.
+    /// </summary>
+    private static unsafe bool TrySymlinkToUserIndex(string symlink, out byte userIndex)
+    {
+        userIndex = InvalidXInputUserId;
+        using SafeFileHandle? handle = PInvoke.CreateFile(
+            symlink,
+            (uint)(FILE_ACCESS_RIGHTS.FILE_GENERIC_READ | FILE_ACCESS_RIGHTS.FILE_GENERIC_WRITE),
+            FILE_SHARE_MODE.FILE_SHARE_READ | FILE_SHARE_MODE.FILE_SHARE_WRITE,
+            null,
+            FILE_CREATION_DISPOSITION.OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_NORMAL,
+            null
+        );
+
+        if (handle.IsInvalid)
+        {
+            return false;
+        }
+
+        byte[] gamepadStateRequest0101 = { 0x01, 0x01, 0x00 };
+        byte[] ledStateData = new byte[3];
+
+        BOOL ok;
+        fixed (byte* inPtr = gamepadStateRequest0101)
+        fixed (byte* outPtr = ledStateData)
+        {
+            Span<byte> inSpan = new(inPtr, 3);
+            Span<byte> outSpan = new(outPtr, 3);
+            ok = PInvoke.DeviceIoControl(
+                handle,
+                IoctlXusbGetLedState,
+                inSpan,
+                outSpan,
+                out _,
+                null
+            );
+        }
+
+        if (!ok)
+        {
+            return false;
+        }
+
+        byte ledState = ledStateData[2];
+        byte[] map = XinputLedToPortMap;
+        if (ledState >= map.Length)
+        {
+            return false;
+        }
+
+        byte mapped = map[ledState];
+        if (mapped == InvalidXInputUserId)
+        {
+            return false;
+        }
+
+        userIndex = mapped;
+        return true;
+    }
+}

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -90,16 +90,16 @@ internal static class XInputSlotResolver
             return false;
         }
 
-        if (NegativeResolutionExpiryByBaseContainer.TryGetValue(dshmContainer, out DateTime negUntil)
-            && DateTime.UtcNow < negUntil)
-        {
-            return false;
-        }
-
         if (ResolutionCacheByBaseContainer.TryGetValue(dshmContainer, out byte cached))
         {
             userIndex = cached;
             return true;
+        }
+
+        if (NegativeResolutionExpiryByBaseContainer.TryGetValue(dshmContainer, out DateTime negUntil)
+            && DateTime.UtcNow < negUntil)
+        {
+            return false;
         }
 
         foreach (string xusbPath in EnumeratePresentXusbDeviceInterfacePaths())

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 
 using Nefarius.DsHidMini.ControlApp.Models;
+using Nefarius.DsHidMini.ControlApp.Models.Util;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Models.Util.Web;
 using Nefarius.DsHidMini.ControlApp.Services;
@@ -94,6 +95,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
 
     private void OnDshmConfigUpdated(object? obj, EventArgs? eventArgs)
     {
+        XInputSlotResolver.InvalidateResolutionCache();
         ReconnectDevicesWithMismatchedHidMode();
     }
 

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;
+using System.Windows;
 
 using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
@@ -458,10 +459,10 @@ public partial class DeviceViewModel : ObservableObject
         AdjustSettingsTabState();
         OnPropertyChanged(nameof(DeviceSettingsStatus));
         OnPropertyChanged(nameof(IsHidModeMismatched));
-        RefreshXInputSlotLabel();
+        await RefreshXInputSlotLabelAsync();
     }
 
-    private void RefreshXInputSlotLabel()
+    private async Task RefreshXInputSlotLabelAsync()
     {
         OnPropertyChanged(nameof(IsXInputHidMode));
         if (HidEmulationMode != SettingsContext.XInput)
@@ -471,16 +472,39 @@ public partial class DeviceViewModel : ObservableObject
             return;
         }
 
-        if (XInputSlotResolver.TryGetXInputUserIndex(Device, out byte userIndex))
+        PnPDevice device = Device;
+        (bool ok, byte userIndex) = await Task.Run(() =>
         {
-            XInputSlotDetail = $"Player {userIndex + 1}";
-            XInputSlotBanner = $"XInput: Player {userIndex + 1}";
-        }
-        else
+            bool success = XInputSlotResolver.TryGetXInputUserIndex(device, out byte idx);
+            return (success, idx);
+        });
+
+        await Application.Current.Dispatcher.InvokeAsync(() =>
         {
-            XInputSlotDetail = "Unavailable";
-            XInputSlotBanner = "XInput: Unavailable";
-        }
+            if (device.InstanceId != Device.InstanceId)
+            {
+                return;
+            }
+
+            if (HidEmulationMode != SettingsContext.XInput)
+            {
+                XInputSlotBanner = null;
+                XInputSlotDetail = null;
+                return;
+            }
+
+            OnPropertyChanged(nameof(IsXInputHidMode));
+            if (ok)
+            {
+                XInputSlotDetail = $"Player {userIndex + 1}";
+                XInputSlotBanner = $"XInput: Player {userIndex + 1}";
+            }
+            else
+            {
+                XInputSlotDetail = "Unavailable";
+                XInputSlotBanner = "XInput: Unavailable";
+            }
+        });
     }
 
     [RelayCommand]

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -5,6 +5,7 @@ using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.Enums;
+using Nefarius.DsHidMini.ControlApp.Models.Util;
 using Nefarius.DsHidMini.ControlApp.Models.Util.Web;
 using Nefarius.DsHidMini.ControlApp.Services;
 using Nefarius.DsHidMini.IPC.Models.Drivers;
@@ -128,6 +129,23 @@ public partial class DeviceViewModel : ObservableObject
         DshmDriverTranslationUtils.HidDeviceMode[Device.GetProperty<byte>(DsHidMiniDriver.HidDeviceModeProperty)];
 
     public HidModeShort HidModeShort => (HidModeShort)HidEmulationMode;
+
+    /// <summary>
+    ///     True when the driver reports active HID mode XInput (0x05). Used to show XInput player slot only in that mode.
+    /// </summary>
+    public bool IsXInputHidMode => HidEmulationMode == SettingsContext.XInput;
+
+    /// <summary>
+    ///     Full line for the device list (e.g. "XInput: Player 1") when <see cref="IsXInputHidMode" />; otherwise null.
+    /// </summary>
+    [ObservableProperty]
+    private string? _xInputSlotBanner;
+
+    /// <summary>
+    ///     Short value for the Info tab (e.g. "Player 1" or "Unavailable"); null when not in XInput HID mode.
+    /// </summary>
+    [ObservableProperty]
+    private string? _xInputSlotDetail;
 
     /// <summary>
     ///     The Hid Mode the device is expected to be based on the device's user data
@@ -440,6 +458,29 @@ public partial class DeviceViewModel : ObservableObject
         AdjustSettingsTabState();
         OnPropertyChanged(nameof(DeviceSettingsStatus));
         OnPropertyChanged(nameof(IsHidModeMismatched));
+        RefreshXInputSlotLabel();
+    }
+
+    private void RefreshXInputSlotLabel()
+    {
+        OnPropertyChanged(nameof(IsXInputHidMode));
+        if (HidEmulationMode != SettingsContext.XInput)
+        {
+            XInputSlotBanner = null;
+            XInputSlotDetail = null;
+            return;
+        }
+
+        if (XInputSlotResolver.TryGetXInputUserIndex(Device, out byte userIndex))
+        {
+            XInputSlotDetail = $"Player {userIndex + 1}";
+            XInputSlotBanner = $"XInput: Player {userIndex + 1}";
+        }
+        else
+        {
+            XInputSlotDetail = "Unavailable";
+            XInputSlotBanner = "XInput: Unavailable";
+        }
     }
 
     [RelayCommand]

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Windows;
 
 using Nefarius.DsHidMini.ControlApp.Models;
@@ -24,6 +25,8 @@ public partial class DeviceViewModel : ObservableObject
     private readonly AppSnackbarMessagesService _appSnackbarMessagesService;
     private readonly Timer _batteryQuery;
     private readonly IContentDialogService _contentDialogService;
+
+    private int _xInputSlotRefreshGeneration;
 
     private readonly DeviceData _deviceUserData;
 
@@ -464,6 +467,8 @@ public partial class DeviceViewModel : ObservableObject
 
     private async Task RefreshXInputSlotLabelAsync()
     {
+        int refreshGeneration = Interlocked.Increment(ref _xInputSlotRefreshGeneration);
+
         OnPropertyChanged(nameof(IsXInputHidMode));
         if (HidEmulationMode != SettingsContext.XInput)
         {
@@ -481,7 +486,7 @@ public partial class DeviceViewModel : ObservableObject
 
         await Application.Current.Dispatcher.InvokeAsync(() =>
         {
-            if (device.InstanceId != Device.InstanceId)
+            if (refreshGeneration != _xInputSlotRefreshGeneration)
             {
                 return;
             }

--- a/ControlApp/Views/Pages/DevicesPage.xaml
+++ b/ControlApp/Views/Pages/DevicesPage.xaml
@@ -52,7 +52,8 @@
                                 <Grid Width="200" ShowGridLines="False">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="20" />
-                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
                                         <RowDefinition Height="25" />
                                     </Grid.RowDefinitions>
                                     <!--  Device name  -->
@@ -69,7 +70,15 @@
                                         Grid.ColumnSpan="2"
                                         FontSize="12"
                                         Text="{Binding DeviceSettingsStatus}" />
-                                    <DockPanel Grid.Row="2" LastChildFill="False">
+                                    <!--  XInput player slot (driver HID mode XInput only)  -->
+                                    <ui:TextBlock
+                                        Grid.Row="2"
+                                        Grid.ColumnSpan="2"
+                                        FontSize="11"
+                                        Opacity="0.9"
+                                        Text="{Binding XInputSlotBanner}"
+                                        Visibility="{Binding IsXInputHidMode, Converter={StaticResource BoolToVis_TV_FC}}" />
+                                    <DockPanel Grid.Row="3" LastChildFill="False">
 
 
                                         <DockPanel DockPanel.Dock="Right" LastChildFill="False">

--- a/ControlApp/Views/UserControls/DeviceUserControl.xaml
+++ b/ControlApp/Views/UserControls/DeviceUserControl.xaml
@@ -123,6 +123,21 @@
                                 DockPanel.Dock="Right"
                                 Text="{Binding HidEmulationMode, Mode=OneWay}" />
                         </DockPanel>
+                        <!--  XInput player slot (XInput HID mode only)  -->
+                        <DockPanel
+                            Margin="{StaticResource MyKey_NextLineSpacement}"
+                            DockPanel.Dock="Top"
+                            Visibility="{Binding IsXInputHidMode, Converter={StaticResource BoolToVis_TV_FC}}">
+                            <ui:TextBlock
+                                DockPanel.Dock="Left"
+                                Style="{StaticResource MyKey_InfoDescriptionTextbox}"
+                                Text="XInput player slot:" />
+                            <ui:TextBlock
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                DockPanel.Dock="Right"
+                                Text="{Binding XInputSlotDetail}" />
+                        </DockPanel>
                         <!--  Current host address  -->
                         <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
                             <ui:TextBlock

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="10.1.0" />
+    <PackageReference Include="Nuke.Common" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and displays XInput player slot for devices in XInput HID mode, showing active player (1–4) or "Unavailable".
  * Adds an XInput slot banner above device controls and a slot row in device details.

* **Chores**
  * Adds a resolution cache with TTL and explicit invalidation when devices or configuration change.
  * Updates build configuration/tooling targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->