### PR TITLE
Fix rumble duration handling (issue #356)

### DIFF
--- a/driver/Device.c
+++ b/driver/Device.c
@@ -862,6 +862,37 @@ DsDevice_InitContext(
 			break;
 		}
 
+		//
+		// Create periodic timer used to keep active rumble alive against
+		// the finite motor duration now written by
+		// DS3_PROCESS_RUMBLE_STRENGTH (see issue #356). This is the
+		// driver's only periodic timer; every other one here is one-shot.
+		// 
+
+		WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
+		attributes.ParentObject = Device;
+
+		WDF_TIMER_CONFIG_INIT_PERIODIC(
+			&timerCfg,
+			DS3_EvtRumbleKeepAliveTimerFunc,
+			DS3_RUMBLE_KEEPALIVE_PERIOD_MS
+		);
+
+		if (!NT_SUCCESS(status = WdfTimerCreate(
+			&timerCfg,
+			&attributes,
+			&pDevCtx->RumbleControlState.RumbleKeepAliveTimer
+		)))
+		{
+			TraceError(
+				TRACE_DEVICE,
+				"WdfTimerCreate (RumbleKeepAliveTimer) failed with status %!STATUS!",
+				status
+			);
+			EventWriteFailedWithNTStatus(__FUNCTION__, L"WdfTimerCreate (RumbleKeepAliveTimer)", status);
+			break;
+		}
+
 #pragma region IPC
 
 		SECURITY_DESCRIPTOR sd = { 0 };

--- a/driver/Device.h
+++ b/driver/Device.h
@@ -425,6 +425,16 @@ typedef struct _DEVICE_CONTEXT
 		//
 		DS_RESCALE_STATE HeavyRescale;
 
+		//
+		// Periodically re-sends the current output report while at least
+		// one motor is active, so the finite motor duration written by
+		// DS3_PROCESS_RUMBLE_STRENGTH never lapses for as long as rumble
+		// stays engaged (issue #356). Started/restarted from
+		// DS3_PROCESS_RUMBLE_STRENGTH, stopped once both motors go quiet
+		// and on device power-down (see driver/Power.c).
+		//
+		WDFTIMER RumbleKeepAliveTimer;
+
 	} RumbleControlState;
 
 	UINT32 SlotIndex;
@@ -531,6 +541,8 @@ EVT_WDF_TIMER DSHM_OutputReportDelayTimerElapsed;
 EVT_WDF_TIMER DsDevice_EvtHidModeRestartTimerFunc;
 
 EVT_WDF_TIMER DsDevice_EvtBthDisconnectRetryTimerFunc;
+
+EVT_WDF_TIMER DS3_EvtRumbleKeepAliveTimerFunc;
 
 EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL DSHM_EvtWdfIoQueueIoDeviceControl;
 

--- a/driver/Device.h
+++ b/driver/Device.h
@@ -435,6 +435,17 @@ typedef struct _DEVICE_CONTEXT
 		//
 		WDFTIMER RumbleKeepAliveTimer;
 
+		//
+		// Set by DsHidMini_EvtDeviceD0Exit/DsHidMini_EvtDeviceReleaseHardware
+		// before RumbleKeepAliveTimer is stopped, and checked by
+		// DS3_PROCESS_RUMBLE_STRENGTH before (re-)arming it, so a rumble
+		// write racing with power-down cannot re-arm the timer after
+		// teardown has decided to stop it (issue #356). Reset per power
+		// cycle in DsHidMini_EvtDeviceD0Entry, matching the
+		// InputReportDropLogged/HidModeRestartRequested latches.
+		//
+		BOOLEAN IsTearingDown;
+
 	} RumbleControlState;
 
 	UINT32 SlotIndex;

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -1309,7 +1309,12 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	// #356). Disarm it once both motors are silent - the next
 	// DS3_PROCESS_RUMBLE_STRENGTH call (if any) re-arms it.
 	//
