### PR TITLE
Speed up CI by dropping the abseil vcpkg rebuild and tightening cache…

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nefarius.tools.vpatch": {
+      "version": "2.7.0",
+      "commands": [
+        "vpatch"
+      ]
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,10 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
   DOTNET_NOLOGO: 'true'
   SCPLIB_ENABLE_TELEMETRY: 'false'
-  # Disabled by default; enabled per-job below only when the VCPKG_NUGET_TOKEN secret is present.
-  # GITHUB_TOKEN cannot push new packages under a personal-account GitHub Packages namespace, so a
-  # PAT with read:packages/write:packages is required. See:
+  # Files cache is always enabled (see Configure vcpkg binary cache). The GitHub Packages NuGet
+  # provider is appended only when VCPKG_NUGET_TOKEN is present. GITHUB_TOKEN cannot push new
+  # packages under a personal-account GitHub Packages namespace, so a PAT with
+  # read:packages/write:packages is required. See:
   # https://github.com/microsoft/vcpkg/issues/47470
   VCPKG_BINARY_SOURCES: 'clear'
 
@@ -70,6 +71,60 @@ jobs:
         shell: cmd
         run: .\XInputBridge\vcpkg\bootstrap-vcpkg.bat -disableMetrics
 
+      - name: 'Resolve cache keys'
+        id: cache-keys
+        shell: pwsh
+        run: |
+          # ImageVersion is a runner process env var, not an Actions `env:` context value,
+          # so capture it here for the cache keys (invalidates on toolchain image upgrades).
+          $dmfSha = git rev-parse HEAD:DMF
+          $vcpkgSha = git rev-parse HEAD:XInputBridge/vcpkg
+          $imageVersion = $env:ImageVersion
+          echo "dmf-sha=$dmfSha" >> $env:GITHUB_OUTPUT
+          echo "vcpkg-sha=$vcpkgSha" >> $env:GITHUB_OUTPUT
+          echo "image-version=$imageVersion" >> $env:GITHUB_OUTPUT
+          Write-Output "DMF $dmfSha / vcpkg $vcpkgSha (ImageVersion=$imageVersion)"
+
+      - name: 'Cache NuGet packages'
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          # Explicit project list so DMF submodule csproj churn does not evict the cache.
+          key: nuget-${{ runner.os }}-${{ hashFiles('ControlApp/ControlApp.csproj', 'ipctest/ipctest.csproj', 'SDK/Nefarius.DsHidMini.IPC/Nefarius.DsHidMini.IPC.csproj', 'build/_build.csproj', 'nuget.config', '.config/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: 'Restore local .NET tools'
+        run: dotnet tool restore
+
+      # DMF output is fully determined by the submodule commit and the runner toolchain.
+      # Skip the build entirely on a cache hit (x86 never builds DMF). No restore-keys: a
+      # partial match must never reuse libs built for a different commit or image.
+      - name: 'Cache DMF libraries'
+        if: matrix.platform != 'x86'
+        id: dmf-cache
+        uses: actions/cache@v4
+        with:
+          path: DMF/Release/${{ matrix.platform }}
+          key: dmf-v1-${{ matrix.platform }}-${{ steps.cache-keys.outputs.dmf-sha }}-${{ steps.cache-keys.outputs.image-version }}
+
+      # vcpkg validates every archive against its own ABI hash, so a partial key match is
+      # safe to restore: unused or stale archives are ignored rather than reused.
+      - name: 'Cache vcpkg binary archives'
+        uses: actions/cache@v4
+        with:
+          path: vcpkg-archives
+          key: vcpkg-v1-${{ matrix.platform }}-${{ hashFiles('XInputBridge/vcpkg.json') }}-${{ steps.cache-keys.outputs.vcpkg-sha }}-${{ steps.cache-keys.outputs.image-version }}
+          restore-keys: |
+            vcpkg-v1-${{ matrix.platform }}-
+
+      - name: 'Configure vcpkg files binary cache'
+        shell: pwsh
+        run: |
+          $archives = (Join-Path $env:GITHUB_WORKSPACE 'vcpkg-archives').Replace('\', '/')
+          New-Item -ItemType Directory -Force -Path $archives | Out-Null
+          echo "VCPKG_BINARY_SOURCES=clear;files,$archives,readwrite" >> $env:GITHUB_ENV
+
       - name: 'Configure vcpkg NuGet binary cache'
         if: ${{ env.VCPKG_NUGET_TOKEN != '' }}
         shell: pwsh
@@ -83,25 +138,14 @@ jobs:
             -Password "$env:VCPKG_NUGET_TOKEN"
           & $nugetExe setapikey "$env:VCPKG_NUGET_TOKEN" `
             -Source "https://nuget.pkg.github.com/nefarius/index.json"
-          echo "VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/nefarius/index.json,readwrite" >> $env:GITHUB_ENV
-
-      - name: 'Cache NuGet packages'
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'nuget.config') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-
-
-      - name: 'Install vpatch'
-        run: dotnet tool install --global Nefarius.Tools.Vpatch
+          echo "VCPKG_BINARY_SOURCES=$env:VCPKG_BINARY_SOURCES;nuget,https://nuget.pkg.github.com/nefarius/index.json,readwrite" >> $env:GITHUB_ENV
 
       - name: 'Stamp version into driver and XInputBridge'
         shell: cmd
         run: |
-          vpatch --stamp-version "%BUILD_VERSION%" --target-file ".\driver\dshidmini.vcxproj" --vcxproj.inf-time-stamp
-          vpatch --stamp-version "%BUILD_VERSION%" --target-file ".\driver\dshidmini.rc" --resource.file-version --resource.product-version
-          vpatch --stamp-version "%BUILD_VERSION%" --target-file ".\XInputBridge\XInputBridge.rc" --resource.file-version --resource.product-version
+          dotnet vpatch --stamp-version "%BUILD_VERSION%" --target-file ".\driver\dshidmini.vcxproj" --vcxproj.inf-time-stamp
+          dotnet vpatch --stamp-version "%BUILD_VERSION%" --target-file ".\driver\dshidmini.rc" --resource.file-version --resource.product-version
+          dotnet vpatch --stamp-version "%BUILD_VERSION%" --target-file ".\XInputBridge\XInputBridge.rc" --resource.file-version --resource.product-version
 
       - name: 'Restore managed projects'
         # msbuild's /t:Rebuild over the whole solution does not implicitly restore SDK-style
@@ -112,38 +156,9 @@ jobs:
           dotnet restore .\ControlApp\
           dotnet restore .\ipctest\
 
-      # DMF output is fully determined by the submodule commit and the runner toolchain.
-      # Skip the build entirely on a cache hit (x86 never builds DMF). No restore-keys: a
-      # partial match must never reuse libs built for a different commit or image.
-      - name: 'Resolve DMF submodule commit'
-        if: matrix.platform != 'x86'
-        id: dmf-sha
-        shell: pwsh
-        run: |
-          # ImageVersion is a runner process env var, not an Actions `env:` context value,
-          # so capture it here for the cache key (invalidates on toolchain image upgrades).
-          $sha = git rev-parse HEAD:DMF
-          $imageVersion = $env:ImageVersion
-          echo "sha=$sha" >> $env:GITHUB_OUTPUT
-          echo "image-version=$imageVersion" >> $env:GITHUB_OUTPUT
-          Write-Output "DMF submodule commit $sha (ImageVersion=$imageVersion)"
-
-      - name: 'Cache DMF libraries'
-        if: matrix.platform != 'x86'
-        id: dmf-cache
-        uses: actions/cache@v4
-        with:
-          path: DMF/Release/${{ matrix.platform }}
-          key: dmf-v1-${{ matrix.platform }}-${{ steps.dmf-sha.outputs.sha }}-${{ steps.dmf-sha.outputs.image-version }}
-
       - name: 'Build'
         shell: cmd
-        run: .\build.cmd --target-platform ${{ matrix.platform }} ${{ steps.dmf-cache.outputs.cache-hit == 'true' && '--skip BuildDmf' || '' }}
-
-      - name: 'Publish ControlApp'
-        if: matrix.platform == 'x64'
-        shell: cmd
-        run: .\build.cmd PublishControlApp --skip Compile
+        run: .\build.cmd Compile ${{ matrix.platform == 'x64' && 'PublishControlApp' || '' }} --target-platform ${{ matrix.platform }} ${{ steps.dmf-cache.outputs.cache-hit == 'true' && '--skip BuildDmf' || '' }}
 
       - name: 'Pack driver CAB'
         if: matrix.platform != 'x86'

--- a/.gitignore
+++ b/.gitignore
@@ -347,6 +347,7 @@ healthchecksdb
 /setup/DsHidMini Driver-SetupFiles
 /setup/DsHidMini Driver-cache
 **/vcpkg_installed
+/vcpkg-archives
 **/*.g.wxs
 /XInputBridge/exports
 **/*_OTEL

--- a/XInputBridge/Common.h
+++ b/XInputBridge/Common.h
@@ -26,7 +26,6 @@
 #include <format>
 
 //
-// Abseil
-// 
-#include <absl/cleanup/cleanup.h>
-#include <absl/strings/match.h>
+// Scope guard (replaces absl::Cleanup / absl::EqualsIgnoreCase)
+//
+#include "ScopeGuard.h"

--- a/XInputBridge/GlobalState.Util.cpp
+++ b/XInputBridge/GlobalState.Util.cpp
@@ -63,7 +63,7 @@ std::optional<std::vector<std::wstring>> GlobalState::GetSymbolicLinksForDeviceI
 	if (szListBuffer == nullptr)
 		return std::nullopt;
 
-	absl::Cleanup freeBuffer = [szListBuffer]
+	ScopeCleanup freeBuffer = [szListBuffer]
 	{
 		free(szListBuffer);
 	};
@@ -109,7 +109,7 @@ std::optional<std::wstring> GlobalState::InterfaceIdToInstanceId(const std::wstr
 	if (instanceIdBuf == nullptr)
 		return std::nullopt;
 
-	absl::Cleanup freeBuffer = [instanceIdBuf]
+	ScopeCleanup freeBuffer = [instanceIdBuf]
 	{
 		free(instanceIdBuf);
 	};
@@ -162,7 +162,7 @@ std::optional<std::vector<std::wstring>> GlobalState::GetDeviceChildren(const st
 
 	const auto childrenIdBuf = static_cast<PBYTE>(calloc(childrenIdBytes, 1));
 
-	absl::Cleanup freeBuffer = [childrenIdBuf]
+	ScopeCleanup freeBuffer = [childrenIdBuf]
 	{
 		free(childrenIdBuf);
 	};
@@ -212,7 +212,7 @@ std::optional<std::vector<std::wstring>> GlobalState::InstanceIdToHidPaths(const
 	if (buffer == nullptr)
 		return std::nullopt;
 
-	absl::Cleanup freeBuffer = [buffer]
+	ScopeCleanup freeBuffer = [buffer]
 	{
 		free(buffer);
 	};

--- a/XInputBridge/GlobalState.XInput.cpp
+++ b/XInputBridge/GlobalState.XInput.cpp
@@ -10,7 +10,7 @@ DWORD GlobalState::ProxyXInputGetExtended(_In_ DWORD dwUserIndex, _Out_ SCP_EXTN
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -124,7 +124,7 @@ DWORD GlobalState::ProxyXInputGetState(_In_ DWORD dwUserIndex, _Out_ XINPUT_STAT
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -282,7 +282,7 @@ DWORD GlobalState::ProxyXInputSetState(_In_ DWORD dwUserIndex, _In_ XINPUT_VIBRA
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -366,7 +366,7 @@ DWORD GlobalState::ProxyXInputGetCapabilities(_In_ DWORD dwUserIndex, _In_ DWORD
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -444,7 +444,7 @@ DWORD GlobalState::ProxyXInputGetDSoundAudioDeviceGuids(DWORD dwUserIndex, GUID*
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -464,7 +464,7 @@ DWORD GlobalState::ProxyXInputGetBatteryInformation(_In_ DWORD dwUserIndex,
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -482,7 +482,7 @@ DWORD GlobalState::ProxyXInputGetKeystroke(DWORD dwUserIndex, DWORD dwReserved, 
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -500,7 +500,7 @@ DWORD GlobalState::ProxyXInputGetStateEx(_In_ DWORD dwUserIndex, _Out_ XINPUT_ST
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -655,7 +655,7 @@ DWORD GlobalState::ProxyXInputWaitForGuideButton(_In_ DWORD dwUserIndex, _In_ DW
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -673,7 +673,7 @@ DWORD GlobalState::ProxyXInputCancelGuideButtonWait(_In_ DWORD dwUserIndex)
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};
@@ -691,7 +691,7 @@ DWORD GlobalState::ProxyXInputPowerOffController(_In_ DWORD dwUserIndex)
 	WaitForSingleObject(this->StartupFinishedEvent, MAX_STARTUP_WAIT_MS);
 
 	AcquireSRWLockShared(&this->StatesLock);
-	absl::Cleanup lockRelease = [this]
+	ScopeCleanup lockRelease = [this]
 	{
 		ReleaseSRWLockShared(&this->StatesLock);
 	};

--- a/XInputBridge/GlobalState.cpp
+++ b/XInputBridge/GlobalState.cpp
@@ -58,7 +58,7 @@ bool GlobalState::SymlinkToUserIndex(_In_ PCWSTR Symlink, _Inout_ PDWORD UserInd
 		nullptr
 	);
 
-	absl::Cleanup handleFree = [handle]
+	ScopeCleanup handleFree = [handle]
 	{
 		if (handle != INVALID_HANDLE_VALUE)
 			CloseHandle(handle);
@@ -146,7 +146,7 @@ DeviceState* GlobalState::FindBySymbolicLink(const std::wstring& Symlink)
 	const auto item = std::ranges::find_if(this->States,
 		[narrow](const DeviceState& element)
 		{
-			return absl::EqualsIgnoreCase(element.SymbolicLink, narrow);
+			return EqualsIgnoreCase(element.SymbolicLink, narrow);
 		});
 
 	return (item != this->States.end()) ? &(*item) : nullptr;

--- a/XInputBridge/README.md
+++ b/XInputBridge/README.md
@@ -51,7 +51,7 @@ Usage, setup, and deployment are documented on the project site:
 | `Common.h`, `Macros.h`, `Types.h`, `UniUtil.h` | Shared types and helpers. |
 | `XInput.def` | Export ordinals (matches XInput 1.3 + ordinal 200 for GetExtended). |
 
-Dependencies (via [vcpkg](https://vcpkg.io/)): **hidapi**, **abseil**, **winreg**.
+Dependencies (via [vcpkg](https://vcpkg.io/)): **hidapi**, **winreg**.
 
 ## Build
 
@@ -74,5 +74,5 @@ The bridge is maintained and stable. You can use it in your own projects if you 
 - [ScpToolkit / ScpXInputBridge](https://github.com/nefarius/ScpToolkit/tree/master/ScpXInputBridge) — extended XInput API origin
 - [X1nput](https://github.com/araghon007/X1nput), [OpenXInput](https://github.com/Nemirtingas/OpenXinput) — XInput proxy ideas
 - [RPCS3 ds3_pad_handler](https://github.com/RPCS3/rpcs3/blob/master/rpcs3/Input/ds3_pad_handler.cpp), [PCSX2 XInputEnum](https://github.com/PCSX2/pcsx2/blob/master/pcsx2/PAD/Windows/XInputEnum.cpp) — reference implementations
-- [HIDAPI](https://github.com/libusb/hidapi), [Abseil](https://abseil.io/), [WinReg](https://github.com/GiovanniDicanio/WinReg) — dependencies
+- [HIDAPI](https://github.com/libusb/hidapi), [WinReg](https://github.com/GiovanniDicanio/WinReg) — dependencies
 - [RawInputDemo](https://github.com/DJm00n/RawInputDemo) — Raw Input / device enumeration reference

--- a/XInputBridge/ScopeGuard.h
+++ b/XInputBridge/ScopeGuard.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string_view>
+#include <utility>
+
+//
+// Drop-in for absl::Cleanup using the copy-init form:
+//   ScopeCleanup name = [captures] { ... };
+//
+template <typename F>
+class ScopeCleanup
+{
+public:
+	ScopeCleanup(F callback) : m_callback(std::move(callback)) {}
+	ScopeCleanup(const ScopeCleanup&) = delete;
+	ScopeCleanup& operator=(const ScopeCleanup&) = delete;
+	~ScopeCleanup() { m_callback(); }
+
+private:
+	F m_callback;
+};
+
+template <typename F>
+ScopeCleanup(F) -> ScopeCleanup<F>;
+
+//
+// ASCII-only, locale-independent case-insensitive compare (absl::EqualsIgnoreCase).
+//
+inline bool EqualsIgnoreCase(std::string_view left, std::string_view right)
+{
+	if (left.size() != right.size())
+		return false;
+
+	for (size_t i = 0; i < left.size(); ++i)
+	{
+		unsigned char a = static_cast<unsigned char>(left[i]);
+		unsigned char b = static_cast<unsigned char>(right[i]);
+		if (a >= 'A' && a <= 'Z')
+			a = static_cast<unsigned char>(a + ('a' - 'A'));
+		if (b >= 'A' && b <= 'Z')
+			b = static_cast<unsigned char>(b + ('a' - 'A'));
+		if (a != b)
+			return false;
+	}
+
+	return true;
+}

--- a/XInputBridge/XInputBridge.vcxproj
+++ b/XInputBridge/XInputBridge.vcxproj
@@ -290,6 +290,7 @@
     <ClInclude Include="GlobalState.h" />
     <ClInclude Include="Macros.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="ScopeGuard.h" />
     <ClInclude Include="Types.h" />
     <ClInclude Include="UniUtil.h" />
     <ClInclude Include="XInputBridge.h" />

--- a/XInputBridge/XInputBridge.vcxproj.filters
+++ b/XInputBridge/XInputBridge.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ScopeGuard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="UniUtil.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/XInputBridge/vcpkg.json
+++ b/XInputBridge/vcpkg.json
@@ -6,7 +6,6 @@
   "supports": "!(arm | uwp)",
   "dependencies": [
     { "name": "hidapi" },
-    { "name": "abseil" },
     { "name": "winreg" }
   ]
 }


### PR DESCRIPTION
…/tool restore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Performance**
  * Improved build caching for dependencies, tools, and compiled components.
  * Reduced unnecessary compilation when cached artifacts are available.
  * Streamlined version stamping and application publishing during builds.

* **Maintenance**
  * Simplified resource cleanup and text comparison handling for improved runtime consistency.
  * Removed an unused third-party dependency from the project.
  * Added local tooling support for automated version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->