### PR TITLE
Cache DMF libraries and build only DmfU

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,9 +120,13 @@ jobs:
         id: dmf-sha
         shell: pwsh
         run: |
+          # ImageVersion is a runner process env var, not an Actions `env:` context value,
+          # so capture it here for the cache key (invalidates on toolchain image upgrades).
           $sha = git rev-parse HEAD:DMF
+          $imageVersion = $env:ImageVersion
           echo "sha=$sha" >> $env:GITHUB_OUTPUT
-          Write-Output "DMF submodule commit $sha"
+          echo "image-version=$imageVersion" >> $env:GITHUB_OUTPUT
+          Write-Output "DMF submodule commit $sha (ImageVersion=$imageVersion)"
 
       - name: 'Cache DMF libraries'
         if: matrix.platform != 'x86'
@@ -130,7 +134,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: DMF/Release/${{ matrix.platform }}
-          key: dmf-v1-${{ matrix.platform }}-${{ steps.dmf-sha.outputs.sha }}-${{ env.ImageVersion }}
+          key: dmf-v1-${{ matrix.platform }}-${{ steps.dmf-sha.outputs.sha }}-${{ steps.dmf-sha.outputs.image-version }}
 
       - name: 'Build'
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,9 +112,29 @@ jobs:
           dotnet restore .\ControlApp\
           dotnet restore .\ipctest\
 
+      # DMF output is fully determined by the submodule commit and the runner toolchain.
+      # Skip the build entirely on a cache hit (x86 never builds DMF). No restore-keys: a
+      # partial match must never reuse libs built for a different commit or image.
+      - name: 'Resolve DMF submodule commit'
+        if: matrix.platform != 'x86'
+        id: dmf-sha
+        shell: pwsh
+        run: |
+          $sha = git rev-parse HEAD:DMF
+          echo "sha=$sha" >> $env:GITHUB_OUTPUT
+          Write-Output "DMF submodule commit $sha"
+
+      - name: 'Cache DMF libraries'
+        if: matrix.platform != 'x86'
+        id: dmf-cache
+        uses: actions/cache@v4
+        with:
+          path: DMF/Release/${{ matrix.platform }}
+          key: dmf-v1-${{ matrix.platform }}-${{ steps.dmf-sha.outputs.sha }}-${{ env.ImageVersion }}
+
       - name: 'Build'
         shell: cmd
-        run: .\build.cmd --target-platform ${{ matrix.platform }}
+        run: .\build.cmd --target-platform ${{ matrix.platform }} ${{ steps.dmf-cache.outputs.cache-hit == 'true' && '--skip BuildDmf' || '' }}
 
       - name: 'Publish ControlApp'
         if: matrix.platform == 'x64'

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -131,10 +131,13 @@ class Build : NukeBuild
 
             foreach ((Configuration config, MSBuildTargetPlatform platform) in buildCombinations)
             {
-                Log.Information("Building DMF {Configuration} | {Platform}", config, platform);
+                // dshidmini is UMDF and links only DmfU.lib; skip the kernel-mode half of Dmf.sln.
+                // MSBuild resolves "DmfU" as a solution-level target and pulls in its dependencies
+                // (DmfUFramework, DmfUModules.Library, DmfUModules.Template, DmfUModules.Library.Tests).
+                Log.Information("Building DMF DmfU {Configuration} | {Platform}", config, platform);
                 MSBuildTasks.MSBuild(s => s
                     .SetTargetPath(DmfSolution)
-                    .SetTargets("Build")
+                    .SetTargets("DmfU")
                     .SetConfiguration(config)
                     .SetTargetPlatform(platform)
                     .SetMaxCpuCount(Environment.ProcessorCount)


### PR DESCRIPTION
## Summary
- Build only the `DmfU` solution target in `BuildDmf` (skip unused kernel-mode DMF projects).
- Cache `DMF/Release/<platform>` keyed on the DMF submodule commit + runner `ImageVersion`.
- On a cache hit, `--skip BuildDmf` so warm CI jobs avoid rebuilding DMF.

## Expected impact
- Cold: somewhat cheaper from dropping the DmfK half.
- Warm: ARM64/x64 should drop from ~9.4/~7.9 min toward ~5 min each.

## Test plan
- [ ] Cold PR run: cache miss, DmfU-only build, artifacts still produced for x64/ARM64/x86
- [ ] Warm re-run: cache hit, BuildDmf skipped, driver still links
- [ ] Compare durations and cache entry size vs baseline

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved build times by reusing cached prebuilt components when they match the current source revision and toolchain/image version.
  * Added logic to avoid rebuilding DMF components when compatible cached artifacts are available.
* **Build Improvements**
  * Updated the DMF build behavior to build only the required UMDF portion instead of compiling extra targets and dependencies.
  * Refined build logging to better reflect the components being built for each configuration/platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->