-	if ((UCHAR)heavyRumble != 0 || (UCHAR)lightRumble != 0)
+	// IsTearingDown is checked here (rather than relying on
+	// DsHidMini_EvtDeviceD0Exit/ReleaseHardware's WdfTimerStop alone) so a
+	// rumble write racing with power-down on another thread cannot re-arm
+	// the timer after teardown already decided to stop it.
+	//
+	if (!Context->RumbleControlState.IsTearingDown && ((UCHAR)heavyRumble != 0 || (UCHAR)lightRumble != 0))
 	{
 		WdfTimerStart(
 			Context->RumbleControlState.RumbleKeepAliveTimer,
@@ -1330,6 +1335,15 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 // OutputReport.Lock here is safe - mirrors the lock/apply/send sequence
 // DsBth_EvtStartupDelayTimerFunc already uses.
 //
+// Deliberately does not stop itself here even if both motors happen to
+// read quiet: DS3_PROCESS_RUMBLE_STRENGTH is the sole authority that starts
+// and stops this timer, and it always stops the timer itself once strength
+// drops to zero. A callback-side stop based on this cache read (as this
+// used to do) can race a fresh WdfTimerStart from a rumble write that
+// arrives concurrently - cancelling a legitimately just-armed timer. Any
+// stray invocation this races against instead just resends the current
+// (by then already-zeroed) buffer once, which is harmless.
+//
 _Use_decl_annotations_
 VOID
 DS3_EvtRumbleKeepAliveTimerFunc(
@@ -1339,19 +1353,6 @@ DS3_EvtRumbleKeepAliveTimerFunc(
 	FuncEntry(TRACE_DSHIDMINIDRV);
 
 	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(WdfTimerGetParentObject(Timer));
-
-	//
-	// Belt-and-braces: if both motors have since gone quiet (e.g. a racing
-	// DS3_PROCESS_RUMBLE_STRENGTH call stopped the timer just as this
-	// callback was already queued), stop the timer and skip the send.
-	//
-	if (pDevCtx->RumbleControlState.HeavyCache == 0 && pDevCtx->RumbleControlState.LightCache == 0)
-	{
-		WdfTimerStop(Timer, FALSE);
-
-		FuncExitNoReturn(TRACE_DSHIDMINIDRV);
-		return;
-	}
 
 	const NTSTATUS status = DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverHighPriority);
 

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -1249,6 +1249,28 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 				Context->OutputReportMemory,
 				NULL
 			), (UCHAR)lightRumble);
+
+		//
+		// Always accompany a strength update with an explicit, finite
+		// duration (issue #356). Without this the duration bytes are
+		// whatever residue was last written into the shared buffer -
+		// which used to be an accidental 0xFF (infinite) on USB and an
+		// accidental, permanently time-capped 0xFE on Bluetooth. Matching
+		// the real PS3 console's own behaviour (see
+		// docs/PS3_USB_STARTUP.md) makes rumble time out on its own if the
+		// keep-alive timer below (or the requesting application) ever
+		// stops updating it.
+		//
+		DS3_USB_SET_LARGE_RUMBLE_DURATION(
+			(PUCHAR)WdfMemoryGetBuffer(
+				Context->OutputReportMemory,
+				NULL
+			), DS3_RUMBLE_DURATION_DEFAULT);
+		DS3_USB_SET_SMALL_RUMBLE_DURATION(
+			(PUCHAR)WdfMemoryGetBuffer(
+				Context->OutputReportMemory,
+				NULL
+			), DS3_RUMBLE_DURATION_DEFAULT);
 		break;
 
 	case DsDeviceConnectionTypeBth:
@@ -1263,7 +1285,85 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 				Context->OutputReportMemory,
 				NULL
 			), (UCHAR)lightRumble);
+
+		//
+		// See USB case above (issue #356).
+		//
+		DS3_BTH_SET_LARGE_RUMBLE_DURATION(
+			(PUCHAR)WdfMemoryGetBuffer(
+				Context->OutputReportMemory,
+				NULL
+			), DS3_RUMBLE_DURATION_DEFAULT);
+		DS3_BTH_SET_SMALL_RUMBLE_DURATION(
+			(PUCHAR)WdfMemoryGetBuffer(
+				Context->OutputReportMemory,
+				NULL
+			), DS3_RUMBLE_DURATION_DEFAULT);
 		break;
 	}
 
