### PR TITLE
Allow dragging ControlApp profiles to reorder the list.

### DIFF
--- a/ControlApp.Tests/ProfileReorderTests.cs
+++ b/ControlApp.Tests/ProfileReorderTests.cs
@@ -1,0 +1,90 @@
+using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class ProfileReorderTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "dshm-tests-" + Guid.NewGuid().ToString("N"));
+
+    public ProfileReorderTests()
+    {
+        Directory.CreateDirectory(UserDir);
+        Directory.CreateDirectory(DriverDir);
+        ProfileData.DefaultProfile.Settings.ResetToDefault();
+    }
+
+    private string UserDir => Path.Combine(_root, "ControlApp");
+    private string DriverDir => Path.Combine(_root, "DsHidMini");
+
+    public void Dispose()
+    {
+        ProfileData.DefaultProfile.Settings.ResetToDefault();
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void MoveUserProfile_ReordersDisplayList_WithDefaultPinned()
+    {
+        DshmConfigManager manager = CreateManager();
+        ProfileData first = manager.CreateProfile("First");
+        ProfileData second = manager.CreateProfile("Second");
+        ProfileData third = manager.CreateProfile("Third");
+
+        Assert.True(manager.MoveUserProfile(third, 0));
+
+        List<ProfileData> list = manager.GetListOfProfilesWithDefault();
+        Assert.Same(ProfileData.DefaultProfile, list[0]);
+        Assert.Equal(third.ProfileGuid, list[1].ProfileGuid);
+        Assert.Equal(first.ProfileGuid, list[2].ProfileGuid);
+        Assert.Equal(second.ProfileGuid, list[3].ProfileGuid);
+    }
+
+    [Fact]
+    public void MoveUserProfile_PersistsOrder_AcrossSaveAndReload()
+    {
+        DshmConfigLocations locations = new(UserDir, DriverDir);
+        DshmConfigManager manager = new(locations);
+        ProfileData first = manager.CreateProfile("First");
+        ProfileData second = manager.CreateProfile("Second");
+        ProfileData third = manager.CreateProfile("Third");
+        Assert.True(manager.MoveUserProfile(third, 0));
+        manager.SaveChanges();
+
+        DshmConfigManager reloaded = new(locations);
+        List<ProfileData> list = reloaded.GetListOfProfilesWithDefault();
+        Assert.Same(ProfileData.DefaultProfile, list[0]);
+        Assert.Equal(third.ProfileGuid, list[1].ProfileGuid);
+        Assert.Equal("Third", list[1].ProfileName);
+        Assert.Equal(first.ProfileGuid, list[2].ProfileGuid);
+        Assert.Equal(second.ProfileGuid, list[3].ProfileGuid);
+    }
+
+    [Fact]
+    public void MoveUserProfile_NoOps_ForDefaultUnknownAndUnchangedIndex()
+    {
+        DshmConfigManager manager = CreateManager();
+        ProfileData first = manager.CreateProfile("First");
+        ProfileData second = manager.CreateProfile("Second");
+        List<Guid> original = manager.GetListOfProfilesWithDefault().Select(p => p.ProfileGuid).ToList();
+
+        Assert.False(manager.MoveUserProfile(ProfileData.DefaultProfile, 0));
+        Assert.False(manager.MoveUserProfile(new ProfileData { ProfileName = "Missing" }, 0));
+        Assert.False(manager.MoveUserProfile(first, 0));
+        Assert.False(manager.MoveUserProfile(second, -1));
+        Assert.False(manager.MoveUserProfile(second, 99));
+
+        Assert.Equal(original, manager.GetListOfProfilesWithDefault().Select(p => p.ProfileGuid));
+    }
+
+    private DshmConfigManager CreateManager() =>
+        new(new DshmConfigLocations(UserDir, DriverDir));
+}

