### PR TITLE
Show BthPS3 install and version status in ControlApp.

### DIFF
--- a/ControlApp/App.xaml.cs
+++ b/ControlApp/App.xaml.cs
@@ -84,6 +84,7 @@ public partial class App
 
             services.AddSingleton<DshmDevMan>();
             services.AddSingleton<DshmConfigManager>();
+            services.AddSingleton<BthPS3StatusService>();
 
             services.AddSingleton<DevicesPage>();
             services.AddSingleton<DevicesViewModel>();

--- a/ControlApp/Models/Drivers/BthPS3Setup.cs
+++ b/ControlApp/Models/Drivers/BthPS3Setup.cs
@@ -64,10 +64,16 @@ internal static class BthPS3Setup
     public static Version? SetupVersion => ReadSetupRegistryVersion("Version");
 
     /// <summary>
-    ///     True when the profile driver version meets the DsHidMini minimum.
+    ///     Best available installed version: profile driver, then setup package, then filter driver.
+    /// </summary>
+    public static Version? InstalledVersion =>
+        ProfileDriverVersion ?? SetupVersion ?? FilterDriverVersion;
+
+    /// <summary>
+    ///     True when the resolved installed version meets the DsHidMini minimum.
     /// </summary>
     public static bool IsVersionSupported =>