+	//
+	// Arm (or restart) the keep-alive timer while at least one motor is
+	// active, so the finite duration set above never times out for as
+	// long as the requesting application keeps rumble engaged (issue
+	// #356). Disarm it once both motors are silent - the next
+	// DS3_PROCESS_RUMBLE_STRENGTH call (if any) re-arms it.
+	//
+	if ((UCHAR)heavyRumble != 0 || (UCHAR)lightRumble != 0)
+	{
+		WdfTimerStart(
+			Context->RumbleControlState.RumbleKeepAliveTimer,
+			WDF_REL_TIMEOUT_IN_MS(DS3_RUMBLE_KEEPALIVE_PERIOD_MS)
+		);
+	}
+	else
+	{
+		WdfTimerStop(Context->RumbleControlState.RumbleKeepAliveTimer, FALSE);
+	}
+}
+
+//
+// Periodically re-sends the current output report while rumble is active,
+// so the finite motor duration DS3_PROCESS_RUMBLE_STRENGTH now writes on
+// every strength update (issue #356) never lapses as long as at least one
+// motor stays engaged. Runs at PASSIVE_LEVEL (UMDF), so taking
+// OutputReport.Lock here is safe - mirrors the lock/apply/send sequence
+// DsBth_EvtStartupDelayTimerFunc already uses.
+//
+_Use_decl_annotations_
+VOID
+DS3_EvtRumbleKeepAliveTimerFunc(
+	WDFTIMER Timer
+)
+{
+	FuncEntry(TRACE_DSHIDMINIDRV);
+
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(WdfTimerGetParentObject(Timer));
+
+	//
+	// Belt-and-braces: if both motors have since gone quiet (e.g. a racing
+	// DS3_PROCESS_RUMBLE_STRENGTH call stopped the timer just as this
+	// callback was already queued), stop the timer and skip the send.
+	//
+	if (pDevCtx->RumbleControlState.HeavyCache == 0 && pDevCtx->RumbleControlState.LightCache == 0)
+	{
+		WdfTimerStop(Timer, FALSE);
+
+		FuncExitNoReturn(TRACE_DSHIDMINIDRV);
+		return;
+	}
+
+	const NTSTATUS status = DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverHighPriority);
+
+	if (!NT_SUCCESS(status))
+	{
+		TraceError(
+			TRACE_DSHIDMINIDRV,
+			"DSHM_SendOutputReport failed with status %!STATUS!",
+			status
+		);
+		EventWriteFailedWithNTStatus(__FUNCTION__, L"DSHM_SendOutputReport", status);
+	}
+
+	FuncExitNoReturn(TRACE_DSHIDMINIDRV);
 }

--- a/driver/Ds3.h
+++ b/driver/Ds3.h
@@ -33,6 +33,21 @@ extern const UCHAR G_Ds3BthHidOutputReport[];
 #define DS3_BTH_SET_SMALL_RUMBLE_STRENGTH(_buf_, _str_)  ((_buf_)[4] = (_str_) > 0 ? 0x01 : 0x00)
 #define DS3_BTH_SET_LARGE_RUMBLE_STRENGTH(_buf_, _str_)  ((_buf_)[6] = (_str_))
 
+//
+// Motor duration the PS3 console writes on every output report (see
+// docs/PS3_USB_STARTUP.md). Finite on purpose: a stalled driver or a
+// crashed application cannot leave the motors running, because the
+// controller times them out on its own (issue #356).
+//
+#define DS3_RUMBLE_DURATION_DEFAULT     0x96
+
+//
+// Keep-alive re-send period while at least one motor is active. Must stay
+// safely below whatever 0x96 expands to on real hardware, and above the
+// ~25 ms window in which a DS3 drops back-to-back output reports (issue #20).
+//
+#define DS3_RUMBLE_KEEPALIVE_PERIOD_MS  200
+
 #define DS3_USB_COMMON_ENABLE		0x42, 0x0C, 0x00, 0x00
 #define DS3_USB_COMMON_DISABLE		0x42, 0x0B, 0x00, 0x00
 #define DS3_BTH_SIXAXIS_ENABLE		0x53, 0xF4, 0x42, 0x03, 0x00, 0x00