--- a/ControlApp/Helpers/ListViewReorderBehavior.cs
+++ b/ControlApp/Helpers/ListViewReorderBehavior.cs
@@ -1,0 +1,260 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Nefarius.DsHidMini.ControlApp.Helpers;
+
+public interface IListReorderable
+{
+    bool CanReorder { get; }
+}
+
+public sealed class ListViewReorderRequest
+{
+    public ListViewReorderRequest(object item, int newIndex)
+    {
+        Item = item;
+        NewIndex = newIndex;
+    }
+
+    public object Item { get; }
+
+    public int NewIndex { get; }
+}
+
+/// <summary>
+///     Drag-and-drop reorder for a <see cref="ListBox" />. Index 0 is treated as pinned and is not a valid drop target.
+/// </summary>
+public static class ListViewReorderBehavior
+{
+    public static readonly DependencyProperty IsEnabledProperty = DependencyProperty.RegisterAttached(
+        "IsEnabled",
+        typeof(bool),
+        typeof(ListViewReorderBehavior),
+        new PropertyMetadata(false, OnIsEnabledChanged));
+
+    public static readonly DependencyProperty ReorderCommandProperty = DependencyProperty.RegisterAttached(
+        "ReorderCommand",
+        typeof(ICommand),
+        typeof(ListViewReorderBehavior),
+        new PropertyMetadata(null));
+
+    private static readonly DependencyProperty DragStateProperty = DependencyProperty.RegisterAttached(
+        "DragState",
+        typeof(DragState),
+        typeof(ListViewReorderBehavior),
+        new PropertyMetadata(null));
+
+    private const string DragFormat = "ControlApp.ListViewReorder";
+
+    public static bool GetIsEnabled(DependencyObject obj) => (bool)obj.GetValue(IsEnabledProperty);
+
+    public static void SetIsEnabled(DependencyObject obj, bool value) => obj.SetValue(IsEnabledProperty, value);
+
+    public static ICommand? GetReorderCommand(DependencyObject obj) =>
+        (ICommand?)obj.GetValue(ReorderCommandProperty);
+
+    public static void SetReorderCommand(DependencyObject obj, ICommand? value) =>
+        obj.SetValue(ReorderCommandProperty, value);
+
+    private static void OnIsEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ListBox listBox)
+        {
+            return;
+        }
+
+        Detach(listBox);
+        if (e.NewValue is true)
+        {
+            Attach(listBox);
+        }
+    }
+
+    private static void Attach(ListBox listBox)
+    {
+        listBox.AllowDrop = true;
+        DragState state = new();
+        listBox.SetValue(DragStateProperty, state);
+
+        listBox.PreviewMouseLeftButtonDown += OnPreviewMouseLeftButtonDown;
+        listBox.PreviewMouseMove += OnPreviewMouseMove;
+        listBox.PreviewMouseLeftButtonUp += OnPreviewMouseLeftButtonUp;
+        listBox.DragOver += OnDragOver;
+        listBox.Drop += OnDrop;
+    }
+
+    private static void Detach(ListBox listBox)
+    {
+        listBox.PreviewMouseLeftButtonDown -= OnPreviewMouseLeftButtonDown;
+        listBox.PreviewMouseMove -= OnPreviewMouseMove;
+        listBox.PreviewMouseLeftButtonUp -= OnPreviewMouseLeftButtonUp;
+        listBox.DragOver -= OnDragOver;
+        listBox.Drop -= OnDrop;
+        listBox.ClearValue(DragStateProperty);
+    }
+
+    private static void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not ListBox listBox || GetDragState(listBox) is not DragState state)
+        {
+            return;
+        }
+
+        object? item = GetItemFromSource(listBox, e.OriginalSource as DependencyObject);
+        if (item is null || !CanReorder(item))
+        {
+            state.Reset();
+            return;
+        }
+
+        state.DragItem = item;
+        state.StartPoint = e.GetPosition(listBox);
+    }
+
+    private static void OnPreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (sender is not ListBox listBox
+            || e.LeftButton != MouseButtonState.Pressed
+            || GetDragState(listBox) is not { DragItem: { } item } state)
+        {
+            return;
+        }
+
+        Point current = e.GetPosition(listBox);
+        Vector delta = current - state.StartPoint;
+        if (Math.Abs(delta.X) < SystemParameters.MinimumHorizontalDragDistance
+            && Math.Abs(delta.Y) < SystemParameters.MinimumVerticalDragDistance)
+        {
+            return;
+        }
+
+        state.Reset();
+        DataObject data = new(DragFormat, item);
+        DragDrop.DoDragDrop(listBox, data, DragDropEffects.Move);
+    }
+
+    private static void OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is ListBox listBox)
+        {
+            GetDragState(listBox)?.Reset();
+        }
+    }
+
+    private static void OnDragOver(object sender, DragEventArgs e)
+    {
+        e.Effects = e.Data.GetDataPresent(DragFormat) ? DragDropEffects.Move : DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private static void OnDrop(object sender, DragEventArgs e)
+    {
+        if (sender is not ListBox listBox || e.Data.GetData(DragFormat) is not { } item || !CanReorder(item))
+        {
+            return;
+        }
+
+        int? newIndex = GetTargetIndex(listBox, item, e.GetPosition(listBox));
+        if (newIndex is null)
+        {
+            return;
+        }
+
+        ICommand? command = GetReorderCommand(listBox);
+        ListViewReorderRequest request = new(item, newIndex.Value);
+        if (command?.CanExecute(request) == true)
+        {
+            command.Execute(request);
+        }
+
+        e.Handled = true;
+    }
+
+    private static int? GetTargetIndex(ListBox listBox, object draggedItem, Point position)
+    {
+        int sourceIndex = listBox.Items.IndexOf(draggedItem);
+        if (sourceIndex < 0)
+        {
+            return null;
+        }
+
+        int insertIndex = Math.Max(1, GetInsertionIndex(listBox, position));
+        int newIndex = insertIndex > sourceIndex ? insertIndex - 1 : insertIndex;
+        if (newIndex < 1)
+        {
+            newIndex = 1;
+        }
+
+        if (newIndex >= listBox.Items.Count)
+        {
+            newIndex = listBox.Items.Count - 1;
+        }
+
+        return newIndex == sourceIndex ? null : newIndex;
+    }
+
+    private static int GetInsertionIndex(ListBox listBox, Point position)
+    {
+        for (int i = 0; i < listBox.Items.Count; i++)
+        {
+            if (listBox.ItemContainerGenerator.ContainerFromIndex(i) is not FrameworkElement container)
+            {
+                continue;
+            }
+
+            Point topLeft = container.TransformToAncestor(listBox).Transform(new Point(0, 0));
+            if (position.Y < topLeft.Y + container.ActualHeight / 2)
+            {
+                return i;
+            }
+        }
+
+        return listBox.Items.Count;
+    }
+
+    private static object? GetItemFromSource(ListBox listBox, DependencyObject? origin)
+    {
+        if (origin is null)
+        {
+            return null;
+        }
+
+        DependencyObject? container = ItemsControl.ContainerFromElement(listBox, origin);
+        if (container is not null)
+        {
+            return listBox.ItemContainerGenerator.ItemFromContainer(container);
+        }
+
+        while (origin is not null)
+        {
+            if (origin is ListBoxItem listBoxItem)
+            {
+                return listBox.ItemContainerGenerator.ItemFromContainer(listBoxItem);
+            }
+
+            origin = VisualTreeHelper.GetParent(origin);
+        }
+
+        return null;
+    }
+
+    private static bool CanReorder(object item) =>
+        item is IListReorderable reorderable && reorderable.CanReorder;
+
+    private static DragState? GetDragState(ListBox listBox) =>
+        listBox.GetValue(DragStateProperty) as DragState;
+
+    private sealed class DragState
+    {
+        public object? DragItem { get; set; }
+
+        public Point StartPoint { get; set; }
+
+        public void Reset()
+        {
+            DragItem = null;
+            StartPoint = default;
+        }
+    }
+}