-        ProfileDriverVersion is { } version && version >= MinimumSupportedVersion;
+        InstalledVersion is { } version && version >= MinimumSupportedVersion;
 
     private static Version? ReadFileVersion(string path)
     {

--- a/ControlApp/Models/Drivers/BthPS3Setup.cs
+++ b/ControlApp/Models/Drivers/BthPS3Setup.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using System.IO;
+
+using Microsoft.Win32;
+
+namespace Nefarius.DsHidMini.ControlApp.Models.Drivers;
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal static class BthPS3Setup
+{
+    public static readonly Version MinimumSupportedVersion = new(2, 0, 144);
+
+    private const string ServiceKeyPath = @"SYSTEM\CurrentControlSet\Services\BthPS3";
+
+    private const string SetupKeyPath =
+        @"Software\Nefarius Software Solutions e.U.\Nefarius BthPS3 Bluetooth Drivers";
+
+    private static string ProfileDriverPath =>
+        Path.Combine(Environment.SystemDirectory, "drivers", "BthPS3.sys");
+
+    private static string FilterDriverPath =>
+        Path.Combine(Environment.SystemDirectory, "drivers", "BthPS3PSM.sys");
+
+    /// <summary>
+    ///     True if the BthPS3 profile service or driver file is present.
+    /// </summary>
+    public static bool IsInstalled
+    {
+        get
+        {
+            try
+            {
+                if (File.Exists(ProfileDriverPath))
+                {
+                    return true;
+                }
+
+                using RegistryKey? key = RegistryHelpers.GetRegistryKey(ServiceKeyPath);
+                return key is not null;
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Warning(ex, "Failed to determine whether BthPS3 is installed.");
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     File version of BthPS3.sys, falling back to the installer registry value.
+    /// </summary>
+    public static Version? ProfileDriverVersion =>
+        ReadFileVersion(ProfileDriverPath) ?? ReadSetupRegistryVersion("DriverVersion");
+
+    /// <summary>
+    ///     File version of BthPS3PSM.sys, falling back to the installer registry value.
+    /// </summary>
+    public static Version? FilterDriverVersion =>
+        ReadFileVersion(FilterDriverPath) ?? ReadSetupRegistryVersion("FilterVersion");
+
+    /// <summary>
+    ///     BthPS3 setup package version from the Nefarius installer registry key.
+    /// </summary>
+    public static Version? SetupVersion => ReadSetupRegistryVersion("Version");
+
+    /// <summary>
+    ///     True when the profile driver version meets the DsHidMini minimum.
+    /// </summary>
+    public static bool IsVersionSupported =>
+        ProfileDriverVersion is { } version && version >= MinimumSupportedVersion;
+
+    private static Version? ReadFileVersion(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            FileVersionInfo info = FileVersionInfo.GetVersionInfo(path);
+            if (info.FileMajorPart == 0 && info.FileMinorPart == 0 && info.FileBuildPart == 0)
+            {
+                return null;
+            }
+
+            return new Version(info.FileMajorPart, info.FileMinorPart, info.FileBuildPart);
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to read file version from {Path}.", path);
+            return null;
+        }
+    }
+
+    private static Version? ReadSetupRegistryVersion(string valueName)
+    {
+        try
+        {
+            using RegistryKey? key = RegistryHelpers.GetRegistryKey(SetupKeyPath);
+            object? value = key?.GetValue(valueName);
+            if (value is null)
+            {
+                return null;
+            }
+
+            return Version.TryParse(value.ToString(), out Version? version) ? version : null;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to read BthPS3 setup registry value {ValueName}.", valueName);
+            return null;
+        }
+    }
+}

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -90,6 +90,28 @@ public class AppSnackbarMessagesService
         );
     }
 
+    public void ShowBthPS3SettingsRectifiedMessage()
+    {
+        _snackbarService.Show(
+            "BthPS3 settings updated",
+            "PSM patching is enabled and RAW PDO is disabled.",
+            ControlAppearance.Success,
+            new SymbolIcon(SymbolRegular.CheckmarkCircle24),
+            TimeSpan.FromSeconds(3)
+        );
+    }
+
+    public void ShowBthPS3SettingsRectifyFailedMessage()
+    {
+        _snackbarService.Show(
+            "Failed to update BthPS3 settings",
+            "Run as Administrator and confirm BthPS3 is installed.",
+            ControlAppearance.Danger,
+            new SymbolIcon(SymbolRegular.DismissCircle24),
+            TimeSpan.FromSeconds(5)
+        );
+    }
+
     public void ShowPowerCyclingDeviceMessage(bool isWireless, bool isAppElevated, bool reconnectionResult)
     {
         if (!isWireless && !isAppElevated)

--- a/ControlApp/Services/BthPS3StatusService.cs
+++ b/ControlApp/Services/BthPS3StatusService.cs
@@ -1,0 +1,273 @@
+using Nefarius.DsHidMini.ControlApp.Models.Drivers;
+using Nefarius.Utilities.Bluetooth;
+
+using Wpf.Ui.Controls;
+
+namespace Nefarius.DsHidMini.ControlApp.Services;
+
+/// <summary>
+///     Aggregates BthPS3 install, version, and configuration state for the ControlApp UI.
+/// </summary>
+public partial class BthPS3StatusService : ObservableObject
+{
+    [ObservableProperty]
+    private bool _areSettingsIncorrect;
+
+    [ObservableProperty]
+    private bool _canRectifySettings;
+
+    [ObservableProperty]
+    private bool _hasProblem;
+
+    [ObservableProperty]
+    private Version? _installedVersion;
+
+    [ObservableProperty]
+    private string _installedVersionDisplay = "Unknown";
+
+    [ObservableProperty]
+    private bool _isElevated;
+
+    [ObservableProperty]
+    private bool _isFilterAvailable;
+
+    [ObservableProperty]
+    private bool _isInstalled;
+
+    [ObservableProperty]
+    private bool _isPsmPatchingEnabled;
+
+    [ObservableProperty]
+    private bool _isPsmStateKnown;
+
+    [ObservableProperty]
+    private bool _isRadioOperable;
+
+    [ObservableProperty]
+    private bool _isRawPdoDisabled;
+
+    [ObservableProperty]
+    private bool _isVersionSupported;
+
+    [ObservableProperty]
+    private string _psmPatchingDisplay = "Unknown";
+
+    [ObservableProperty]
+    private string _rawPdoDisplay = "Unknown";
+
+    [ObservableProperty]
+    private string _requiredVersionDisplay = BthPS3Setup.MinimumSupportedVersion.ToString();
+
+    [ObservableProperty]
+    private InfoBarSeverity _severity = InfoBarSeverity.Informational;
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private string _statusTitle = string.Empty;
+
+    public BthPS3StatusService()
+    {
+        Refresh();
+    }
+
+    /// <summary>
+    ///     Re-reads radio, install, version, PSM, and RawPDO state.
+    /// </summary>
+    public void Refresh()
+    {
+        IsElevated = SecurityUtil.IsElevated;
+
+        try
+        {
+            IsRadioOperable = HostRadio.IsOperable;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to query Bluetooth radio state.");
+            IsRadioOperable = false;
+        }
+
+        IsInstalled = BthPS3Setup.IsInstalled;
+        InstalledVersion = BthPS3Setup.ProfileDriverVersion
+                           ?? BthPS3Setup.SetupVersion
+                           ?? BthPS3Setup.FilterDriverVersion;
+        IsVersionSupported = InstalledVersion is { } version &&
+                             version >= BthPS3Setup.MinimumSupportedVersion;
+
+        try
+        {
+            IsFilterAvailable = BthPS3FilterDriver.IsFilterAvailable;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to query BthPS3 filter availability.");
+            IsFilterAvailable = false;
+        }
+
+        IsPsmStateKnown = false;
+        IsPsmPatchingEnabled = false;
+        if (IsElevated && IsFilterAvailable)
+        {
+            try
+            {
+                IsPsmPatchingEnabled = BthPS3FilterDriver.IsFilterEnabled;
+                IsPsmStateKnown = true;
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Warning(ex, "Failed to query BthPS3 PSM patching state.");
+            }
+        }
+
+        try
+        {
+            IsRawPdoDisabled = !BthPS3ProfileDriver.RawPDO;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to query BthPS3 RawPDO setting.");
+            IsRawPdoDisabled = true;
+        }
+
+        InstalledVersionDisplay = InstalledVersion?.ToString() ?? (IsInstalled ? "Unknown" : "Not installed");
+        RequiredVersionDisplay = BthPS3Setup.MinimumSupportedVersion.ToString();
+        PsmPatchingDisplay = !IsPsmStateKnown
+            ? IsElevated ? "Unknown" : "Unknown (run as Administrator)"
+            : IsPsmPatchingEnabled
+                ? "Enabled"
+                : "Disabled";
+        RawPdoDisplay = IsRawPdoDisabled ? "Disabled" : "Enabled";
+
+        AreSettingsIncorrect = IsInstalled && IsVersionSupported && IsFilterAvailable &&
+                               (!IsRawPdoDisabled || (IsPsmStateKnown && !IsPsmPatchingEnabled));
+        CanRectifySettings = IsElevated && AreSettingsIncorrect;
+
+        ApplyStatus();
+    }
+
+    /// <summary>
+    ///     Disables RawPDO and enables PSM patching, then refreshes status.
+    /// </summary>
+    public bool TryRectifySettings()
+    {
+        if (!IsElevated)
+        {
+            return false;
+        }
+
+        try
+        {
+            BthPS3ProfileDriver.RawPDO = false;
+            BthPS3FilterDriver.IsFilterEnabled = true;
+            Refresh();
+            return !AreSettingsIncorrect;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Error(ex, "Failed to rectify BthPS3 settings.");
+            Refresh();
+            return false;
+        }
+    }
+
+    private void ApplyStatus()
+    {
+        if (!IsRadioOperable)
+        {
+            SetStatus(
+                false,
+                InfoBarSeverity.Informational,
+                "No Bluetooth radio detected",
+                "Turn on Bluetooth (with the default Windows drivers) to use wireless controllers.");
+            return;
+        }
+
+        if (!IsInstalled)
+        {
+            SetStatus(
+                true,
+                InfoBarSeverity.Error,
+                "BthPS3 is not installed",
+                "Install BthPS3 to use DualShock 3 controllers over Bluetooth.");
+            return;
+        }
+
+        if (InstalledVersion is { Major: < 2 })
+        {
+            SetStatus(
+                true,
+                InfoBarSeverity.Error,
+                "Incompatible BthPS3 version 1.x detected",
+                $"DsHidMini requires BthPS3 {BthPS3Setup.MinimumSupportedVersion} or newer. Uninstall BthPS3 v1 and install a current release.");
+            return;
+        }
+
+        if (InstalledVersion is { } outdated && outdated < BthPS3Setup.MinimumSupportedVersion)
+        {
+            SetStatus(
+                true,
+                InfoBarSeverity.Warning,
+                $"BthPS3 {outdated} is outdated",
+                $"Update BthPS3 to {BthPS3Setup.MinimumSupportedVersion} or newer.");
+            return;
+        }
+
+        if (InstalledVersion is null)
+        {
+            SetStatus(
+                true,
+                InfoBarSeverity.Warning,
+                "BthPS3 version could not be determined",
+                $"Could not read the installed BthPS3 version. DsHidMini requires {BthPS3Setup.MinimumSupportedVersion} or newer.");
+            return;
+        }
+
+        if (!IsFilterAvailable)
+        {
+            SetStatus(
+                true,
+                InfoBarSeverity.Warning,
+                "PSM filter driver not loaded",
+                "BthPS3 is installed but the PSM filter is not available. Bluetooth may be off, or BthPS3PSM failed to load.");
+            return;
+        }
+
+        if (AreSettingsIncorrect)
+        {
+            SetStatus(
+                true,
+                InfoBarSeverity.Warning,
+                "BthPS3 settings need correcting",
+                IsElevated
+                    ? "PSM patching is disabled and/or RAW PDO is enabled. Use Fix settings to apply the required values."
+                    : "PSM patching is disabled and/or RAW PDO is enabled. Restart as Administrator to fix them.");
+            return;
+        }
+
+        if (!IsElevated && !IsPsmStateKnown)
+        {
+            SetStatus(
+                false,
+                InfoBarSeverity.Informational,
+                "BthPS3 is installed",
+                "Run as Administrator to verify PSM patching and change BthPS3 settings.");
+            return;
+        }
+
+        SetStatus(
+            false,
+            InfoBarSeverity.Success,
+            "BthPS3 is installed and configured correctly",
+            $"Version {InstalledVersion} meets the minimum requirement of {BthPS3Setup.MinimumSupportedVersion}.");
+    }
+
+    private void SetStatus(bool hasProblem, InfoBarSeverity severity, string title, string message)
+    {
+        HasProblem = hasProblem;
+        Severity = severity;
+        StatusTitle = title;
+        StatusMessage = message;
+    }
+}

--- a/ControlApp/Services/BthPS3StatusService.cs
+++ b/ControlApp/Services/BthPS3StatusService.cs
@@ -67,11 +67,6 @@ public partial class BthPS3StatusService : ObservableObject
     [ObservableProperty]
     private string _statusTitle = string.Empty;
 
-    public BthPS3StatusService()
-    {
-        Refresh();
-    }
-
     /// <summary>
     ///     Re-reads radio, install, version, PSM, and RawPDO state.
     /// </summary>
@@ -90,11 +85,8 @@ public partial class BthPS3StatusService : ObservableObject
         }
 
         IsInstalled = BthPS3Setup.IsInstalled;
-        InstalledVersion = BthPS3Setup.ProfileDriverVersion
-                           ?? BthPS3Setup.SetupVersion
-                           ?? BthPS3Setup.FilterDriverVersion;
-        IsVersionSupported = InstalledVersion is { } version &&
-                             version >= BthPS3Setup.MinimumSupportedVersion;
+        InstalledVersion = BthPS3Setup.InstalledVersion;
+        IsVersionSupported = BthPS3Setup.IsVersionSupported;
 
         try
         {

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -7,6 +7,7 @@ using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Models.Util.Web;
 using Nefarius.DsHidMini.ControlApp.Services;
 using Nefarius.DsHidMini.ControlApp.ViewModels.UserControls;
+using Nefarius.DsHidMini.ControlApp.Views.Pages;
 
 using Wpf.Ui;
 using Wpf.Ui.Abstractions.Controls;
@@ -25,6 +26,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
     private readonly DshmConfigManager _dshmConfigManager;
 
     private readonly DshmDevMan _dshmDevMan;
+    private readonly INavigationService _navigationService;
     private int _refreshGeneration;
 
     /// <summary>
@@ -45,7 +47,9 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
         DshmConfigManager dshmConfigManager,
         AppSnackbarMessagesService appSnackbarMessagesService,
         IContentDialogService contentDialogService,
-        AddressValidator addressValidator
+        AddressValidator addressValidator,
+        BthPS3StatusService bthPs3,
+        INavigationService navigationService
     )
     {
         _dshmDevMan = dshmDevMan;
@@ -55,8 +59,12 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
         _dshmConfigManager.DshmConfigurationUpdated += OnDshmConfigUpdated;
         _contentDialogService = contentDialogService;
         _addressValidator = addressValidator;
+        BthPs3 = bthPs3;
+        _navigationService = navigationService;
         RefreshDevicesList();
     }
+
+    public BthPS3StatusService BthPs3 { get; }
 
 
     /// <summary>
@@ -73,6 +81,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
     {
         Log.Logger.Debug(
             "Navigating to Devices page. Refreshing dynamic properties of each connected Device ViewModel.");
+        BthPs3.Refresh();
         foreach (DeviceViewModel device in Devices)
         {
             await device.RefreshDeviceSettings();
@@ -93,6 +102,12 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
     private void OnConnectedDevicesListUpdated(object? obj, EventArgs? eventArgs)
     {
         RefreshDevicesList();
+    }
+
+    [RelayCommand]
+    private void GoToBthPs3Settings()
+    {
+        _navigationService.Navigate(typeof(SettingsPage));
     }
 
     private void OnDshmConfigUpdated(object? obj, EventArgs? eventArgs)
@@ -195,6 +210,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
             int generation = Interlocked.Increment(ref _refreshGeneration);
             try
             {
+                BthPs3.Refresh();
                 string? selectedAddress = SelectedDevice?.DeviceAddress;
                 SelectedDevice = null;
                 List<DeviceViewModel> previous = Devices.ToList();
@@ -294,35 +310,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
         }
     }
 
-    public bool IsFilterAvailable => IsElevated && BthPS3FilterDriver.IsFilterAvailable;
-
-    public bool IsFilterUnavailable => IsElevated && !BthPS3FilterDriver.IsFilterAvailable;
-
-    public bool IsFilterEnabled
-    {
-        get => IsElevated && BthPS3FilterDriver.IsFilterEnabled;
-        set => BthPS3FilterDriver.IsFilterEnabled = value;
-    }
-
-    public bool IsRawPDODisabled => !BthPS3ProfileDriver.RawPDO;
-
-    public bool AreBthPS3SettingsCorrect =>
-        IsElevated && !BthPS3ProfileDriver.RawPDO && BthPS3FilterDriver.IsFilterEnabled;
-
-    public bool AreBthPS3SettingsIncorrect =>
-        IsElevated && (BthPS3ProfileDriver.RawPDO || !BthPS3FilterDriver.IsFilterEnabled);
-
     public bool IsPressureMutingSupported => IsEditable && SelectedDevice.IsPressureMutingSupported;
-
-    public event PropertyChangedEventHandler PropertyChanged;
-
-    public void RefreshProperties()
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IsFilterEnabled"));
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IsRawPDODisabled"));
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("AreBthPS3SettingsIncorrect"));
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("AreBthPS3SettingsCorrect"));
-    }
     */
 }
 

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -210,7 +210,6 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
             int generation = Interlocked.Increment(ref _refreshGeneration);
             try
             {
-                BthPs3.Refresh();
                 string? selectedAddress = SelectedDevice?.DeviceAddress;
                 SelectedDevice = null;
                 List<DeviceViewModel> previous = Devices.ToList();

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -2,6 +2,7 @@
 
 using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
+using Nefarius.DsHidMini.ControlApp.Services;
 
 using Wpf.Ui.Abstractions.Controls;
 using Wpf.Ui.Appearance;
@@ -10,6 +11,7 @@ namespace Nefarius.DsHidMini.ControlApp.ViewModels.Pages;
 
 public partial class SettingsViewModel : ObservableObject, INavigationAware
 {
+    private readonly AppSnackbarMessagesService _appSnackbarMessagesService;
     private readonly DshmConfigManager _dshmConfigManager;
 
     [ObservableProperty]
@@ -20,10 +22,17 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     private bool _isInitialized;
 
-    public SettingsViewModel(DshmConfigManager dshmConfigManager)
+    public SettingsViewModel(
+        DshmConfigManager dshmConfigManager,
+        BthPS3StatusService bthPs3,
+        AppSnackbarMessagesService appSnackbarMessagesService)
     {
         _dshmConfigManager = dshmConfigManager;
+        BthPs3 = bthPs3;
+        _appSnackbarMessagesService = appSnackbarMessagesService;
     }
+
+    public BthPS3StatusService BthPs3 { get; }
 
     /// <summary>
     ///     When enabled (default), the driver requests a self restart on a HID mode mismatch instead of requiring a
@@ -84,6 +93,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             InitializeViewModel();
         }
 
+        BthPs3.Refresh();
+
         return Task.CompletedTask;
     }
 