--- a/driver/DsBth.Timers.c
+++ b/driver/DsBth.Timers.c
@@ -46,16 +46,20 @@ DsBth_EvtStartupDelayTimerFunc(
 	//
 	// Apply LEDs (mode-aware, authority-checked - fixes issue #351 for the
 	// wireless startup path, which used to always use the single-LED
-	// mapping and write regardless of authority), set rumble durations and
-	// strength, then send - all under one hold of the lock so nothing can
-	// copy a half-updated buffer in between (fixes issue #351/bug 6).
+	// mapping and write regardless of authority), zero rumble strength,
+	// then send - all under one hold of the lock so nothing can copy a
+	// half-updated buffer in between (fixes issue #351/bug 6).
+	//
+	// The zero-strength call below also writes an explicit, finite
+	// duration by itself now (DS3_PROCESS_RUMBLE_STRENGTH, issue #356), so
+	// the two 0xFE duration writes that used to precede it - and that were
+	// never restored afterwards, permanently time-capping every wireless
+	// rumble for the rest of the session - are gone.
 	// 
 	WdfWaitLockAcquire(pDevCtx->OutputReport.Lock, NULL);
 
 	DsLed_ApplyLocked(pDevCtx);
 
-	DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0xFE);
-	DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0xFE);
 	DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0x00);
 
 	status = DSHM_SendOutputReportUnlocked(pDevCtx, Ds3OutputReportSourceDriverHighPriority);

--- a/driver/DsHidMiniDrv.c
+++ b/driver/DsHidMiniDrv.c
@@ -1159,18 +1159,29 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 					pDevCtx->RumbleControlState.AltMode.IsEnabled = !pDevCtx->RumbleControlState.AltMode.IsEnabled;
 
 					//
-					// Send rumble feedback to indicate change in rumble mode
+					// Send rumble feedback to indicate change in rumble mode.
+					// DS3_SET_BOTH_RUMBLE_STRENGTH writes its own finite
+					// default duration (issue #356), so the short, one-shot
+					// durations for this feedback buzz are applied
+					// afterwards, overwriting that default just before the
+					// send below.
 					//
+					DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0xFF);
 					DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0x30);
 					DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0x20);
-					DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0xFF);
 					(void)DSHM_SendOutputReport(pDevCtx, Ds3OutputReportSourceDriverLowPriority);
 
 					//
-					// Restore default rumble duration
+					// Reset cached rumble strength back to idle instead of
+					// restoring an infinite duration (issue #356): leaving
+					// RumbleControlState.LightCache at 0xFF here used to
+					// mean the *next* unrelated send (e.g. an LED battery
+					// update) would silently re-buzz the light motor
+					// forever. Zeroing strength also stops the keep-alive
+					// timer DS3_SET_BOTH_RUMBLE_STRENGTH just armed, so this
+					// feedback buzz stays a single short pulse.
 					//
-					DS3_SET_LARGE_RUMBLE_DURATION(pDevCtx, 0xFF);
-					DS3_SET_SMALL_RUMBLE_DURATION(pDevCtx, 0xFF);
+					DS3_SET_BOTH_RUMBLE_STRENGTH(pDevCtx, 0x00, 0x00);
 
 
 					//