--- a/ControlApp/Models/DshmConfigManager/DshmConfigManager.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfigManager.cs
@@ -225,6 +225,41 @@ public class DshmConfigManager
         FixDevicesWithBlankProfiles();
     }
 
+    /// <summary>
+    ///     Moves a user profile to <paramref name="targetIndex" /> in the user-profile list (Default excluded).
+    /// </summary>
+    /// <returns>
+    ///     <see langword="true" /> if the list changed; otherwise <see langword="false" />.
+    /// </returns>
+    public bool MoveUserProfile(ProfileData profile, int targetIndex)
+    {
+        if (profile == ProfileData.DefaultProfile || profile.ProfileGuid == ProfileData.DefaultGuid)
+        {
+            Log.Logger.Debug("Default profile cannot be reordered.");
+            return false;
+        }
+
+        int currentIndex = _userData.Profiles.FindIndex(existing => existing.ProfileGuid == profile.ProfileGuid);
+        if (currentIndex < 0)
+        {
+            Log.Logger.Debug("Profile '{ProfileGuid}' is not in the user profile list.", profile.ProfileGuid);
+            return false;
+        }
+
+        if (targetIndex < 0 || targetIndex >= _userData.Profiles.Count || targetIndex == currentIndex)
+        {
+            return false;
+        }
+
+        ProfileData item = _userData.Profiles[currentIndex];
+        _userData.Profiles.RemoveAt(currentIndex);
+        _userData.Profiles.Insert(targetIndex, item);
+        Log.Logger.Information(
+            "Moved profile '{ProfileName}' ({ProfileGuid}) from {FromIndex} to {ToIndex}.",
+            item.ProfileName, item.ProfileGuid, currentIndex, targetIndex);
+        return true;
+    }
+
     public SettingsContext GetDeviceExpectedHidMode(DeviceData dev) =>
         ResolveEffectiveSettings(dev).HidMode.SettingsContext;
 

--- a/ControlApp/ViewModels/Pages/ProfilesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/ProfilesViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Nefarius.DsHidMini.ControlApp.Models;
+﻿using Nefarius.DsHidMini.ControlApp.Helpers;
+using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Services;
 using Nefarius.DsHidMini.ControlApp.ViewModels.UserControls;