@@ -132,6 +143,25 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
                 CurrentTheme = ApplicationTheme.Dark;
 
                 break;
+        }
+    }
+
+    [RelayCommand]
+    private void RefreshBthPs3()
+    {
+        BthPs3.Refresh();
+    }
+
+    [RelayCommand]
+    private void RectifyBthPs3Settings()
+    {
+        if (BthPs3.TryRectifySettings())
+        {
+            _appSnackbarMessagesService.ShowBthPS3SettingsRectifiedMessage();
+        }
+        else
+        {
+            _appSnackbarMessagesService.ShowBthPS3SettingsRectifyFailedMessage();
         }
     }
 }

--- a/ControlApp/ViewModels/Windows/MainWindowViewModel.cs
+++ b/ControlApp/ViewModels/Windows/MainWindowViewModel.cs
@@ -130,13 +130,5 @@ public partial class MainWindowViewModel : ObservableObject
             }
         }
     }
-
-    public void RefreshProperties()
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IsFilterEnabled"));
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IsRawPDODisabled"));
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("AreBthPS3SettingsIncorrect"));
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("AreBthPS3SettingsCorrect"));
-    }
     */
 }

--- a/ControlApp/Views/Pages/DevicesPage.xaml
+++ b/ControlApp/Views/Pages/DevicesPage.xaml
@@ -20,7 +20,24 @@
     <Page.Resources>
         <DataTemplate x:Key="MyKey_DeviceStatusSummary" DataType="{x:Type viewuserctrls:DeviceUserControl}" />
     </Page.Resources>
