### PR TITLE
Mark DSHMC as deprecated so agents use ControlApp instead.

### DIFF
--- a/.cursor/rules/dshmc-deprecated.mdc
+++ b/.cursor/rules/dshmc-deprecated.mdc
@@ -1,0 +1,12 @@
+---
+description: DSHMC is deprecated; use ControlApp for all control-app work
+alwaysApply: true
+---
+
+# DSHMC is deprecated
+
+`DSHMC/` is a legacy .NET Framework control utility. Do not add features, fix bugs,
+or use it as a template for new work unless the user explicitly asks to change DSHMC.
+
+Use `ControlApp/` instead. That is the current configuration app (WPF, .NET 9,
+`Nefarius.DsHidMini.IPC`).

--- a/DSHMC/README.md
+++ b/DSHMC/README.md
@@ -1,5 +1,9 @@
 # DsHidMini Control Utility (DSHMC)
 
+> [!WARNING]
+> **Deprecated.** `DSHMC` is a legacy control utility. Do not extend it.
+> Use [`ControlApp/`](../ControlApp/) for all configuration-app work.
+
 Portable single-executable .NET Framework 4.6 application to read and alter driver properties.
 
 ## Sources & 3rd party credits

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See the [issue tracker](https://github.com/nefarius/DsHidMini/issues) for known 
 | [XInputBridge/](XInputBridge/README.md) | XInput proxy DLL (`XInput1_3.dll`), extended API for DS3 pressure data |
 | [setup/](setup/README.md) | MSI installer (WixSharp), release packaging |
 | [ControlApp/](ControlApp/) | Configuration app (WPF) |
+| [DSHMC/](DSHMC/) | **Deprecated** legacy control utility. Use [ControlApp/](ControlApp/) |
 | [docs/](docs/README.md) | R&D notes; official docs at [docs.nefarius.at](https://docs.nefarius.at/projects/DsHidMini/) |
 
 For **how the driver works** (UMDF, DMF, config) and **build prerequisites** (Visual Studio, WDK, DMF), see [driver/README.md](driver/README.md). For the XInput Bridge build, see [XInputBridge/README.md](XInputBridge/README.md).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Marked DSHMC as deprecated and advised against extending it.
  - Directed configuration-app development and usage toward the newer ControlApp.
  - Updated repository guidance to distinguish the legacy utility from the current control application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->