### PR TITLE
Strip HTML images from the SDK README before packing for NuGet.

### DIFF
--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: 'Modify README.md for NuGet'
+        shell: bash
+        run: |
+          sed -i 's/# <img[^>]*>/# /' SDK/Nefarius.DsHidMini.IPC/README.md
+
       - name: 'Pack'
         run: dotnet pack SDK/Nefarius.DsHidMini.IPC -c Release -o artifacts
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated NuGet packaging to remove image markup from the SDK README before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->