-    <Grid VerticalAlignment="Stretch">
+    <DockPanel>
+        <StackPanel
+            Margin="0,0,0,8"
+            DockPanel.Dock="Top"
+            Visibility="{Binding ViewModel.BthPs3.HasProblem, Converter={StaticResource BoolToVis_TV_FC}}">
+            <ui:InfoBar
+                Title="{Binding ViewModel.BthPs3.StatusTitle}"
+                IsClosable="False"
+                IsOpen="True"
+                Message="{Binding ViewModel.BthPs3.StatusMessage}"
+                Severity="{Binding ViewModel.BthPs3.Severity}" />
+            <ui:Button
+                Margin="0,4,0,0"
+                HorizontalAlignment="Left"
+                Command="{Binding ViewModel.GoToBthPs3SettingsCommand}"
+                Content="Details" />
+        </StackPanel>
+        <Grid VerticalAlignment="Stretch">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="250" />
             <ColumnDefinition Width="*" />
@@ -200,4 +217,5 @@
 
 
     </Grid>
+    </DockPanel>
 </Page>

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -18,7 +18,7 @@
     <Page.Resources>
     </Page.Resources>
 
-    <Grid>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="20">
             <CheckBox
                 Margin="0,0,0,8"
@@ -38,6 +38,52 @@
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                 Text="When enabled, Minimize and Close hide ControlApp to the notification area. Open the window from the tray icon, or choose Exit to quit."
                 TextWrapping="Wrap" />
