### PR TITLE
Fix/hid mode switching 374

### DIFF
--- a/.cursor/rules/feature-branch-required.mdc
+++ b/.cursor/rules/feature-branch-required.mdc
@@ -1,0 +1,12 @@
+---
+description: Introduce all changes on a new branch from master
+alwaysApply: true
+---
+
+# New branch required
+
+Do not implement or commit work on `master`. Create a new branch from current `master` first
+(`feat/…` or `fix/…`), then make changes there.
+
+- Continue an existing branch only when it already is the requested work.
+- Do not merge or push to `master` unless the user explicitly asks.

--- a/.cursor/rules/feature-branch-required.mdc
+++ b/.cursor/rules/feature-branch-required.mdc
@@ -5,8 +5,10 @@ alwaysApply: true
 
 # New branch required
 
-Do not implement or commit work on `master`. Create a new branch from current `master` first
-(`feat/…` or `fix/…`), then make changes there.
+Do not implement or commit work on `master`. Before making changes, check whether the current
+branch already is the requested work.
 
-- Continue an existing branch only when it already is the requested work.
+- If it is, continue on that branch.
+- Otherwise, create a new branch from current `master` first (`feat/…` or `fix/…`), then make
+  changes there.
 - Do not merge or push to `master` unless the user explicitly asks.

--- a/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfig.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfig.cs
@@ -12,6 +12,7 @@ namespace Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.DshmConfig;
 public class DshmDeviceSettings
 {
     public HidDeviceMode? HIDDeviceMode { get; set; } // = DSHM_HidDeviceModes.DS4Windows;
+    public bool? AutoRestartOnHidModeMismatch { get; set; } // = true;
     public bool? DisableAutoPairing { get; set; }
 
     public DevicePairingMode? DevicePairingMode { get; set; }

--- a/ControlApp/Models/DshmConfigManager/DshmConfigManager.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfigManager.cs
@@ -59,6 +59,17 @@ public class DshmConfigManager
     }
 
     /// <summary>
+    ///     When enabled (default), the driver requests a self restart if the HID mode loaded from configuration at
+    ///     power-up differs from the mode already probed by PnP filters (see issue #374). Applies to all devices;
+    ///     written into the <c>Global</c> section of the DsHidMini configuration file.
+    /// </summary>
+    public bool AutoRestartOnHidModeMismatch
+    {
+        get => dshmManagerUserData.AutoRestartOnHidModeMismatch;
+        set => dshmManagerUserData.AutoRestartOnHidModeMismatch = value;
+    }
+
+    /// <summary>
     ///     Raised when the DsHidMini Configuration File on disk is updated
     /// </summary>
     public event EventHandler<DshmUpdatedEventArgs> DshmConfigurationUpdated;
@@ -137,6 +148,9 @@ public class DshmConfigManager
         DshmConfiguration dshmConfiguration = new();
         DshmManagerToDriverConversion.ConvertDeviceSettingsToDriverFormat(GlobalProfile.Settings,
             dshmConfiguration.Global);
+
+        // App-wide toggle, not tied to any profile (see issue #374)
+        dshmConfiguration.Global.AutoRestartOnHidModeMismatch = AutoRestartOnHidModeMismatch;
 
         foreach (DeviceData dev in dshmManagerUserData.Devices)
         {
@@ -297,6 +311,11 @@ public class DshmConfigManager
         ///     Guid of the profile set as global
         /// </summary>
         public Guid GlobalProfileGuid { get; set; } = ProfileData.DefaultGuid;
+
+        /// <summary>
+        ///     When enabled (default), the driver requests a self restart on a HID mode mismatch (see issue #374).
+        /// </summary>
+        public bool AutoRestartOnHidModeMismatch { get; set; } = true;
 
         /// <summary>
         ///     List of profiles datas

--- a/ControlApp/Models/Util/DshmDriverTranslationUtils.cs
+++ b/ControlApp/Models/Util/DshmDriverTranslationUtils.cs
@@ -12,4 +12,17 @@ internal static class DshmDriverTranslationUtils
         { 0x04, SettingsContext.DS4W },
         { 0x05, SettingsContext.XInput }
     };
