### PR TITLE
fix(bth): make DS3 rumble work over Bluetooth (route output over the interrupt channel)

### DIFF
--- a/driver/Device.c
+++ b/driver/Device.c
@@ -1298,7 +1298,7 @@ DmfDeviceModulesAdd(
 		bthWriterCfg.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
 		bthWriterCfg.ContinuousRequestTargetModuleConfig.PoolTypeInput = NonPagedPoolNx;
 		bthWriterCfg.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
-		bthWriterCfg.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_BTHPS3_HID_CONTROL_WRITE;
+		bthWriterCfg.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_BTHPS3_HID_INTERRUPT_WRITE;
 		bthWriterCfg.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput = DsBth_HidControlWriteContinuousRequestCompleted;
 		bthWriterCfg.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
 		bthWriterCfg.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Manual;

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -23,7 +23,7 @@ const UCHAR G_Ds3UsbHidOutputReport[] = {
 // Default Output Report for LED & Rumble state changes (Bluetooth)
 // 
 const UCHAR G_Ds3BthHidOutputReport[] = {
-	0x52, /* HID BT Set_report (0x50) | Report Type (Output 0x02)*/
+	0xA2, /* HID BT DATA (0xA0) | Report Type (Output 0x02) -- interrupt channel so rumble actuates (was 0x52 Set_report/control) */
 	0x01, /* Report ID */
 	0x00, 0xFF, 0x00, 0xFF, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00,

--- a/driver/OutputReport.c
+++ b/driver/OutputReport.c
@@ -293,7 +293,7 @@ DSHM_EvtExecuteOutputPacketReceived(
 			NULL,
 			0,
 			ContinuousRequestTarget_RequestType_Ioctl,
-			IOCTL_BTHPS3_HID_CONTROL_WRITE,
+			IOCTL_BTHPS3_HID_INTERRUPT_WRITE,
 			0,
 			&bytesWritten
 		);


### PR DESCRIPTION
## Summary

Makes **DualShock 3 / SIXAXIS rumble work over Bluetooth**. Rumble has always worked over USB but
never over BT — LED updates apply, but the motors never actuate wirelessly. This addresses the
long-standing reports in #97 and #4.

## Root cause

On Bluetooth the output report (LED + rumble) is sent over the HID **control** channel
(`IOCTL_BTHPS3_HID_CONTROL_WRITE`) with a `0x52` (SET_REPORT | Output) prefix. The DS3 firmware
honours LED state from a control-channel `Set_Report` but **ignores the rumble bytes** delivered
that way. Over USB the same report goes to the **interrupt OUT** endpoint (`USB_WriteInterruptOutSync`),
which is why rumble works wired. So the report content was fine all along — only the BT transport
was wrong for rumble.

## How it was diagnosed

The deciding clue was that **LED changes *do* apply over Bluetooth** while rumble does not. If LED
updates arrive, the output reports are reaching the pad — so the rumble bytes weren't being lost in
transit, the DS3 was **receiving and ignoring** them. Comparing the two transports in the driver
then showed the only difference: USB writes to the interrupt endpoint, BT sends over the control
channel. Swapping BT to the interrupt channel made the motors actuate.

## Change

Send the BT output report over the HID **interrupt** channel (`IOCTL_BTHPS3_HID_INTERRUPT_WRITE`)
with a `0xA2` (DATA | Output) prefix, mirroring the USB path.

| File | Change |
|------|--------|
| `driver/Device.c` | output writer module IOCTL → `IOCTL_BTHPS3_HID_INTERRUPT_WRITE` |
| `driver/OutputReport.c` | send-call IOCTL → `IOCTL_BTHPS3_HID_INTERRUPT_WRITE` |
| `driver/Ds3.c` | `G_Ds3BthHidOutputReport[0]`: `0x52` → `0xA2` |

Three lines, no new APIs — BthPS3 already exposes the interrupt-write IOCTL (it's used for
`INTERRUPT_READ`).

## Testing

Built with the EWDK (26100) and tested on real hardware — genuine SIXAXIS over BthPS3, XInput mode,
Windows 10:

- ✅ Rumble now actuates over **Bluetooth** (both motors).
- ✅ LED state unaffected (no regression).
- ✅ USB path untouched.
- ✅ Independently confirmed in-browser via the Gamepad API at
  [hardwaretester.com/gamepad](https://hardwaretester.com/gamepad): the pad enumerates as an XInput
  standard gamepad with `VIBRATION: Yes`, and both the "Vibration, 1 sec" and "Vibration, infinite"
  buttons drive the motors over Bluetooth.

A single output report runs the motor for ~1 s (the DS3 duration byte); games that stream rumble
refresh it and sustain continuous vibration (confirmed with a 6 s periodic-resend test). I don't
have a way to test the DS4-emulation / Navigation-controller paths — an extra pair of eyes there
would be welcome.

## Try it before merge

For anyone who wants to test without setting up the WDK, a prebuilt **test-signed** driver + install
notes are here (test-signing required, self-signed cert — security caveats documented):
https://github.com/Cybertiron/ps3_bt_rumble_final_fix/releases/tag/v1.0.0

There's also a **no-Test-Mode** way to try it in that repo — a small userland app driving the
officially-signed ViGEmBus instead of a custom driver (prototype). The same interrupt-channel finding
applies there, which is extra confirmation of the root cause.

Thanks for DsHidMini — happy to adjust the patch to fit your preferences.