@@ -66,6 +67,8 @@ public partial class ProfilesViewModel : ObservableObject, INavigationAware
 
     private void UpdateProfileList()
     {
+        Guid? selectedGuid = SelectedProfileVM?.ProfileData.ProfileGuid;
+
         Log.Logger.Debug("Rebuilding profiles' ViewModels.");
         List<ProfileViewModel> newList = new();
         foreach (ProfileData prof in ProfilesDatas)
@@ -75,6 +78,11 @@ public partial class ProfilesViewModel : ObservableObject, INavigationAware
 
         ProfilesViewModels = newList;
         UpdateGlobalProfileCheck();
+
+        if (selectedGuid is Guid guid)
+        {
+            SelectedProfileVM = ProfilesViewModels.FirstOrDefault(vm => vm.ProfileData.ProfileGuid == guid);
+        }
     }
 
     private void UpdateGlobalProfileCheck()
@@ -153,6 +161,24 @@ public partial class ProfilesViewModel : ObservableObject, INavigationAware
         {
             _appSnackbarMessagesService.ShowDsHidMiniConfigurationUpdateFailedMessage();
         }
+        UpdateProfileList();
+    }
+
+    [RelayCommand]
+    private void ReorderProfile(ListViewReorderRequest? request)
+    {
+        if (request?.Item is not ProfileViewModel profileVm || !profileVm.CanReorder)
+        {
+            return;
+        }
+
+        int userIndex = request.NewIndex - 1;
+        if (!_dshmConfigManager.MoveUserProfile(profileVm.ProfileData, userIndex))
+        {
+            return;
+        }
+
+        _dshmConfigManager.SaveChanges();
         UpdateProfileList();
     }
 }

--- a/ControlApp/ViewModels/UserControls/ProfileViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/ProfileViewModel.cs
@@ -1,9 +1,10 @@
-﻿using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
+﻿using Nefarius.DsHidMini.ControlApp.Helpers;
+using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Services;
 
 namespace Nefarius.DsHidMini.ControlApp.ViewModels.UserControls;
 
-public partial class ProfileViewModel : ObservableObject
+public partial class ProfileViewModel : ObservableObject, IListReorderable
 {
     private readonly AppSnackbarMessagesService _appSnackbarMessagesService;
     private readonly DshmConfigManager _dshmConfigManager;
@@ -28,6 +29,8 @@ public partial class ProfileViewModel : ObservableObject
     }
 
     public ProfileData ProfileData { get; }
+
+    public bool CanReorder => ProfileData != ProfileData.DefaultProfile;
 
     public bool IsEditEnabled
     {

--- a/ControlApp/Views/Pages/ProfilesPage.xaml
+++ b/ControlApp/Views/Pages/ProfilesPage.xaml
@@ -105,6 +105,8 @@
             <ui:ListView
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
+                helpers:ListViewReorderBehavior.IsEnabled="True"
+                helpers:ListViewReorderBehavior.ReorderCommand="{Binding ViewModel.ReorderProfileCommand}"
                 DockPanel.Dock="Top"
                 ItemsSource="{Binding ViewModel.ProfilesViewModels}"
                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
@@ -120,15 +122,24 @@
                                     <RowDefinition Height="30" />
                                 </Grid.RowDefinitions>
                                 <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="5*" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
+                                <ui:SymbolIcon
+                                    Width="16"
+                                    Height="16"
+                                    VerticalAlignment="Center"
+                                    Opacity="0.6"
+                                    Symbol="ReOrderDotsVertical24"
+                                    Visibility="{Binding CanReorder, Converter={StaticResource BoolToVis}}" />
                                 <ui:TextBlock
-                                    Margin="10,0,0,0"
+                                    Grid.Column="1"
+                                    Margin="6,0,0,0"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
                                     Text="{Binding Name}" />
-                                <ui:SymbolIcon Grid.Column="1" Symbol="Globe24">
+                                <ui:SymbolIcon Grid.Column="2" Symbol="Globe24">
                                     <ui:SymbolIcon.Style>
                                         <Style TargetType="ui:SymbolIcon">
                                             <Setter Property="Visibility" Value="Hidden" />


### PR DESCRIPTION
Newly added profiles were stuck at the bottom. Persist the new order in user data and keep the Default profile pinned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop reordering for user profiles.
  * The default profile remains pinned and cannot be reordered.
  * Profile order is saved and restored across application reloads.
  * Added visual reorder handles and updated profile list layout.
* **Bug Fixes**
  * The selected profile remains selected when the list refreshes.
  * Invalid or unchanged reorder requests are safely ignored.
* **Tests**
  * Added coverage for profile reordering, persistence, default-profile pinning, and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->