+
+    /// <summary>
+    ///     Converts a <see cref="SettingsContext" /> HID mode back into the byte value the driver stores in
+    ///     DEVPKEY_DsHidMini_RW_HidDeviceMode (see <see cref="HidDeviceMode" /> for the forward mapping).
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    ///     Thrown if <paramref name="context" /> is not one of the concrete HID device modes (e.g. Unknown, General,
+    ///     Global).
+    /// </exception>
+    public static byte ToHidDeviceModePropertyValue(SettingsContext context)
+    {
+        return (byte)HidDeviceMode.First(pair => pair.Value == context).Key;
+    }
 }

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -106,7 +106,10 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
         {
             if (devVM.IsHidModeMismatched)
             {
-                if (!DshmDevMan.TryReconnectDevice(devVM.Device))
+                // Best-effort: write the expected mode to the device property first, so the driver's
+                // D0Entry-time mismatch check (issue #374) sees a matching value on the very next power-up.
+                bool propertyApplyResult = devVM.ApplyExpectedHidModeProperty();
+                if (!DshmDevMan.TryReconnectDevice(devVM.Device) || !propertyApplyResult)
                 {
                     oneOrMoreFails = true;
                 }

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using System.Reflection;
 
+using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
+
 using Wpf.Ui.Abstractions.Controls;
 using Wpf.Ui.Appearance;
 
@@ -7,6 +9,8 @@ namespace Nefarius.DsHidMini.ControlApp.ViewModels.Pages;
 
 public partial class SettingsViewModel : ObservableObject, INavigationAware
 {
+    private readonly DshmConfigManager _dshmConfigManager;
+
     [ObservableProperty]
     private string _appVersion = string.Empty;
 
@@ -14,6 +18,31 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private ApplicationTheme _currentTheme = ApplicationTheme.Unknown;
 
     private bool _isInitialized;
+
+    public SettingsViewModel(DshmConfigManager dshmConfigManager)
+    {
+        _dshmConfigManager = dshmConfigManager;
+    }
+
+    /// <summary>
+    ///     When enabled (default), the driver requests a self restart on a HID mode mismatch instead of requiring a
+    ///     manual reconnect / second replug (see issue #374).
+    /// </summary>
+    public bool AutoRestartOnHidModeMismatch
+    {
+        get => _dshmConfigManager.AutoRestartOnHidModeMismatch;
+        set
+        {
+            if (_dshmConfigManager.AutoRestartOnHidModeMismatch == value)
+            {
+                return;
+            }
+
+            _dshmConfigManager.AutoRestartOnHidModeMismatch = value;
+            _dshmConfigManager.SaveChangesAndUpdateDsHidMiniConfigFile();
+            OnPropertyChanged();
+        }
+    }
 
     public Task OnNavigatedToAsync()
     {

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -542,15 +542,39 @@ public partial class DeviceViewModel : ObservableObject
         await RefreshDeviceSettings();
     }
 
+    /// <summary>
+    ///     Writes the expected HID mode into DEVPKEY_DsHidMini_RW_HidDeviceMode before requesting a reconnect, so the
+    ///     driver's D0Entry-time mismatch check (see issue #374) sees a matching value on the very next power-up
+    ///     instead of the still-stale one the PnP-time filters probed. Best-effort: setting a device property
+    ///     requires elevation, same as <see cref="DshmDevMan.TryReconnectDevice" />.
+    /// </summary>
+    public bool ApplyExpectedHidModeProperty()
+    {
+        try
+        {
+            Device.SetProperty(DsHidMiniDriver.HidDeviceModeProperty,
+                DshmDriverTranslationUtils.ToHidDeviceModePropertyValue(ExpectedHidMode));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Error(ex,
+                "Failed to write expected HID mode {ExpectedHidMode} to device '{DeviceAddress}' before reconnecting.",
+                ExpectedHidMode, DeviceAddress);
+            return false;
+        }
+    }
+
     [RelayCommand]
     private void RestartDevice()
     {
+        bool propertyApplyResult = ApplyExpectedHidModeProperty();
         bool reconnectionResult = DshmDevMan.TryReconnectDevice(Device);
         Log.Logger.Information(
             "User instructed {Wireless} device '{DeviceAddress}' to restart/disconnect.",
             IsWireless ? "wireless" : "wired", DeviceAddress);
         _appSnackbarMessagesService.ShowPowerCyclingDeviceMessage(IsWireless, SecurityUtil.IsElevated,
-            reconnectionResult);
+            reconnectionResult && propertyApplyResult);
     }
 
     [RelayCommand]

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -19,6 +19,16 @@
     </Page.Resources>
 
     <Grid>
-        <TextBlock Margin="20">Uh oh, nobody has anything programmed for in here yet!</TextBlock>
+        <StackPanel Margin="20">
+            <CheckBox
+                Margin="0,0,0,8"
+                Content="Automatically restart devices on HID mode mismatch"
+                IsChecked="{Binding ViewModel.AutoRestartOnHidModeMismatch, Mode=TwoWay}" />
+            <TextBlock
+                MaxWidth="600"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="When enabled, DsHidMini requests a device restart on its own if the HID mode it loaded from configuration doesn't match the mode already probed by Windows, instead of requiring a manual reconnect or a second replug."
+                TextWrapping="Wrap" />
+        </StackPanel>
     </Grid>
 </Page>

--- a/driver/Configuration.c
+++ b/driver/Configuration.c
@@ -485,6 +485,12 @@ static void ConfigNodeParse(
 			pCfg->HidDeviceMode = HID_DEVICE_MODE_FROM_NAME(cJSON_GetStringValue(pNode));
 			EventWriteOverrideSettingUInt(ParentNode->string, "HidDeviceMode", pCfg->HidDeviceMode);
 		}
+
+		if ((pNode = cJSON_GetObjectItem(ParentNode, "AutoRestartOnHidModeMismatch")))
+		{
+			pCfg->AutoRestartOnHidModeMismatch = (BOOLEAN)cJSON_IsTrue(pNode);
+			EventWriteOverrideSettingUInt(ParentNode->string, "AutoRestartOnHidModeMismatch", pCfg->AutoRestartOnHidModeMismatch);
+		}
 	}
 
 	if ((pNode = cJSON_GetObjectItem(ParentNode, "DevicePairingMode")))
@@ -993,6 +999,7 @@ ConfigSetDefaults(
 	Config->HidDeviceMode = DsHidMiniDeviceModeXInputHIDCompatible;
 	Config->DevicePairingMode = DsDevicePairingModeAuto;
 	Config->PairOnHotReload = FALSE;
+	Config->AutoRestartOnHidModeMismatch = TRUE;
 	for (int i = 0; i < 6; i++)
 	{
 		Config->CustomHostAddress[i] = 0x00;

--- a/driver/Device.c
+++ b/driver/Device.c
@@ -428,6 +428,39 @@ NTSTATUS DsDevice_ReadProperties(WDFDEVICE Device)
 }
 
 //
+// Deferred callback that requests a self re-enumeration when
+// DMF_DsHidMini_Open detected that the HID mode loaded from configuration
+// differs from the mode already exposed via
+// DEVPKEY_DsHidMini_RW_HidDeviceMode (see issue #374).
+//
+// Running this from a timer rather than inline in DMF_DsHidMini_Open keeps
+// WdfDeviceSetFailed off the power-up call stack, mirroring the approach
+// already used for the failed-resume restart in DsUsb.c (issue #311).
+// 
+_Use_decl_annotations_
+VOID
+DsDevice_EvtHidModeRestartTimerFunc(
+	WDFTIMER Timer
+)
+{
+	FuncEntry(TRACE_DEVICE);
+
+	const WDFDEVICE device = WdfTimerGetParentObject(Timer);
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(device);
+
+	TraceWarning(
+		TRACE_DEVICE,
+		"Requesting a device restart, HID mode from configuration mismatched the mode already probed by PnP"
+	);
+
+	EventWriteRequestingDeviceRestartOnHidModeMismatch(pDevCtx->DeviceAddressString);
+
+	WdfDeviceSetFailed(device, WdfDeviceFailedAttemptRestart);
+
+	FuncExitNoReturn(TRACE_DEVICE);
+}
+
+//
 // Initialize remaining device context fields
 // 
 NTSTATUS
@@ -748,6 +781,34 @@ DsDevice_InitContext(
 				status
 			);
 			EventWriteFailedWithNTStatus(__FUNCTION__, L"WdfTimerCreate", status);
+			break;
+		}
+
+		//
+		// Create timer used to defer a self re-enumeration request when a
+		// HID mode mismatch is detected (see issue #374)
+		// 
+
+		WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
+		attributes.ParentObject = Device;
+
+		WDF_TIMER_CONFIG_INIT(
+			&timerCfg,
+			DsDevice_EvtHidModeRestartTimerFunc
+		);
+
+		if (!NT_SUCCESS(status = WdfTimerCreate(
+			&timerCfg,
+			&attributes,
+			&pDevCtx->HidModeRestartTimer
+		)))
+		{
+			TraceError(
+				TRACE_DEVICE,
+				"WdfTimerCreate (HidModeRestartTimer) failed with status %!STATUS!",
+				status
+			);
+			EventWriteFailedWithNTStatus(__FUNCTION__, L"WdfTimerCreate (HidModeRestartTimer)", status);
 			break;
 		}
 

--- a/driver/Device.h
+++ b/driver/Device.h
@@ -114,7 +114,7 @@ typedef struct _FFB_ATTRIBUTES
 /**
  * Output report context.
  *
- * @author	Benjamin "Nefarius" Hˆglinger-Stelzer
+ * @author	Benjamin "Nefarius" Hùglinger-Stelzer
  * @date	01.04.2021
  */
 typedef struct _DS_OUTPUT_REPORT_CONTEXT
@@ -139,7 +139,7 @@ typedef struct _DS_OUTPUT_REPORT_CONTEXT
 /**
  * Cached output report values to help with rate-control.
  *
- * @author	Benjamin "Nefarius" Hˆglinger-Stelzer
+ * @author	Benjamin "Nefarius" Hùglinger-Stelzer
  * @date	12.03.2021
  */
 typedef struct _DS_OUTPUT_REPORT_CACHE
@@ -208,6 +208,21 @@ typedef struct _DEVICE_CONTEXT
 	// the trace at report rate. Reset in DsHidMini_EvtDeviceD0Entry.
 	// 
 	BOOLEAN InputReportDropLogged;
+
+	//
+	// Timer used to defer a self re-enumeration request off the D0Entry
+	// path when DMF_DsHidMini_Open detects that the HID mode loaded from
+	// configuration differs from the mode already exposed via
+	// DEVPKEY_DsHidMini_RW_HidDeviceMode (see issue #374).
+	// 
+	WDFTIMER HidModeRestartTimer;
+
+	//
+	// Set once a self re-enumeration has been requested because of a HID
+	// mode mismatch, so this power-up only asks for it once. Reset in
+	// DsHidMini_EvtDeviceD0Entry.
+	// 
+	BOOLEAN HidModeRestartRequested;
 	
 	struct
 	{
@@ -446,6 +461,8 @@ DMF_Open DMF_DsHidMini_Open;
 EVT_DMF_ThreadedBufferQueue_Callback DSHM_EvtExecuteOutputPacketReceived;
 
 EVT_WDF_TIMER DSHM_OutputReportDelayTimerElapsed;
+
+EVT_WDF_TIMER DsDevice_EvtHidModeRestartTimerFunc;
 
 EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL DSHM_EvtWdfIoQueueIoDeviceControl;
 

--- a/driver/DsCommon.h
+++ b/driver/DsCommon.h
@@ -561,6 +561,14 @@ typedef struct _DS_DRIVER_CONFIGURATION
 	BOOLEAN PairOnHotReload;
 
 	//
+	// When set, the driver requests a self re-enumeration if the HID mode
+	// loaded from configuration differs from the mode already exposed via
+	// DEVPKEY_DsHidMini_RW_HidDeviceMode when this power-up started (see
+	// issue #374). Can't be altered at runtime.
+	// 
+	BOOLEAN AutoRestartOnHidModeMismatch;
+
+	//
 	// True if output rate control is enabled, false if not
 	// 
 	BOOLEAN IsOutputRateControlEnabled;

--- a/driver/DsHidMini.json
+++ b/driver/DsHidMini.json
@@ -1,6 +1,7 @@
 {
   "Global": {
     "HidDeviceMode": "DS4Windows",
+    "AutoRestartOnHidModeMismatch": true,
     "DevicePairingMode": "Auto",
     "PairOnHotReload": false,
     "IsOutputRateControlEnabled": true,

--- a/driver/DsHidMini.man
+++ b/driver/DsHidMini.man
@@ -68,6 +68,7 @@
 					<event value="14" channel="SYSTEM" level="win:Informational" message="$(string.FFBNoFreeEffectBlockIndex.EventMessage)" opcode="win:Info" symbol="FFBNoFreeEffectBlockIndex" />
 					<event value="15" channel="SYSTEM" level="win:Informational" message="$(string.ApplyingWirelessWorkarounds.EventMessage)" opcode="win:Info" symbol="ApplyingWirelessWorkarounds" />
 					<event value="16" channel="SYSTEM" level="win:Warning" message="$(string.RequestingDeviceRestartAfterResume.EventMessage)" opcode="win:Info" symbol="RequestingDeviceRestartAfterResume" template="tid_device_address"/>
+					<event value="17" channel="SYSTEM" level="win:Warning" message="$(string.RequestingDeviceRestartOnHidModeMismatch.EventMessage)" opcode="win:Info" symbol="RequestingDeviceRestartOnHidModeMismatch" template="tid_device_address"/>
 				</events>
 			</provider>
 		</events>
@@ -91,6 +92,7 @@
 				<string id="FFBNoFreeEffectBlockIndex.EventMessage" value="No free effect block index, can't create Force-Feedback Effect"/>
 				<string id="ApplyingWirelessWorkarounds.EventMessage" value="Battery status still unknown, applying workarounds"/>
 				<string id="RequestingDeviceRestartAfterResume.EventMessage" value="Device %1 failed to resume from a low-power state; requesting a device restart"/>
+				<string id="RequestingDeviceRestartOnHidModeMismatch.EventMessage" value="Device %1 HID mode configuration mismatched the mode already probed by PnP; requesting a device restart"/>
 			</stringTable>
 		</resources>
 	</localization>

--- a/driver/DsHidMiniDrv.c
+++ b/driver/DsHidMiniDrv.c
@@ -463,6 +463,29 @@ DMF_DsHidMini_Open(
 	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
 	propertyData.Lcid = LOCALE_NEUTRAL;
 
+	//
+	// Re-query the property before it gets overwritten below: at this point
+	// it still holds whatever value the PnP-time filters (e.g. nssmkig) saw
+	// while the device stack was being built - potentially stale, since it
+	// was last written by a previous power-up before this one loaded the
+	// current configuration (see issue #374). Comparing it against the mode
+	// that was just loaded from configuration is what lets us detect the
+	// mismatch that causes the filter to run with the wrong HID report
+	// descriptor.
+	// 
+	DS_HID_DEVICE_MODE previouslyExposedHidDeviceMode = DsHidMiniDeviceModeUnknown;
+	ULONG previousModeRequiredSize = 0;
+	DEVPROPTYPE previousModePropType = DEVPROP_TYPE_EMPTY;
+
+	const NTSTATUS queryPreviousModeStatus = WdfDeviceQueryPropertyEx(
+		device,
+		&propertyData,
+		sizeof(BYTE),
+		(PBYTE)&previouslyExposedHidDeviceMode,
+		&previousModeRequiredSize,
+		&previousModePropType
+	);
+
 	status = WdfDeviceAssignProperty(
 		device,
 		&propertyData,
@@ -470,6 +493,30 @@ DMF_DsHidMini_Open(
 		sizeof(BYTE),
 		&pDevCtx->Configuration.HidDeviceMode
 	);
+
+	if (NT_SUCCESS(status)
+		&& NT_SUCCESS(queryPreviousModeStatus)
+		&& previouslyExposedHidDeviceMode != pDevCtx->Configuration.HidDeviceMode
+		&& pDevCtx->Configuration.AutoRestartOnHidModeMismatch
+		&& !pDevCtx->HidModeRestartRequested)
+	{
+		//
+		// Latch so this power-up only requests a restart once: the property
+		// now matches the loaded configuration, so on the next power-up
+		// (after the restart completes) this comparison will no longer
+		// trigger. Reset in DsHidMini_EvtDeviceD0Entry.
+		// 
+		pDevCtx->HidModeRestartRequested = TRUE;
+
+		TraceWarning(
+			TRACE_DSHIDMINIDRV,
+			"HID Device Mode mismatch detected (previously exposed: 0x%02X, configured: 0x%02X); scheduling a device restart",
+			previouslyExposedHidDeviceMode,
+			pDevCtx->Configuration.HidDeviceMode
+		);
+
+		WdfTimerStart(pDevCtx->HidModeRestartTimer, WDF_REL_TIMEOUT_IN_MS(1000));
+	}
 
 exit:
 	if (!NT_SUCCESS(status))

--- a/driver/Power.c
+++ b/driver/Power.c
@@ -192,6 +192,12 @@ NTSTATUS DsHidMini_EvtDeviceD0Entry(
 	// 
 	pDevCtx->InputReportDropLogged = FALSE;
 
+	//
+	// Re-arm the HID mode mismatch restart latch for this power cycle (see
+	// DMF_DsHidMini_Open, issue #374).
+	// 
+	pDevCtx->HidModeRestartRequested = FALSE;
+
 	if (pDevCtx->ConnectionType == DsDeviceConnectionTypeUsb)
 	{
 		status = DsUsb_D0Entry(Device, PreviousState);


### PR DESCRIPTION
Fixes #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a setting to automatically restart devices when their configured HID mode differs from the mode detected by Windows.
  - The option is enabled by default and can be changed from the Settings page.
  - Devices can automatically re-enumerate after a HID mode mismatch so the configured mode takes effect.

- **Improvements**
  - Manual and automatic reconnection now apply the expected HID mode first.
  - Reconnection reports failure if applying the mode or reconnecting fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->