+
+            <ui:TextBlock
+                Margin="0,28,0,8"
+                FontTypography="Subtitle"
+                Text="Bluetooth (BthPS3)" />
+            <ui:InfoBar
+                Title="{Binding ViewModel.BthPs3.StatusTitle}"
+                IsClosable="False"
+                IsOpen="True"
+                Message="{Binding ViewModel.BthPs3.StatusMessage}"
+                Severity="{Binding ViewModel.BthPs3.Severity}" />
+            <TextBlock
+                Margin="0,12,0,4"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="{Binding ViewModel.BthPs3.InstalledVersionDisplay, StringFormat=Installed version: {0}}" />
+            <TextBlock
+                Margin="0,0,0,4"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="{Binding ViewModel.BthPs3.RequiredVersionDisplay, StringFormat=Required version: {0}+}" />
+            <TextBlock
+                Margin="0,0,0,4"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="{Binding ViewModel.BthPs3.PsmPatchingDisplay, StringFormat=PSM patching: {0}}" />
+            <TextBlock
+                Margin="0,0,0,12"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="{Binding ViewModel.BthPs3.RawPdoDisplay, StringFormat=RAW PDO: {0}}" />
+            <StackPanel Margin="0,0,0,8" Orientation="Horizontal">
+                <ui:Button
+                    Margin="0,0,8,0"
+                    Command="{Binding ViewModel.RectifyBthPs3SettingsCommand}"
+                    Content="Fix settings"
+                    IsEnabled="{Binding ViewModel.BthPs3.CanRectifySettings}" />
+                <ui:Button Command="{Binding ViewModel.RefreshBthPs3Command}" Content="Refresh" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal">
+                <ui:HyperlinkButton
+                    Margin="0,0,8,0"
+                    Content="Download BthPS3"
+                    Icon="{ui:SymbolIcon ArrowDownload24}"
+                    NavigateUri="https://github.com/nefarius/BthPS3/releases/latest" />
+                <ui:HyperlinkButton
+                    Content="Open online help"
+                    Icon="{ui:SymbolIcon QuestionCircle24}"
+                    NavigateUri="https://docs.nefarius.at/projects/BthPS3/" />
+            </StackPanel>
         </StackPanel>
-    </Grid>
+    </ScrollViewer>
 </Page>


### PR DESCRIPTION
Makes Bluetooth troubleshooting visible when BthPS3 is missing, outdated, or misconfigured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Bluetooth PS3 driver status monitoring, including installation, version, patching, and device-state details.
  - Added status alerts and a dedicated Bluetooth PS3 settings section with refresh and repair actions.
  - Added links to download BthPS3 and access online help.
  - Added success and failure notifications for settings repair.
  - Added navigation from the Devices page to Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->