--- a/driver/Power.c
+++ b/driver/Power.c
@@ -119,6 +119,17 @@ DsHidMini_EvtDeviceReleaseHardware(
 	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
 
 	//
+	// Idempotent: if D0Exit already stopped this (normal removal path)
+	// this is a no-op; if D0Entry failed before D0Exit could run (issue
+	// #311), this is what prevents the keep-alive from firing against a
+	// device that is about to be surprise-removed (issue #356).
+	//
+	if (pDevCtx->RumbleControlState.RumbleKeepAliveTimer)
+	{
+		WdfTimerStop(pDevCtx->RumbleControlState.RumbleKeepAliveTimer, TRUE);
+	}
+
+	//
 	// Stop delivering input reports before any DMF Module gets a chance to
 	// close. Idempotent: if D0Exit already stopped this target (normal
 	// removal path) this is a no-op; if D0Entry failed before D0Exit could
@@ -274,6 +285,16 @@ NTSTATUS DsHidMini_EvtDeviceD0Exit(
 	FuncEntry(TRACE_POWER);
 
 	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
+
+	//
+	// Stop the rumble keep-alive before the output worker below, so it
+	// cannot enqueue a send against a worker that is about to stop
+	// accepting new work (issue #356).
+	//
+	if (pDevCtx->RumbleControlState.RumbleKeepAliveTimer)
+	{
+		WdfTimerStop(pDevCtx->RumbleControlState.RumbleKeepAliveTimer, TRUE);
+	}
 
 	//
 	// Stop processing received output report packets

--- a/driver/Power.c
+++ b/driver/Power.c
@@ -122,8 +122,13 @@ DsHidMini_EvtDeviceReleaseHardware(
 	// Idempotent: if D0Exit already stopped this (normal removal path)
 	// this is a no-op; if D0Entry failed before D0Exit could run (issue
 	// #311), this is what prevents the keep-alive from firing against a
-	// device that is about to be surprise-removed (issue #356).
+	// device that is about to be surprise-removed (issue #356). The flag
+	// is set before the stop so a rumble write racing on another thread
+	// cannot re-arm the timer afterwards (DS3_PROCESS_RUMBLE_STRENGTH
+	// checks it before every WdfTimerStart).
 	//
+	pDevCtx->RumbleControlState.IsTearingDown = TRUE;
+
 	if (pDevCtx->RumbleControlState.RumbleKeepAliveTimer)
 	{
 		WdfTimerStop(pDevCtx->RumbleControlState.RumbleKeepAliveTimer, TRUE);
@@ -233,6 +238,13 @@ NTSTATUS DsHidMini_EvtDeviceD0Entry(
 	pDevCtx->HidModeRestartRequested = FALSE;
 
 	//
+	// Allow the rumble keep-alive to be armed again for this power cycle
+	// (issue #356); see DsHidMini_EvtDeviceD0Exit/ReleaseHardware where it
+	// is set.
+	// 
+	pDevCtx->RumbleControlState.IsTearingDown = FALSE;
+
+	//
 	// Restore the Automatic authority hand-off for this power cycle: without
 	// this, OutputReport.Mode stayed latched at whatever an application last
 	// wrote (or, before it was ever written, its initial WDF-context-zeroed
@@ -289,8 +301,11 @@ NTSTATUS DsHidMini_EvtDeviceD0Exit(
 	//
 	// Stop the rumble keep-alive before the output worker below, so it
 	// cannot enqueue a send against a worker that is about to stop
-	// accepting new work (issue #356).
+	// accepting new work (issue #356). Set before the stop for the same
+	// re-arm-race reason as DsHidMini_EvtDeviceReleaseHardware.
 	//
+	pDevCtx->RumbleControlState.IsTearingDown = TRUE;
+
 	if (pDevCtx->RumbleControlState.RumbleKeepAliveTimer)
 	{
 		WdfTimerStop(pDevCtx->RumbleControlState.RumbleKeepAliveTimer, TRUE);


### PR DESCRIPTION
The DS4 output report (0x05) does not carry a rumble duration field at all - report bytes are valid flags, weak/strong motor strength, lightbar RGB and lightbar flash on/off duration. The reported symptom is real but originates on the DS3 side: no rumble path (DS4W, PID force feedback, XInput HID) ever wrote the DS3 motor duration bytes, so the value was whatever residue was left in the shared output buffer - an accidental 0xFF (infinite) on USB, and an accidental, never-restored 0xFE on Bluetooth after the wireless startup sequence.

- DS3_PROCESS_RUMBLE_STRENGTH now writes an explicit, finite duration (0x96, matching the real PS3 console) alongside every strength update.
- A new periodic RumbleKeepAliveTimer re-sends the current output report every 200 ms while at least one motor is active, so held rumble never lapses against the finite duration. Stopped on D0Exit and ReleaseHardware (surprise removal).
- Removed the dead 0xFE duration writes in DsBth_EvtStartupDelayTimerFunc and fixed the alt-rumble-mode toggle buzz, which used to leave the light motor strength cached at 0xFF indefinitely after restoring an infinite duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller rumble reliability by periodically refreshing active vibration commands.
  * Fixed rumble duration handling to prevent vibration from being unintentionally capped.
  * Fixed alternative rumble-mode feedback so brief vibration does not retrigger unexpectedly.
  * Improved shutdown and power-transition handling so rumble activity does not continue after device removal or disconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->