### PR TITLE
Expand NuGet package paths in PowerShell before pushing.

### DIFF
--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -74,8 +74,16 @@ jobs:
           user: Nefarius
 
       - name: 'Push package'
-        run: >
-          dotnet nuget push artifacts/*.nupkg
-          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
-          --source https://api.nuget.org/v3/index.json
-          --skip-duplicate
+        shell: pwsh
+        run: |
+          $packages = Get-ChildItem -LiteralPath artifacts -Filter *.nupkg -File
+          if (-not $packages) {
+            throw 'No .nupkg files found under artifacts/.'
+          }
+          foreach ($package in $packages) {
+            dotnet nuget push $package.FullName `
+              --api-key ${{ steps.login.outputs.NUGET_API_KEY }} `
+              --source https://api.nuget.org/v3/index.json `
+              --skip-duplicate
+            if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          }


### PR DESCRIPTION
pwsh does not expand artifacts/*.nupkg, so the publish job must enumerate the files explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NuGet package publishing reliability by validating that packages are available before publishing.
  * Publishing now reports failures accurately when an individual package upload does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->