### PR TITLE
Unify LED handling behind driver/DsLed.c (issues #349, #350, #351, #365)

### DIFF
--- a/.cursor/plans/led-handling-unification.plan.md
+++ b/.cursor/plans/led-handling-unification.plan.md
@@ -9,7 +9,7 @@ todos:
     content: Add driver/DsLed.h and driver/DsLed.c with the authority check, effect constants, mode-aware battery mapping tables, lock-taking public entry points plus locked internals, DsLed_Apply/DsLed_Refresh and the charging animation; register in dshidmini.vcxproj, .filters and Trace.h
     status: pending
   - id: primitives
-    content: "Fix Ds3.c/Ds3.h: correct default effect blocks in the static output reports, drop the broken DS3_SET_LED_DURATION_DEFAULT and the dead DsUsb_Ds3IndicatorsOff, rename the ALL-CAPS LED functions"
+    content: "Fix Ds3.c/Ds3.h: correct default effect blocks in the static output reports, drop the broken DS3_SET_LED_DURATION_DEFAULT, rename the ALL-CAPS LED functions"
     status: pending
   - id: outputreport
     content: Split DSHM_SendOutputReport into a lock-taking public entry and an unlocked send helper; apply custom pattern in the locked send-prep path immediately before the report copy, only when DsLed_IsDriverInCharge
@@ -18,10 +18,10 @@ todos:
     content: Rewire DsBth.Timers.c, DsHidMiniDrv.c, Device.c and HID.Reports.c to the new DsLed API using the documented lock-ownership sequence; capture previous USB BatteryStatus before assigning, then write the property only on change; drop the dead LED-flags guard
     status: pending
   - id: config-power
-    content: Initialize LEDSettings.Authority in ConfigSetDefaults, align custom-pattern defaults, reset OutputReport.Mode on D0Entry, and also reset it to DriverHandled on hot-reload before DsLed_Refresh
+    content: Initialize LEDSettings.Authority in ConfigSetDefaults, align custom-pattern defaults, add an OutputReport.Mode reset to DriverHandled in DsHidMini_EvtDeviceD0Entry (none exists today), and also reset it on hot-reload before DsLed_Refresh
     status: pending
   - id: build
-    content: Build the driver (x64 Release) and review the resulting diff
+    content: Build the driver with NUKE (.\build.cmd Compile --configuration Release) and review the resulting diff
     status: pending
 isProject: false
 ---
@@ -63,7 +63,17 @@ flowchart TD
 6. **Wireless startup ignores both mode and authority.** `DsBth_EvtStartupDelayTimerFunc` always uses the single-LED mapping, so bar-graph users get the wrong display until the first battery change, and it writes LEDs even under `Application` authority.
 7. **Dead guard.** `if (DS3_GET_LED_FLAGS(pDevCtx) != 0x00)` in the Bluetooth battery handler can never be false, because `Device.c` seeds the Bluetooth buffer with `DS3_LED_OFF` (`0x20`).
 8. **Unsynchronized buffer access.** All of the above mutate the shared `OutputReportMemory` from USB/Bluetooth completion routines, the hot-reload thread-pool callback and the HID write path, while `OutputReport.Lock` is only held inside `DSHM_SendOutputReport`.
-9. **Minor.** `DsUsb_Ds3IndicatorsOff` is dead code; `ConfigSetDefaults` never initializes `LEDSettings.Authority`; `Device.c:678` uses the Bluetooth-specific `DS3_BTH_SET_LED` instead of the connection-agnostic setter; the four-LED effect magic numbers `(0xFF, 15, 127, 127)` and `(0xFF, 3, 127, 127)` are repeated across three files.
+9. **Minor.** `ConfigSetDefaults` never initializes `LEDSettings.Authority` (it only works today because the device context is zero-initialized and `0 == DsLEDAuthorityAutomatic`); `Device.c:678` uses the Bluetooth-specific `DS3_BTH_SET_LED` instead of the connection-agnostic setter; the slow-flash effect `(0xFF, 15, 127, 127)` is repeated across three files (`DsBth.Timers.c`, `DsHidMiniDrv.c`, `HID.Reports.c`) and the fast-flash effect `(0xFF, 3, 127, 127)` four times in `HID.Reports.c`.
+
+## Plan review (2026-09-06)
+
+All bug claims above were re-verified against the current `master` source and issues 349, 350, 351 and 365. Corrections made to the original draft:
+
+- `DsUsb_Ds3IndicatorsOff` does not exist anywhere in the repository; the "delete dead code" item was removed.
+- `DsHidMini_EvtDeviceD0Entry` ([driver/Power.c](../../driver/Power.c)) has **no** `OutputReport.Mode` reset today; the draft claimed one already existed. The reset is a new addition, applied in both D0Entry and the hot-reload callback.
+- Verification must go through NUKE (`.\build.cmd`), not raw `msbuild`, per workspace rules.
+- `DsLed_Apply` needs a defined behavior for `DsBatteryStatusCharging` (reachable via hot-reload while charging on USB); see section 1.
+- ControlApp only ever writes `Automatic` or `Driver` authority (`DshmTranslationUtils.cs:139-140`), so making `Application` strict only affects hand-edited JSON configs.
 
 ## Decisions already taken
 
@@ -71,7 +81,7 @@ flowchart TD
 - `DsLEDAuthorityApplication` becomes strict: the driver never touches LEDs. Only `Automatic` keeps the current start-in-driver-mode handoff.
 - Authority is checked per mutator: charging/apply/refresh require `DsLed_IsDriverInCharge`; `DsLed_SetFlagsAndEffects` does not.
 - Battery-to-flags tables stay mode-aware (single-LED vs bar-graph).
-- Hot-reload resets `OutputReport.Mode` to `DriverHandled` before refresh; D0Entry already does the same and stays unchanged.
+- Hot-reload resets `OutputReport.Mode` to `DriverHandled` before refresh, and D0Entry gets the same reset (neither exists today; the mode is currently latched to `WriteReportPassThrough` for the lifetime of the device object).
 
 ## Approach
 
@@ -114,13 +124,13 @@ Lock ownership (one sequence, no re-acquire on the same path):
 - returns immediately unless `DsLed_IsDriverInCharge`
 - for `DsLEDModeCustomPattern`, writes `CustomPatterns.LEDFlags` and the four configured blocks (also re-applied in locked send-prep immediately before the report copy, still gated by `DsLed_IsDriverInCharge`, so rumble/HID sends cannot drop a driver-owned custom pattern — issue 350)
 - for the two battery-indicator modes, applies a **mode-aware** mapping from `Context->BatteryStatus` (not one shared table). Separate entries for `None`, `Low`/`Dying`, `Medium`, `High`, and `Charged`/`Full` in both `DsLEDModeBatteryIndicatorPlayerIndex` (single LED 1–4) and `DsLEDModeBatteryIndicatorBarGraph` (fill 1 / 1–2 / 1–3 / 1–4), so bar-graph startup never receives single-LED flags. `Low`/`Dying` use `DS3_LED_EFFECT_SLOW_FLASH`; other known levels use `DS3_LED_EFFECT_STATIC`; `None` leaves flags at `DS3_LED_OFF`
+- for `DsBatteryStatusCharging` (USB only, reachable on hot-reload mid-charge) it leaves the flag byte untouched so the running animation frame survives, and only normalizes the effect blocks (static for lit LEDs, zero for unlit); `DsLed_AdvanceChargingAnimation` keeps owning the flag byte in that state
 - zeroes the effect block of every LED whose flag bit is clear, per the issue 351 discussion and matching what ControlApp already writes
 
 ### 2. Fix the primitives in [driver/Ds3.c](../../driver/Ds3.c) / [driver/Ds3.h](../../driver/Ds3.h)
 
 - Change the static `G_Ds3UsbHidOutputReport` / `G_Ds3BthHidOutputReport` LED blocks from `FF 27 10 00 32` to `FF 00 01 00 01`, and seed both with `DS3_LED_OFF` consistently.
 - Replace `DS3_SET_LED_DURATION_DEFAULT` (whose `0x27` is the truncated-`0x2710` bug) with `DsLed_SetFlagsAndEffects(..., DS3_LED_EFFECT_STATIC)`.
-- Delete the unused `DsUsb_Ds3IndicatorsOff`.
 - Rename the ALL-CAPS pseudo-macro functions to the driver's normal convention (`DsLed_SetFlags`, `DsLed_GetFlags`, `DsLed_SetEffect`, `Ds3_GetUnifiedOutputReportBuffer`, `Ds3_GetRawOutputReportBuffer`), keeping the genuinely-macro `DS3_USB_SET_LED` family as-is.
 
 ### 3. Rewire the call sites
@@ -129,10 +139,10 @@ Lock ownership (one sequence, no re-acquire on the same path):
 - [driver/DsHidMiniDrv.c](../../driver/DsHidMiniDrv.c): both battery handlers call `DsLed_Refresh`; the charging animation calls `DsLed_AdvanceChargingAnimation`. In the USB handler, capture `previous = pDevCtx->BatteryStatus`, assign `pDevCtx->BatteryStatus = battery` unconditionally, then write the battery property only when `previous != battery` (fixes bug 5). Drop the dead `DS3_GET_LED_FLAGS() != 0x00` guard (bug 7).
 - [driver/OutputReport.c](../../driver/OutputReport.c): lock-taking `DSHM_SendOutputReport` runs locked send-prep (custom pattern if `DsLed_IsDriverInCharge` and mode is custom, immediately before the copy), then the unlocked enqueue helper. After that prep, the send itself is a pure copy of the current buffer.
 - [driver/Device.c](../../driver/Device.c): use the connection-agnostic setter for the initial fill. In `DsDevice_HotReloadEventCallback`, reset `OutputReport.Mode` to `Ds3OutputReportModeDriverHandled` **before** `DsLed_Refresh(...)` so Automatic authority is restored and the new LED settings apply (fixes bug 4 / issue 349).
-- [driver/HID.Reports.c](../../driver/HID.Reports.c): replace both `Authority == / != DsLEDAuthorityDriver` checks with `!DsLed_IsDriverInCharge` / `DsLed_IsDriverInCharge`, and swap the repeated four-call `DS3_SET_LED_DURATION_DEFAULT` blocks for `DsLed_SetFlagsAndEffects` (no authority guard inside that helper).
+- [driver/HID.Reports.c](../../driver/HID.Reports.c): replace both `Authority == / != DsLEDAuthorityDriver` checks with `!DsLed_IsDriverInCharge` / `DsLed_IsDriverInCharge`, and swap the repeated four-call `DS3_SET_LED_DURATION_DEFAULT` blocks for `DsLed_SetFlagsAndEffects` (no authority guard inside that helper). Keep the existing order: `OutputReport.Mode = WriteReportPassThrough` is assigned (lines 281, 343) **before** the check, so under `Automatic` the first app write hands off exactly as today, while `Driver` still preserves the 21-byte LED block on SIXAXIS pass-through.
 - [driver/Configuration.c](../../driver/Configuration.c): set `Config->LEDSettings.Authority = DsLEDAuthorityAutomatic` explicitly in `ConfigSetDefaults`, and align the custom-pattern defaults with `DS3_LED_EFFECT_STATIC`.
-- [driver/Power.c](../../driver/Power.c): reset `OutputReport.Mode` to `Ds3OutputReportModeDriverHandled` in `DsHidMini_EvtDeviceD0Entry` so the Automatic handoff is per power cycle rather than permanent. Leave this D0Entry reset as-is; the extra hot-reload reset lives only in the Device.c callback above.
+- [driver/Power.c](../../driver/Power.c): **add** a reset of `OutputReport.Mode` to `Ds3OutputReportModeDriverHandled` in `DsHidMini_EvtDeviceD0Entry` (next to the existing `InputReportDropLogged` / `HidModeRestartRequested` re-arms) so the Automatic handoff is per power cycle rather than permanent. No such reset exists today.
 
 ### 4. Verification
 
-`msbuild dshidmini.sln` for x64 (Release) to confirm the driver still compiles; there is no test harness on the driver side, so the remaining validation is manual on hardware. Work happens on a new `fix/351-unify-led-handling` branch off `master`.
+Build through NUKE per workspace rules: `.\build.cmd Compile --configuration Release` (local builds compile the solution's default platform; `BuildDmf` runs first automatically). There is no test harness on the driver side, so the remaining validation is manual on hardware. Work happens on a new `fix/351-unify-led-handling` branch off `master`.

--- a/driver/Configuration.c
+++ b/driver/Configuration.c
@@ -1076,6 +1076,15 @@ ConfigSetDefaults(
 	Config->RumbleSettings.AlternativeMode.ToggleButtonCombo.Buttons[2] = DS3_BUTTON_COMBO_OFFSET_PS;
 
 	Config->LEDSettings.Mode = DsLEDModeBatteryIndicatorPlayerIndex;
+
+	//
+	// Explicit default (issue #351 minor): this previously relied on the
+	// device context being zero-initialized, since DsLEDAuthorityAutomatic
+	// happens to be 0. Spelling it out here makes the default independent
+	// of that coincidence.
+	// 
+	Config->LEDSettings.Authority = DsLEDAuthorityAutomatic;
+
 	Config->LEDSettings.CustomPatterns.LEDFlags = DS3_LED_1;
 
 	const PDS_LED pPlayerSlots[] =
@@ -1086,6 +1095,10 @@ ConfigSetDefaults(
 		&Config->LEDSettings.CustomPatterns.Player4,
 	};
 
+	//
+	// Matches DS3_LED_EFFECT_STATIC from DsLed.h (the PS3-correct static
+	// effect, issue #365).
+	// 
 	for (ULONGLONG playerIndex = 0; playerIndex < _countof(pPlayerSlots); playerIndex++)
 	{
 		pPlayerSlots[playerIndex]->TotalDuration = 0xFF;

--- a/driver/Device.c
+++ b/driver/Device.c
@@ -673,9 +673,12 @@ DsDevice_InitContext(
 		);
 
 		//
-		// Turn flashing LEDs off
+		// Turn flashing LEDs off. Uses the connection-agnostic setter
+		// (ConnectionType is already assigned above) instead of the
+		// Bluetooth-specific macro, so this matches the USB path and
+		// DsLed's own primitives.
 		// 
-		DS3_BTH_SET_LED(outReportBuffer, DS3_LED_OFF);
+		DsLed_SetFlags(pDevCtx, DS3_LED_OFF);
 
 #pragma region StartupDelay
 
@@ -1052,9 +1055,24 @@ DsDevice_HotReloadEventCallback(
 		}
 
 		//
-		// Changes to LED settings need to be pushed to the device
+		// Restore the Automatic authority hand-off for this reload before
+		// recomputing LED state: without this, OutputReport.Mode would stay
+		// latched at whatever an application last wrote (or its power-up
+		// default), and DsLed_IsDriverInCharge would never allow the new
+		// LED settings below to actually apply under Automatic authority
+		// (issue #349/#351).
 		// 
-		(void)DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverHighPriority);
+		pDevCtx->OutputReport.Mode = Ds3OutputReportModeDriverHandled;
+
+		//
+		// Changes to LED settings need to be pushed to the device. Unlike
+		// the previous plain DSHM_SendOutputReport call, DsLed_Refresh
+		// recomputes flags/effects from the newly loaded configuration and
+		// current battery status first, so a hot-reload into e.g. a
+		// different LED mode actually takes effect immediately instead of
+		// re-sending the stale pattern (issue #349).
+		// 
+		(void)DsLed_Refresh(pDevCtx, Ds3OutputReportSourceDriverHighPriority);
 
 	} while (FALSE);
 

--- a/driver/Driver.h
+++ b/driver/Driver.h
@@ -39,6 +39,7 @@
 #include "Power.h"
 #include "DsUsb.h"
 #include "Ds3.h"
+#include "DsLed.h"
 #include "DsBth.h"
 #include "HID.ReportHandlers.h"
 

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -10,10 +10,18 @@ const UCHAR G_Ds3UsbHidOutputReport[] = {
 	0x01, /* Report ID */
 	0x00, 0xFF, 0x00, 0xFF, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
+	//
+	// LED flags byte (offset 10) starts off (see issue #351); the four
+	// 5-byte effect blocks below use the PS3-correct static effect
+	// (FF.00.01.00.01, see issue #365) rather than the previous
+	// FF.27.10.00.32, which is meaningless since no LED flag is set here
+	// anyway - DsLed_Apply/DsLed_SetFlagsAndEffects normalize both flags
+	// and effect blocks together before anything is ever sent.
+	// 
+	0xFF, 0x00, 0x01, 0x00, 0x01,
+	0xFF, 0x00, 0x01, 0x00, 0x01,
+	0xFF, 0x00, 0x01, 0x00, 0x01,
+	0xFF, 0x00, 0x01, 0x00, 0x01,
 	0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
@@ -27,10 +35,16 @@ const UCHAR G_Ds3BthHidOutputReport[] = {
 	0x01, /* Report ID */
 	0x00, 0xFF, 0x00, 0xFF, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
-	0xFF, 0x27, 0x10, 0x00, 0x32,
+	//
+	// See G_Ds3UsbHidOutputReport above (issues #351 and #365); LED flags
+	// byte (offset 11) starts off and is seeded to DS3_LED_OFF explicitly
+	// in Device.c right after this buffer is copied in, so both connection
+	// types are consistent from the very first output report.
+	// 
+	0xFF, 0x00, 0x01, 0x00, 0x01,
+	0xFF, 0x00, 0x01, 0x00, 0x01,
+	0xFF, 0x00, 0x01, 0x00, 0x01,
+	0xFF, 0x00, 0x01, 0x00, 0x01,
 	0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
@@ -212,7 +226,7 @@ NTSTATUS DsUsb_Ds3Shutdown(PDEVICE_CONTEXT Context)
 // SET_REPORT, exactly like the PS3 itself does for the very first report
 // after enumeration and again right after enabling streaming (see issue
 // #321). Buffer must not include the report ID byte (Caller strips it, same
-// convention as DS3_GET_UNIFIED_OUTPUT_REPORT_BUFFER for USB).
+// convention as Ds3_GetUnifiedOutputReportBuffer for USB).
 // 
 NTSTATUS DsUsb_Ds3SendOutputReportControl(PDEVICE_CONTEXT Context, PUCHAR Buffer, ULONG BufferLength)
 {
@@ -923,7 +937,7 @@ NTSTATUS DsBth_Ds3SixaxisInit(PDEVICE_CONTEXT Context)
 //
 // Sets all properties for a specific Player LED
 // 
-VOID DS3_SET_LED_DURATION(
+VOID DsLed_SetEffect(
 	PDEVICE_CONTEXT Context,
 	UCHAR LedIndex,
 	UCHAR TotalDuration,
@@ -940,7 +954,7 @@ VOID DS3_SET_LED_DURATION(
 
 	PUCHAR buffer;
 
-	DS3_GET_UNIFIED_OUTPUT_REPORT_BUFFER(
+	Ds3_GetUnifiedOutputReportBuffer(
 		Context,
 		&buffer,
 		NULL
@@ -954,24 +968,9 @@ VOID DS3_SET_LED_DURATION(
 }
 
 //
-// Revert LED properties to default for a specific Player LED
-// 
-VOID DS3_SET_LED_DURATION_DEFAULT(PDEVICE_CONTEXT Context, UCHAR LedIndex)
-{
-	DS3_SET_LED_DURATION(
-		Context,
-		LedIndex,
-		0xFF, // Interval repeat never ends
-		0x27, // BasePortionDuration
-		0x00, // No OFF-portion
-		0x32 // Default ON-portion multiplier
-	);
-}
-
-//
 // Gets output report protocol-agnostic
 // 
-VOID DS3_GET_UNIFIED_OUTPUT_REPORT_BUFFER(
+VOID Ds3_GetUnifiedOutputReportBuffer(
 	PDEVICE_CONTEXT Context,
 	UCHAR** Buffer,
 	PSIZE_T BufferLength
@@ -1016,7 +1015,7 @@ VOID DS3_GET_UNIFIED_OUTPUT_REPORT_BUFFER(
 //
 // Gets output report without offset
 // 
-VOID DS3_GET_RAW_OUTPUT_REPORT_BUFFER(
+VOID Ds3_GetRawOutputReportBuffer(
 	PDEVICE_CONTEXT Context,
 	UCHAR** Buffer,
 	PSIZE_T BufferLength
@@ -1031,7 +1030,7 @@ VOID DS3_GET_RAW_OUTPUT_REPORT_BUFFER(
 //
 // Sets the LED flags byte
 // 
-VOID DS3_SET_LED_FLAGS(
+VOID DsLed_SetFlags(
 	PDEVICE_CONTEXT Context,
 	UCHAR Value
 )
@@ -1063,7 +1062,7 @@ VOID DS3_SET_LED_FLAGS(
 //
 // Gets the LED flags byte
 // 
-UCHAR DS3_GET_LED_FLAGS(
+UCHAR DsLed_GetFlags(
 	PDEVICE_CONTEXT Context
 )
 {

--- a/driver/Ds3.h
+++ b/driver/Ds3.h
@@ -62,7 +62,7 @@ typedef enum
 } DS3_BUTTON_COMBO_OFFSET;
 
 
-VOID DS3_SET_LED_DURATION(
+VOID DsLed_SetEffect(
 	PDEVICE_CONTEXT Context,
 	UCHAR LedIndex,
 	UCHAR TotalDuration,
@@ -71,29 +71,24 @@ VOID DS3_SET_LED_DURATION(
 	UCHAR OnPortionMultiplier
 );
 
-VOID DS3_SET_LED_DURATION_DEFAULT(
-	PDEVICE_CONTEXT Context,
-	UCHAR LedIndex
-);
-
-VOID DS3_GET_UNIFIED_OUTPUT_REPORT_BUFFER(
+VOID Ds3_GetUnifiedOutputReportBuffer(
 	PDEVICE_CONTEXT Context,
 	UCHAR** Buffer,
 	PSIZE_T BufferLength
 );
 
-VOID DS3_GET_RAW_OUTPUT_REPORT_BUFFER(
+VOID Ds3_GetRawOutputReportBuffer(
 	PDEVICE_CONTEXT Context,
 	UCHAR** Buffer,
 	PSIZE_T BufferLength
 );
 
-VOID DS3_SET_LED_FLAGS(
+VOID DsLed_SetFlags(
 	PDEVICE_CONTEXT Context,
 	UCHAR Value
 );
 
-UCHAR DS3_GET_LED_FLAGS(
+UCHAR DsLed_GetFlags(
 	PDEVICE_CONTEXT Context
 );
 

--- a/driver/DsBth.Timers.c
+++ b/driver/DsBth.Timers.c
@@ -44,41 +44,25 @@ DsBth_EvtStartupDelayTimerFunc(
 	}
 
 	//
-	// We have not yet received an input report from the remote device
+	// Apply LEDs (mode-aware, authority-checked - fixes issue #351 for the
+	// wireless startup path, which used to always use the single-LED
+	// mapping and write regardless of authority), set rumble durations and
+	// strength, then send - all under one hold of the lock so nothing can
+	// copy a half-updated buffer in between (fixes issue #351/bug 6).
 	// 
-	if (pDevCtx->BatteryStatus == DsBatteryStatusNone)
-	{
-		DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_OFF);
-	}
-	else
-	{
-		switch (pDevCtx->BatteryStatus)
-		{
-		case DsBatteryStatusCharged:
-		case DsBatteryStatusFull:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_4);
-			break;
-		case DsBatteryStatusHigh:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_3);
-			break;
-		case DsBatteryStatusMedium:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_2);
-			break;
-		case DsBatteryStatusLow:
-		case DsBatteryStatusDying:
-			DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-			DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
-			break;
-		default:
-			break;
-		}
-	}
-		
+	WdfWaitLockAcquire(pDevCtx->OutputReport.Lock, NULL);
+
+	DsLed_ApplyLocked(pDevCtx);
+
 	DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0xFE);
 	DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0xFE);
 	DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0x00);
 
-	if (!NT_SUCCESS(status = DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverHighPriority)))
+	status = DSHM_SendOutputReportUnlocked(pDevCtx, Ds3OutputReportSourceDriverHighPriority);
+
+	WdfWaitLockRelease(pDevCtx->OutputReport.Lock);
+
+	if (!NT_SUCCESS(status))
 	{
 		TraceError(
 			TRACE_DSBTH,

--- a/driver/DsHidMiniDrv.c
+++ b/driver/DsHidMiniDrv.c
@@ -841,16 +841,14 @@ VOID DsUsb_EvtUsbInterruptPipeReadComplete(
 	pDevCtx->BatteryStatus = battery;
 
 	//
-	// Check if state has changed to Charged
+	// If charging, cycle LEDs; on any other change, recompute the full LED
+	// state for the new status. Not just the Charged transition: some
+	// replica controllers report real battery levels over USB even while
+	// not actively drawing charge current (issue #365), so any change away
+	// from Charging needs the same LED refresh as a Charged transition
+	// gets.
 	// 
-	if (battery == DsBatteryStatusCharged && battery != previousBattery)
-	{
-		(void)DsLed_Refresh(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
-	}
-	//
-	// If charging, cycle LEDs
-	// 
-	else if (battery == DsBatteryStatusCharging)
+	if (battery == DsBatteryStatusCharging)
 	{
 		if (pDevCtx->Connection.Usb.ChargingCycleTimestamp.QuadPart == 0)
 		{
@@ -873,6 +871,10 @@ VOID DsUsb_EvtUsbInterruptPipeReadComplete(
 
 			DsLed_AdvanceChargingAnimation(pDevCtx);
 		}
+	}
+	else if (battery != previousBattery)
+	{
+		(void)DsLed_Refresh(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
 	}
 
 	DSHM_ProcessHidInputReport(pDevCtx, pInReport);
@@ -1021,6 +1023,15 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 			);
 
 			//
+			// Update battery status before refreshing LEDs: DsLed_Refresh's
+			// battery-to-flags mapping reads Context->BatteryStatus itself
+			// (not a local variable), so it must already reflect the new
+			// value or the LED mapping would be computed from the stale
+			// status.
+			// 
+			pDevCtx->BatteryStatus = battery;
+
+			//
 			// Push the new battery status to LEDs. The old guard here
 			// ("DS3_GET_LED_FLAGS(pDevCtx) != 0x00") was dead code (issue
 			// #351 bug 7): the Bluetooth output buffer is always seeded
@@ -1031,11 +1042,6 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 			// to live here.
 			// 
 			(void)DsLed_Refresh(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
-
-			//
-			// Update battery status
-			// 
-			pDevCtx->BatteryStatus = battery;
 		}
 	}
 

--- a/driver/DsHidMiniDrv.c
+++ b/driver/DsHidMiniDrv.c
@@ -804,9 +804,17 @@ VOID DsUsb_EvtUsbInterruptPipeReadComplete(
 	battery = (DS_BATTERY_STATUS)pInReport->BatteryStatus;
 
 	//
-	// Update battery status property
+	// Capture the previous value before it gets overwritten below, so both
+	// the property write and the Charged-transition check further down
+	// compare against the value that was actually in effect before this
+	// report (issue #351 bug 5).
 	// 
-	if (battery != pDevCtx->BatteryStatus)
+	const DS_BATTERY_STATUS previousBattery = pDevCtx->BatteryStatus;
+
+	//
+	// Update battery status property, only on an actual change
+	// 
+	if (battery != previousBattery)
 	{
 		WDF_DEVICE_PROPERTY_DATA propertyData;
 
@@ -823,38 +831,21 @@ VOID DsUsb_EvtUsbInterruptPipeReadComplete(
 		);
 	}
 
-	const PDS_LED_SETTINGS pLED = &pDevCtx->Configuration.LEDSettings;
+	//
+	// Always assign, regardless of which branch below runs. The Charging
+	// branch used to never do this, so the comparison above stayed
+	// "different" for the whole charging session and the persistent
+	// (registry-backed) property write above used to run on every single
+	// input report while charging (issue #351 bug 5).
+	// 
+	pDevCtx->BatteryStatus = battery;
 
 	//
 	// Check if state has changed to Charged
 	// 
-	if (battery == DsBatteryStatusCharged
-		&& battery != pDevCtx->BatteryStatus)
+	if (battery == DsBatteryStatusCharged && battery != previousBattery)
 	{
-		pDevCtx->BatteryStatus = battery;
-
-		if (
-			(pLED->Authority == DsLEDAuthorityDriver /* Driver wins over Automatic or Application */ ||
-				pDevCtx->OutputReport.Mode == Ds3OutputReportModeDriverHandled) &&
-			pLED->Mode > DsLEDModeUnknown && pLED->Mode < DsLEDModeCustomPattern
-			)
-		{
-			switch (pLED->Mode)
-			{
-			case DsLEDModeBatteryIndicatorPlayerIndex:
-
-				DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_4);
-
-				break;
-			case DsLEDModeBatteryIndicatorBarGraph:
-
-				DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
-
-				break;
-			}
-
-			(void)DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
-		}
+		(void)DsLed_Refresh(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
 	}
 	//
 	// If charging, cycle LEDs
@@ -880,58 +871,8 @@ VOID DsUsb_EvtUsbInterruptPipeReadComplete(
 			// 
 			pDevCtx->Connection.Usb.ChargingCycleTimestamp.QuadPart = 0;
 
-			UCHAR led = DS3_LED_OFF;
-
-			switch (pLED->Mode)
-			{
-			case DsLEDModeBatteryIndicatorPlayerIndex:
-
-				led = DS3_GET_LED_FLAGS(pDevCtx) << 1;
-
-			//
-			// Cycle through
-			// 
-				if (led > DS3_LED_4 || led < DS3_LED_1)
-				{
-					led = DS3_LED_1;
-				}
-
-				break;
-			case DsLEDModeBatteryIndicatorBarGraph:
-
-				led = DS3_GET_LED_FLAGS(pDevCtx);
-
-			//
-			// Cycle graph from 1 to 4 and repeat
-			// 
-				if (led & 0xF0)
-				{
-					led = DS3_LED_1;
-				}
-				else
-				{
-					led |= (!led) ? DS3_LED_1 : led << 1;
-				}
-
-				break;
-			}
-
-			if (
-				(pLED->Authority == DsLEDAuthorityDriver /* Driver wins over Automatic or Application */ ||
-					pDevCtx->OutputReport.Mode == Ds3OutputReportModeDriverHandled) &&
-				/* validate mode range */
-				pLED->Mode > DsLEDModeUnknown && pLED->Mode < DsLEDModeCustomPattern
-				)
-			{
-				DS3_SET_LED_FLAGS(pDevCtx, led);
-
-				(void)DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
-			}
+			DsLed_AdvanceChargingAnimation(pDevCtx);
 		}
-	}
-	else
-	{
-		pDevCtx->BatteryStatus = battery;
 	}
 
 	DSHM_ProcessHidInputReport(pDevCtx, pInReport);
@@ -1079,83 +1020,17 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 				&battery
 			);
 
-			const PDS_LED_SETTINGS pLED = &pDevCtx->Configuration.LEDSettings;
-
 			//
-			// Don't send update if not initialized yet or custom pattern
+			// Push the new battery status to LEDs. The old guard here
+			// ("DS3_GET_LED_FLAGS(pDevCtx) != 0x00") was dead code (issue
+			// #351 bug 7): the Bluetooth output buffer is always seeded
+			// with DS3_LED_OFF (0x20, non-zero) in Device.c, so this never
+			// evaluated to false. DsLed_Refresh does its own authority
+			// check and mode-aware battery mapping, replacing the
+			// copy-pasted authority guard and duplicated switch that used
+			// to live here.
 			// 
-			if (DS3_GET_LED_FLAGS(pDevCtx) != 0x00)
-			{
-				if (
-					(pLED->Authority == DsLEDAuthorityDriver /* Driver wins over Automatic or Application */ ||
-						pDevCtx->OutputReport.Mode == Ds3OutputReportModeDriverHandled) &&
-					/* validate mode range */
-					pLED->Mode > DsLEDModeUnknown && pLED->Mode < DsLEDModeCustomPattern
-					)
-				{
-					//
-					// Restore defaults to undo any (past) flashing animations
-					// 
-					DS3_SET_LED_DURATION_DEFAULT(pDevCtx, 0);
-					DS3_SET_LED_DURATION_DEFAULT(pDevCtx, 1);
-					DS3_SET_LED_DURATION_DEFAULT(pDevCtx, 2);
-					DS3_SET_LED_DURATION_DEFAULT(pDevCtx, 3);
-
-					switch (pLED->Mode)
-					{
-					case DsLEDModeBatteryIndicatorPlayerIndex:
-
-						switch (battery)
-						{
-						case DsBatteryStatusCharged:
-						case DsBatteryStatusFull:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_4);
-							break;
-						case DsBatteryStatusHigh:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_3);
-							break;
-						case DsBatteryStatusMedium:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_2);
-							break;
-						case DsBatteryStatusLow:
-						case DsBatteryStatusDying:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-							DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
-							break;
-						default:
-							break;
-						}
-
-						break;
-					case DsLEDModeBatteryIndicatorBarGraph:
-
-						switch (battery)
-						{
-						case DsBatteryStatusCharged:
-						case DsBatteryStatusFull:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
-							break;
-						case DsBatteryStatusHigh:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1 | DS3_LED_2 | DS3_LED_3);
-							break;
-						case DsBatteryStatusMedium:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1 | DS3_LED_2);
-							break;
-						case DsBatteryStatusLow:
-						case DsBatteryStatusDying:
-							DS3_SET_LED_FLAGS(pDevCtx, DS3_LED_1);
-							DS3_SET_LED_DURATION(pDevCtx, 0, 0xFF, 15, 127, 127);
-							break;
-						default:
-							break;
-						}
-
-						break;
-					}
-
-					(void)DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
-				}
-			}
+			(void)DsLed_Refresh(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
 
 			//
 			// Update battery status

--- a/driver/DsHidMiniDrv.h
+++ b/driver/DsHidMiniDrv.h
@@ -22,3 +22,18 @@ DSHM_SendOutputReport(
 	_In_ PDEVICE_CONTEXT Context,
 	_In_ DS_OUTPUT_REPORT_SOURCE Source
 );
+
+//
+// Same as DSHM_SendOutputReport, but assumes Context->OutputReport.Lock is
+// already held by the caller. Used by callers that must mutate the output
+// report buffer and send it without releasing the lock in between (see
+// DsLed.c and DsBth.Timers.c), so a concurrent writer can never be copied
+// into the wire buffer mid-update.
+// 
+_Must_inspect_result_
+_Success_(return == STATUS_SUCCESS)
+NTSTATUS
+DSHM_SendOutputReportUnlocked(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ DS_OUTPUT_REPORT_SOURCE Source
+);

--- a/driver/DsLed.c
+++ b/driver/DsLed.c
@@ -295,7 +295,15 @@ DsLed_Refresh(
 
 	DsLed_ApplyLocked(Context);
 
-	const NTSTATUS status = DSHM_SendOutputReportUnlocked(Context, Source);
+	//
+	// Match the no-op contract documented in DsLed.h: if the driver isn't
+	// in charge (e.g. Application authority), DsLed_ApplyLocked above was
+	// already a no-op, and sending here would just push out whatever
+	// application-owned report is already in the buffer, unrequested.
+	// 
+	const NTSTATUS status = DsLed_IsDriverInCharge(Context)
+		? DSHM_SendOutputReportUnlocked(Context, Source)
+		: STATUS_SUCCESS;
 
 	WdfWaitLockRelease(Context->OutputReport.Lock);
 

--- a/driver/DsLed.c
+++ b/driver/DsLed.c
@@ -1,0 +1,376 @@
+#include "Driver.h"
+#include "DsLed.tmh"
+
+
+//
+// Bit masks of the four physical LEDs, indexed 0 (LED 1 / lowest) to 3
+// (LED 4 / highest). Mirrors DS3_LED_1..DS3_LED_4 from Ds3.h.
+// 
+static const UCHAR G_DsLedBits[4] = { DS3_LED_1, DS3_LED_2, DS3_LED_3, DS3_LED_4 };
+
+
+//
+// Returns TRUE if the driver is currently allowed to write LED state.
+// See DsLed.h for the per-authority semantics.
+// 
+_Use_decl_annotations_
+BOOLEAN
+DsLed_IsDriverInCharge(
+	_In_ PDEVICE_CONTEXT Context
+)
+{
+	switch (Context->Configuration.LEDSettings.Authority)
+	{
+	case DsLEDAuthorityDriver:
+		return TRUE;
+
+	case DsLEDAuthorityApplication:
+		return FALSE;
+
+	case DsLEDAuthorityAutomatic:
+	default:
+		return Context->OutputReport.Mode == Ds3OutputReportModeDriverHandled;
+	}
+}
+
+//
+// Locked internal of DsLed_SetFlagsAndEffects; assumes
+// Context->OutputReport.Lock is already held.
+// 
+static
+VOID
+DsLedSetFlagsAndEffectsLocked(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ UCHAR Flags,
+	_In_ const DS_LED* Effect
+)
+{
+	static const DS_LED noEffect = DS3_LED_EFFECT_NONE;
+
+	DsLed_SetFlags(Context, Flags);
+
+	for (UCHAR ledIndex = 0; ledIndex < 4; ledIndex++)
+	{
+		const DS_LED* pEffect = (Flags & G_DsLedBits[ledIndex]) ? Effect : &noEffect;
+
+		DsLed_SetEffect(
+			Context,
+			ledIndex,
+			pEffect->TotalDuration,
+			pEffect->BasePortionDuration,
+			pEffect->OffPortionMultiplier,
+			pEffect->OnPortionMultiplier
+		);
+	}
+}
+
+//
+// Sets the LED flags byte and normalizes all four effect blocks against it.
+// Public, lock-taking entry point; see DsLed.h.
+// 
+_Use_decl_annotations_
+VOID
+DsLed_SetFlagsAndEffects(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ UCHAR Flags,
+	_In_ const DS_LED* Effect
+)
+{
+	FuncEntry(TRACE_LED);
+
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	DsLedSetFlagsAndEffectsLocked(Context, Flags, Effect);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	FuncExitNoReturn(TRACE_LED);
+}
+
+//
+// Writes the configured custom LED pattern (flags + four per-LED effect
+// blocks) into the output report buffer. Assumes
+// Context->OutputReport.Lock is already held; called both from
+// DsLed_Apply's DsLEDModeCustomPattern branch and from OutputReport.c's
+// locked send-prep immediately before every send (issue #350), so a
+// driver-owned custom pattern can never be silently overwritten by a
+// rumble-only or HID application send.
+// 
+_Use_decl_annotations_
+VOID
+DsLed_ApplyCustomPatternLocked(
+	_In_ PDEVICE_CONTEXT Context
+)
+{
+	const PDS_LED_SETTINGS pLed = &Context->Configuration.LEDSettings;
+
+	DsLed_SetFlags(Context, pLed->CustomPatterns.LEDFlags);
+
+	DsLed_SetEffect(
+		Context,
+		0,
+		pLed->CustomPatterns.Player1.TotalDuration,
+		pLed->CustomPatterns.Player1.BasePortionDuration,
+		pLed->CustomPatterns.Player1.OffPortionMultiplier,
+		pLed->CustomPatterns.Player1.OnPortionMultiplier
+	);
+	DsLed_SetEffect(
+		Context,
+		1,
+		pLed->CustomPatterns.Player2.TotalDuration,
+		pLed->CustomPatterns.Player2.BasePortionDuration,
+		pLed->CustomPatterns.Player2.OffPortionMultiplier,
+		pLed->CustomPatterns.Player2.OnPortionMultiplier
+	);
+	DsLed_SetEffect(
+		Context,
+		2,
+		pLed->CustomPatterns.Player3.TotalDuration,
+		pLed->CustomPatterns.Player3.BasePortionDuration,
+		pLed->CustomPatterns.Player3.OffPortionMultiplier,
+		pLed->CustomPatterns.Player3.OnPortionMultiplier
+	);
+	DsLed_SetEffect(
+		Context,
+		3,
+		pLed->CustomPatterns.Player4.TotalDuration,
+		pLed->CustomPatterns.Player4.BasePortionDuration,
+		pLed->CustomPatterns.Player4.OffPortionMultiplier,
+		pLed->CustomPatterns.Player4.OnPortionMultiplier
+	);
+}
+
+//
+// Mode-aware battery-to-flags mapping for the two battery-indicator modes.
+// Separate handling for DsLEDModeBatteryIndicatorPlayerIndex (single LED,
+// 1-4) and DsLEDModeBatteryIndicatorBarGraph (fill 1 / 1-2 / 1-3 / 1-4), so
+// bar-graph configurations never receive single-LED flags (issue #351).
+// Assumes Context->OutputReport.Lock is already held.
+// 
+static
+VOID
+DsLedApplyBatteryIndicatorLocked(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ BOOLEAN IsBarGraph
+)
+{
+	static const DS_LED staticEffect = DS3_LED_EFFECT_STATIC;
+	static const DS_LED slowFlashEffect = DS3_LED_EFFECT_SLOW_FLASH;
+
+	UCHAR flags;
+	const DS_LED* pEffect = &staticEffect;
+
+	switch (Context->BatteryStatus)
+	{
+	case DsBatteryStatusNone:
+	default:
+
+		//
+		// Unknown - all off, no effect matters since no flag bit is set.
+		// 
+		flags = DS3_LED_OFF;
+
+		break;
+
+	case DsBatteryStatusDying:
+	case DsBatteryStatusLow:
+
+		flags = DS3_LED_1;
+		pEffect = &slowFlashEffect;
+
+		break;
+
+	case DsBatteryStatusMedium:
+
+		flags = IsBarGraph ? (DS3_LED_1 | DS3_LED_2) : DS3_LED_2;
+
+		break;
+
+	case DsBatteryStatusHigh:
+
+		flags = IsBarGraph ? (DS3_LED_1 | DS3_LED_2 | DS3_LED_3) : DS3_LED_3;
+
+		break;
+
+	case DsBatteryStatusCharged:
+	case DsBatteryStatusFull:
+
+		flags = IsBarGraph ? (DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4) : DS3_LED_4;
+
+		break;
+
+	case DsBatteryStatusCharging:
+
+		//
+		// Leave the flag byte to DsLed_AdvanceChargingAnimation, which owns
+		// the cycling pattern while USB charging is in progress; only
+		// normalize the effect blocks against whatever flags are currently
+		// set, so a hot-reload mid-charge does not clobber the animation
+		// (issue #349).
+		// 
+		flags = DsLed_GetFlags(Context);
+
+		break;
+	}
+
+	DsLedSetFlagsAndEffectsLocked(Context, flags, pEffect);
+}
+
+//
+// Locked internal of DsLed_Apply; assumes Context->OutputReport.Lock is
+// already held. Also exposed publicly as DsLed_ApplyLocked; see DsLed.h.
+// 
+_Use_decl_annotations_
+VOID
+DsLed_ApplyLocked(
+	_In_ PDEVICE_CONTEXT Context
+)
+{
+	if (!DsLed_IsDriverInCharge(Context))
+	{
+		return;
+	}
+
+	switch (Context->Configuration.LEDSettings.Mode)
+	{
+	case DsLEDModeCustomPattern:
+
+		DsLed_ApplyCustomPatternLocked(Context);
+
+		break;
+
+	case DsLEDModeBatteryIndicatorPlayerIndex:
+
+		DsLedApplyBatteryIndicatorLocked(Context, FALSE);
+
+		break;
+
+	case DsLEDModeBatteryIndicatorBarGraph:
+
+		DsLedApplyBatteryIndicatorLocked(Context, TRUE);
+
+		break;
+
+	default:
+
+		break;
+	}
+}
+
+//
+// Recomputes LED flags/effects, does not send. Public, lock-taking entry
+// point; see DsLed.h.
+// 
+_Use_decl_annotations_
+VOID
+DsLed_Apply(
+	_In_ PDEVICE_CONTEXT Context
+)
+{
+	FuncEntry(TRACE_LED);
+
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	DsLed_ApplyLocked(Context);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	FuncExitNoReturn(TRACE_LED);
+}
+
+//
+// Recomputes LED flags/effects and sends the result, all under one hold of
+// Context->OutputReport.Lock. Public, lock-taking entry point; see DsLed.h.
+// 
+_Use_decl_annotations_
+NTSTATUS
+DsLed_Refresh(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ DS_OUTPUT_REPORT_SOURCE Source
+)
+{
+	FuncEntry(TRACE_LED);
+
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	DsLed_ApplyLocked(Context);
+
+	const NTSTATUS status = DSHM_SendOutputReportUnlocked(Context, Source);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	FuncExit(TRACE_LED, "status=%!STATUS!", status);
+
+	return status;
+}
+
+//
+// Advances the USB charging-cycle LED animation by one step and sends the
+// result. Public, lock-taking entry point; see DsLed.h.
+// 
+_Use_decl_annotations_
+VOID
+DsLed_AdvanceChargingAnimation(
+	_In_ PDEVICE_CONTEXT Context
+)
+{
+	FuncEntry(TRACE_LED);
+
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	do
+	{
+		if (!DsLed_IsDriverInCharge(Context))
+		{
+			break;
+		}
+
+		const DS_LED_MODE mode = Context->Configuration.LEDSettings.Mode;
+
+		if (mode != DsLEDModeBatteryIndicatorPlayerIndex
+			&& mode != DsLEDModeBatteryIndicatorBarGraph)
+		{
+			break;
+		}
+
+		UCHAR led = DsLed_GetFlags(Context);
+
+		if (mode == DsLEDModeBatteryIndicatorPlayerIndex)
+		{
+			//
+			// Cycle through single LEDs 1 -> 4 and repeat
+			// 
+			led <<= 1;
+
+			if (led > DS3_LED_4 || led < DS3_LED_1)
+			{
+				led = DS3_LED_1;
+			}
+		}
+		else
+		{
+			//
+			// Cycle bar-graph fill 1 -> 1-4 and repeat
+			// 
+			if (led & 0xF0)
+			{
+				led = DS3_LED_1;
+			}
+			else
+			{
+				led |= (!led) ? DS3_LED_1 : led << 1;
+			}
+		}
+
+		static const DS_LED staticEffect = DS3_LED_EFFECT_STATIC;
+
+		DsLedSetFlagsAndEffectsLocked(Context, led, &staticEffect);
+
+		(void)DSHM_SendOutputReportUnlocked(Context, Ds3OutputReportSourceDriverLowPriority);
+
+	} while (FALSE);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	FuncExitNoReturn(TRACE_LED);
+}

--- a/driver/DsLed.h
+++ b/driver/DsLed.h
@@ -1,0 +1,134 @@
+#pragma once
+
+//
+// Single policy module for every LED write in the driver (issue #351).
+// 
+// All LED state changes - authority checks, the battery-to-flags mapping and
+// the custom-pattern override - are decided here and nowhere else. Callers
+// that used to re-decide authority and duplicate the battery mapping now
+// call into this module instead; see driver/Ds3.c for the byte-level
+// primitives this module builds on (DsLed_SetFlags, DsLed_GetFlags,
+// DsLed_SetEffect).
+// 
+
+//
+// Named effect blocks (TotalDuration, BasePortionDuration,
+// OffPortionMultiplier, OnPortionMultiplier - see DS_LED in DsCommon.h),
+// replacing the scattered magic numbers that used to live in three
+// different files.
+// 
+
+//
+// PS3-correct static effect: lasts forever, no flashing. See issue #365;
+// ControlApp's DshmTranslationUtils.ApplyCustomLedPatterns uses the same
+// values for its non-custom defaults.
+// 
+#define DS3_LED_EFFECT_STATIC       { 0xFF, 0x0001, 0x00, 0x01 }
+
+//
+// Slow flash, used for Low/Dying battery levels. Same values as the
+// (0xFF, 15, 127, 127) magic numbers previously repeated in
+// DsBth.Timers.c, DsHidMiniDrv.c and HID.Reports.c.
+// 
+#define DS3_LED_EFFECT_SLOW_FLASH   { 0xFF, 0x000F, 0x7F, 0x7F }
+
+//
+// Fast flash, used by the DS4Windows high-latency warning indicator. Same
+// values as the (0xFF, 3, 127, 127) magic numbers previously repeated four
+// times in HID.Reports.c.
+// 
+#define DS3_LED_EFFECT_FAST_FLASH   { 0xFF, 0x0003, 0x7F, 0x7F }
+
+//
+// All-zero effect block, applied to every LED whose flag bit is not set.
+// 
+#define DS3_LED_EFFECT_NONE         { 0x00, 0x0000, 0x00, 0x00 }
+
+//
+// Returns TRUE if the driver is currently allowed to write LED state.
+// 
+//  - DsLEDAuthorityDriver:      always TRUE
+//  - DsLEDAuthorityApplication: always FALSE (issue #351)
+//  - DsLEDAuthorityAutomatic:   TRUE only while OutputReport.Mode is still
+//                               Ds3OutputReportModeDriverHandled, i.e. before
+//                               any application has written its own report
+// 
+BOOLEAN
+DsLed_IsDriverInCharge(
+	_In_ PDEVICE_CONTEXT Context
+);
+
+//
+// Recomputes LED flags/effects from the current configuration and battery
+// status and writes them into the output report buffer. Does not send
+// anything. No-op unless DsLed_IsDriverInCharge. Takes Context->OutputReport.Lock.
+// 
+VOID
+DsLed_Apply(
+	_In_ PDEVICE_CONTEXT Context
+);
+
+//
+// Same as DsLed_Apply, but assumes Context->OutputReport.Lock is already
+// held by the caller. Exposed for callers that must apply LEDs, touch other
+// buffer state (e.g. rumble) and send, all under one hold of the lock - see
+// DsBth_EvtStartupDelayTimerFunc, which follows exactly that sequence
+// (lock, apply LEDs, set rumble, DSHM_SendOutputReportUnlocked, unlock) to
+// fix issue #351 for the wireless startup path without ever dropping the
+// lock between mutation and copy.
+// 
+VOID
+DsLed_ApplyLocked(
+	_In_ PDEVICE_CONTEXT Context
+);
+
+//
+// Same as DsLed_Apply, immediately followed by a send, all under one hold
+// of Context->OutputReport.Lock (so nothing can race the recompute with a
+// send that copies a half-updated buffer). No-op (returns STATUS_SUCCESS
+// without sending) unless DsLed_IsDriverInCharge.
+// 
+NTSTATUS
+DsLed_Refresh(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ DS_OUTPUT_REPORT_SOURCE Source
+);
+
+//
+// Advances the USB charging-cycle LED animation by one step and sends the
+// result. No-op unless DsLed_IsDriverInCharge and LEDSettings.Mode is one of
+// the two battery-indicator modes. Takes Context->OutputReport.Lock.
+// 
+VOID
+DsLed_AdvanceChargingAnimation(
+	_In_ PDEVICE_CONTEXT Context
+);
+
+//
+// Sets the LED flags byte and, for each of the four LEDs, either Effect (if
+// its flag bit is set in Flags) or an all-zero effect block (if it is not).
+// Unlike DsLed_Apply/DsLed_Refresh this is callable even when the driver is
+// not in charge - it is the primitive HID application report handlers
+// (SIXAXIS pass-through, DS4Windows emulation) use to write LED state
+// directly, so it carries no authority guard of its own. Takes
+// Context->OutputReport.Lock.
+// 
+VOID
+DsLed_SetFlagsAndEffects(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ UCHAR Flags,
+	_In_ const DS_LED* Effect
+);
+
+//
+// Same as DsLed_SetFlagsAndEffects, but assumes Context->OutputReport.Lock
+// is already held by the caller. Exposed so OutputReport.c's locked
+// send-prep can re-apply a driver-owned custom pattern immediately before
+// the report copy, without releasing and re-acquiring the lock (issue
+// #350: rumble-only/HID sends must not be able to drop a driver-owned
+// custom pattern).
+// 
+VOID
+DsLed_ApplyCustomPatternLocked(
+	_In_ PDEVICE_CONTEXT Context
+);

--- a/driver/DsUsb.c
+++ b/driver/DsUsb.c
@@ -687,7 +687,7 @@ NTSTATUS DsUsb_D0Entry(WDFDEVICE Device, WDF_POWER_DEVICE_STATE PreviousState)
 			PUCHAR outputReportBuffer = NULL;
 			SIZE_T outputReportBufferLength = 0;
 
-			DS3_GET_UNIFIED_OUTPUT_REPORT_BUFFER(
+			Ds3_GetUnifiedOutputReportBuffer(
 				pDevCtx,
 				&outputReportBuffer,
 				&outputReportBufferLength

--- a/driver/HID.Reports.c
+++ b/driver/HID.Reports.c
@@ -283,7 +283,7 @@ DSHM_WriteReport(
 		//
 		// Get raw buffer pointer (connection agnostic)
 		// 
-		DS3_GET_UNIFIED_OUTPUT_REPORT_BUFFER(
+		Ds3_GetUnifiedOutputReportBuffer(
 			DeviceContext,
 			&buffer,
 			&bufferSize
@@ -292,7 +292,7 @@ DSHM_WriteReport(
 		//
 		// Prevent LED states from being overwritten from outside
 		// 
-		if (DeviceContext->Configuration.LEDSettings.Authority == DsLEDAuthorityDriver)
+		if (DsLed_IsDriverInCharge(DeviceContext))
 		{
 			UCHAR ledBlock[sizeof(UCHAR) + (sizeof(DS_LED) * 4)];
 
@@ -379,17 +379,16 @@ DSHM_WriteReport(
 		//
 		// Only allowed when when in Automatic or Application setting
 		// 
-		if (DeviceContext->Configuration.LEDSettings.Authority != DsLEDAuthorityDriver)
+		if (!DsLed_IsDriverInCharge(DeviceContext))
 		{
 			if (isSetColor)
 			{
-				//
-				// Restore defaults to undo any (past) flashing animations
-				// 
-				DS3_SET_LED_DURATION_DEFAULT(DeviceContext, 0);
-				DS3_SET_LED_DURATION_DEFAULT(DeviceContext, 1);
-				DS3_SET_LED_DURATION_DEFAULT(DeviceContext, 2);
-				DS3_SET_LED_DURATION_DEFAULT(DeviceContext, 3);
+				static const DS_LED staticEffect = DS3_LED_EFFECT_STATIC;
+				static const DS_LED slowFlashEffect = DS3_LED_EFFECT_SLOW_FLASH;
+
+				UCHAR flags = DS3_LED_OFF;
+				const DS_LED* pEffect = &staticEffect;
+				BOOLEAN matched = TRUE;
 
 				//
 				// Single color RED intensity indicates battery level (Light only a single LED from 1 to 4)
@@ -397,17 +396,17 @@ DSHM_WriteReport(
 				if (g == 0x00 && b == 0x00)
 				{
 					if (r >= 202)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_4);
+						flags = DS3_LED_4;
 					else if (r > 148)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_3);
+						flags = DS3_LED_3;
 					else if (r > 94)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_2);
+						flags = DS3_LED_2;
 					else if (r > 64)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1);
+						flags = DS3_LED_1;
 					else
 					{
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1);
-						DS3_SET_LED_DURATION(DeviceContext, 0, 0xFF, 15, 127, 127);
+						flags = DS3_LED_1;
+						pEffect = &slowFlashEffect;
 					}
 				}
 				//
@@ -416,17 +415,17 @@ DSHM_WriteReport(
 				else if (g == 0x00 && b == 0xFF)
 				{
 					if (r >= 202)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
+						flags = DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4;
 					else if (r > 148)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1 | DS3_LED_2 | DS3_LED_3);
+						flags = DS3_LED_1 | DS3_LED_2 | DS3_LED_3;
 					else if (r > 94)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1 | DS3_LED_2);
+						flags = DS3_LED_1 | DS3_LED_2;
 					else if (r > 64)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1);
+						flags = DS3_LED_1;
 					else
 					{
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1);
-						DS3_SET_LED_DURATION(DeviceContext, 0, 0xFF, 15, 127, 127);
+						flags = DS3_LED_1;
+						pEffect = &slowFlashEffect;
 					}
 				}
 				//
@@ -435,22 +434,42 @@ DSHM_WriteReport(
 				else if (g == 0xFF && b == 0xFF)
 				{
 					if (r == 0x00)
-						DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_OFF);
+						flags = DS3_LED_OFF;
 					else if (r >= 0x01 && r <= 0x0F)
-						DS3_SET_LED_FLAGS(DeviceContext, r << 1);
+						flags = r << 1;
+					else
+						matched = FALSE;
+				}
+				else
+				{
+					matched = FALSE;
+				}
+
+				//
+				// DsLed_SetFlagsAndEffects sets the flags byte and
+				// normalizes all four effect blocks against it in one
+				// call (static/slow-flash for lit LEDs, zero for unlit),
+				// replacing the previous reset-to-default-then-set-flags
+				// two-step sequence.
+				// 
+				if (matched)
+				{
+					DsLed_SetFlagsAndEffects(DeviceContext, flags, pEffect);
 				}
 			}
 
 			if (isSetFlashing)
 			{
+				static const DS_LED fastFlashEffect = DS3_LED_EFFECT_FAST_FLASH;
+
 				//
 				// Set to rapidly flash all 4 LEDs
 				// 
-				DS3_SET_LED_FLAGS(DeviceContext, DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4);
-				DS3_SET_LED_DURATION(DeviceContext, 0, 0xFF, 3, 127, 127);
-				DS3_SET_LED_DURATION(DeviceContext, 1, 0xFF, 3, 127, 127);
-				DS3_SET_LED_DURATION(DeviceContext, 2, 0xFF, 3, 127, 127);
-				DS3_SET_LED_DURATION(DeviceContext, 3, 0xFF, 3, 127, 127);
+				DsLed_SetFlagsAndEffects(
+					DeviceContext,
+					DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4,
+					&fastFlashEffect
+				);
 			}
 		}
 

--- a/driver/OutputReport.c
+++ b/driver/OutputReport.c
@@ -3,7 +3,9 @@
 
 
 //
-// Enqueues current output report buffer to get sent to device.
+// Enqueues current output report buffer to get sent to device. Takes
+// Context->OutputReport.Lock; see DSHM_SendOutputReportUnlocked for callers
+// that already hold it.
 //
 _Use_decl_annotations_
 NTSTATUS
@@ -14,13 +16,39 @@ DSHM_SendOutputReport(
 {
 	FuncEntry(TRACE_DSHIDMINIDRV);
 
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	const NTSTATUS status = DSHM_SendOutputReportUnlocked(Context, Source);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	FuncExit(TRACE_DSHIDMINIDRV, "status=%!STATUS!", status);
+
+	return status;
+}
+
+//
+// Same as DSHM_SendOutputReport, but assumes Context->OutputReport.Lock is
+// already held by the caller (see DsLed.c and DsBth.Timers.c). Applies the
+// driver-owned custom LED pattern immediately before the report copy, so a
+// concurrently issued rumble-only or HID application send can never drop it
+// (issue #350) - unlike the previous unconditional re-apply, this now only
+// happens while the driver is actually in charge of LEDs.
+//
+_Use_decl_annotations_
+NTSTATUS
+DSHM_SendOutputReportUnlocked(
+	_In_ const PDEVICE_CONTEXT Context,
+	_In_ const DS_OUTPUT_REPORT_SOURCE Source
+)
+{
+	FuncEntry(TRACE_DSHIDMINIDRV);
+
 	NTSTATUS status;
 	PUCHAR sourceBuffer, sendBuffer;
 	size_t sourceBufferLength;
 	PDS_OUTPUT_REPORT_CONTEXT sendContext;
-	const PDS_DRIVER_CONFIGURATION pConfig = &Context->Configuration;	
-
-	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+	const PDS_DRIVER_CONFIGURATION pConfig = &Context->Configuration;
 
 	do
 	{
@@ -45,50 +73,21 @@ DSHM_SendOutputReport(
 		}
 
 		//
-		// Override LED pattern
+		// Re-apply the driver-owned custom LED pattern immediately before
+		// the copy below, so it survives sends triggered by rumble-only or
+		// HID application writes that did not go through DsLed_Apply
+		// (issue #350). Gated by DsLed_IsDriverInCharge so an application
+		// or Automatic hand-off is never overridden here.
 		// 
-		if (pConfig->LEDSettings.Mode == DsLEDModeCustomPattern)
+		if (pConfig->LEDSettings.Mode == DsLEDModeCustomPattern && DsLed_IsDriverInCharge(Context))
 		{
-			DS3_SET_LED_FLAGS(Context, pConfig->LEDSettings.CustomPatterns.LEDFlags);
-
-			DS3_SET_LED_DURATION(
-				Context,
-				0,
-				pConfig->LEDSettings.CustomPatterns.Player1.TotalDuration,
-				pConfig->LEDSettings.CustomPatterns.Player1.BasePortionDuration,
-				pConfig->LEDSettings.CustomPatterns.Player1.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player1.OnPortionMultiplier
-			);
-			DS3_SET_LED_DURATION(
-				Context,
-				1,
-				pConfig->LEDSettings.CustomPatterns.Player2.TotalDuration,
-				pConfig->LEDSettings.CustomPatterns.Player2.BasePortionDuration,
-				pConfig->LEDSettings.CustomPatterns.Player2.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player2.OnPortionMultiplier
-			);
-			DS3_SET_LED_DURATION(
-				Context,
-				2,
-				pConfig->LEDSettings.CustomPatterns.Player3.TotalDuration,
-				pConfig->LEDSettings.CustomPatterns.Player3.BasePortionDuration,
-				pConfig->LEDSettings.CustomPatterns.Player3.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player3.OnPortionMultiplier
-			);
-			DS3_SET_LED_DURATION(
-				Context,
-				3,
-				pConfig->LEDSettings.CustomPatterns.Player4.TotalDuration,
-				pConfig->LEDSettings.CustomPatterns.Player4.BasePortionDuration,
-				pConfig->LEDSettings.CustomPatterns.Player4.OffPortionMultiplier,
-				pConfig->LEDSettings.CustomPatterns.Player4.OnPortionMultiplier
-			);
+			DsLed_ApplyCustomPatternLocked(Context);
 		}
 
 		//
 		// Get full report (including IDs etc.)
 		//
-		DS3_GET_RAW_OUTPUT_REPORT_BUFFER(
+		Ds3_GetRawOutputReportBuffer(
 			Context,
 			&sourceBuffer,
 			&sourceBufferLength
@@ -121,8 +120,6 @@ DSHM_SendOutputReport(
 		);
 
 	} while (FALSE);
-
-	WdfWaitLockRelease(Context->OutputReport.Lock);
 
 	FuncExit(TRACE_DSHIDMINIDRV, "status=%!STATUS!", status);
 

--- a/driver/Power.c
+++ b/driver/Power.c
@@ -221,6 +221,18 @@ NTSTATUS DsHidMini_EvtDeviceD0Entry(
 	// 
 	pDevCtx->HidModeRestartRequested = FALSE;
 
+	//
+	// Restore the Automatic authority hand-off for this power cycle: without
+	// this, OutputReport.Mode stayed latched at whatever an application last
+	// wrote (or, before it was ever written, its initial WDF-context-zeroed
+	// value, which happens to already equal DriverHandled) for the entire
+	// lifetime of the device object, making the driver-to-application LED
+	// hand-off effectively a one-time, not per-power-cycle, event (issue
+	// #351). Device.c's hot-reload callback does the same reset before its
+	// own DsLed_Refresh call.
+	// 
+	pDevCtx->OutputReport.Mode = Ds3OutputReportModeDriverHandled;
+
 	if (pDevCtx->ConnectionType == DsDeviceConnectionTypeUsb)
 	{
 		status = DsUsb_D0Entry(Device, PreviousState);

--- a/driver/Trace.h
+++ b/driver/Trace.h
@@ -15,6 +15,7 @@
         WPP_DEFINE_BIT(TRACE_DSBTH)                                    \
         WPP_DEFINE_BIT(TRACE_CONFIG)                                   \
         WPP_DEFINE_BIT(TRACE_IPC)                                      \
+        WPP_DEFINE_BIT(TRACE_LED)                                      \
         )                                                              \
 
 #define WPP_FLAG_LEVEL_LOGGER(flag, level)                              \

--- a/driver/dshidmini.vcxproj
+++ b/driver/dshidmini.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="DsBth.Timers.c" />
     <ClCompile Include="DsHid.c" />
     <ClCompile Include="DsHidMiniDrv.c" />
+    <ClCompile Include="DsLed.c" />
     <ClCompile Include="DsUsb.c" />
     <ClCompile Include="HID.FeatureReport.c" />
     <ClCompile Include="HID.Reports.c" />
@@ -53,6 +54,7 @@
     <ClInclude Include="DsHid.h" />
     <ClInclude Include="DsHidMiniDrv.h" />
     <ClInclude Include="DsInternal.h" />
+    <ClInclude Include="DsLed.h" />
     <ClInclude Include="DsUsb.h" />
     <ClInclude Include="HID.ReportHandlers.h" />
     <ClInclude Include="HID\01_SDF_Col1_GamePad.h" />

--- a/driver/dshidmini.vcxproj.filters
+++ b/driver/dshidmini.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="DsInternal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DsLed.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\DsHidMini\Ds3Types.h">
       <Filter>Header Files\Public</Filter>
     </ClInclude>
@@ -186,6 +189,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DsHidMiniDrv.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DsLed.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Power.c">


### PR DESCRIPTION
Consolidate every LED write in the driver behind a single policy module instead of six independent, copy-pasted decision points, and fix the bugs that fell out of the duplication:

- Add DsLed.h/DsLed.c: authority check (DsLed_IsDriverInCharge), named effect constants, mode-aware battery-to-flags tables (including the Charging state), lock-taking entry points (DsLed_Apply/_Refresh/ _AdvanceChargingAnimation/_SetFlagsAndEffects) plus locked internals.
- Ds3.c/Ds3.h: fix the three conflicting "default" LED effects down to the PS3-correct FF.00.01.00.01 (issue #365); drop the broken DS3_SET_LED_DURATION_DEFAULT (truncated 0x2710 -> 0x27); rename the ALL-CAPS LED primitives to the driver's normal convention.
- OutputReport.c: split DSHM_SendOutputReport into a lock-taking public entry and an unlocked send helper; a driver-owned custom pattern is now only re-applied in the locked send-prep when the driver is actually in charge, instead of unconditionally on every send (issue #350).
- DsBth.Timers.c, DsHidMiniDrv.c, Device.c, HID.Reports.c: rewire every LED write through the new DsLed API. Fixes DsLEDAuthorityApplication not being honored and OutputReport.Mode never resetting (issue #351); hot-reload now recomputes LED state instead of just re-sending the stale buffer (issue #349); the USB battery handler now always assigns BatteryStatus so the persistent property write only fires on an actual change instead of on every report while charging; drop the always-true dead LED-flags guard in the Bluetooth battery handler.
- Configuration.c/Power.c: initialize LEDSettings.Authority explicitly in ConfigSetDefaults, and reset OutputReport.Mode to DriverHandled on both D0Entry and hot-reload so the Automatic driver-to-application hand-off is per power cycle instead of a one-time latch.
- Register DsLed.c/.h in the vcxproj/.filters and TRACE_LED in Trace.h.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added charging animations and battery-based LED indicators, including player-index and bar-graph modes.
  - Added support for custom LED patterns and consistent LED effects across USB and Bluetooth connections.
  - LED state now refreshes correctly after configuration reloads and power cycles.
- **Bug Fixes**
  - Corrected default LED effects to match PS3 behavior.
  - Improved battery-state updates and LED refresh behavior.
  - Improved synchronization of LED and output-report updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->