### PR TITLE
Add Defender BT PS3-mode switch helper to ControlApp (#282)

### DIFF
--- a/ControlApp/App.xaml.cs
+++ b/ControlApp/App.xaml.cs
@@ -85,6 +85,7 @@ public partial class App
             services.AddSingleton<DshmDevMan>();
             services.AddSingleton<DshmConfigManager>();
             services.AddSingleton<BthPS3StatusService>();
+            services.AddSingleton<DefenderBtStatusService>();
 
             services.AddSingleton<DevicesPage>();
             services.AddSingleton<DevicesViewModel>();

--- a/ControlApp/Models/ApplicationConfiguration.cs
+++ b/ControlApp/Models/ApplicationConfiguration.cs
@@ -39,6 +39,12 @@ public class ApplicationConfiguration
     /// </summary>
     public bool HasAcknowledgedDonationDialog { get; set; } = false;
 
+    /// <summary>
+    ///     When true, a Retro Fighters Defender Bluetooth Edition detected in DualShock 4 mode is automatically
+    ///     switched into DualShock 3 (PS3) mode without requiring the user to press a button (see issue #282).
+    /// </summary>
+    public bool AutoSwitchDefenderBtToPs3Mode { get; set; } = false;
+
     private bool _minimizeToTray;
 
     /// <summary>

--- a/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
+++ b/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
@@ -41,8 +41,9 @@ public enum DefenderBtModeSwitchResult
 /// <remarks>
 ///     See issue #282 and <c>docs/PS3_USB_STARTUP.md</c> ("Retro Fighters Defender") for how this sequence was
 ///     derived from real PS3-to-Defender-BT USB captures. The report is a verbatim replay of what a genuine PS3
-///     periodically sends a real DualShock 4 as well (harmless no-op there), so sending it to a device that
-///     merely looks like a Defender BT but is not carries no risk beyond it being ignored.
+///     periodically sends a real DualShock 4 as well (harmless no-op there), but detection/targeting still
+///     requires the Defender-specific <see cref="DefenderBtVersionNumber" /> discriminator below (in addition
+///     to VID/PID) so that a genuine DualShock 4 is never misidentified as, or targeted as, a Defender BT.
 /// </remarks>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
 public static class DefenderBtModeSwitcher
@@ -61,6 +62,16 @@ public static class DefenderBtModeSwitcher
     ///     Product ID the Defender BT (and a genuine DualShock 3) enumerates as after the probe below succeeds.
     /// </summary>
     public const ushort DualShock3ProductId = 0x0268;
+
+    /// <summary>
+    ///     The <c>bcdDevice</c> / <see cref="HIDD_ATTRIBUTES.VersionNumber" /> value observed on the Defender BT
+    ///     while in its DualShock 4 identity. A genuine DualShock 4 reports <c>0x0100</c> here instead, so this
+    ///     is required - in addition to matching VID/PID - before a device is treated as (or targeted as) a
+    ///     Defender BT. Without this check a real DualShock 4 would be misidentified and offered/subjected to
+    ///     the mode switch. See <c>docs/PS3_USB_STARTUP.md</c> ("Retro Fighters Defender") for the capture this
+    ///     was derived from.
+    /// </summary>
+    public const ushort DefenderBtVersionNumber = 0x0221;
 
     /// <summary>
     ///     The 17-byte <c>SET_REPORT Feature 0x14</c> payload a real PS3 sends every ~1 second while a
@@ -86,14 +97,14 @@ public static class DefenderBtModeSwitcher
     }
 
     /// <summary>
-    ///     True if <paramref name="devicePath" /> points to a HID device currently reporting Sony's Defender-BT
-    ///     DualShock 4 identity (VID 0x054C, PID 0x05C4).
+    ///     True if <paramref name="devicePath" /> points to a HID device currently reporting the Defender-BT
+    ///     DualShock 4 identity (VID 0x054C, PID 0x05C4, VersionNumber 0x0221) - not just any DualShock 4.
     /// </summary>
     public static bool IsDefenderBtInDs4Mode(string devicePath)
     {
         using SafeFileHandle handle = OpenDevice(devicePath);
         return !handle.IsInvalid && TryGetAttributes(handle, out HIDD_ATTRIBUTES attributes) &&
-               attributes.VendorID == SonyVendorId && attributes.ProductID == DualShock4ProductId;
+               IsDefenderBtCandidate(attributes);
     }
 
     /// <summary>
@@ -105,7 +116,7 @@ public static class DefenderBtModeSwitcher
         using SafeFileHandle handle = OpenDevice(devicePath);
 
         if (handle.IsInvalid || !TryGetAttributes(handle, out HIDD_ATTRIBUTES attributes) ||
-            attributes.VendorID != SonyVendorId || attributes.ProductID != DualShock4ProductId)
+            !IsDefenderBtCandidate(attributes))
         {
             return DefenderBtModeSwitchResult.NotADefenderBt;
         }
@@ -129,6 +140,18 @@ public static class DefenderBtModeSwitcher
         }
 
         return DefenderBtModeSwitchResult.Sent;
+    }
+
+    /// <summary>
+    ///     True if <paramref name="attributes" /> match the Defender BT's known DualShock 4 identity signature
+    ///     (VID/PID plus the Defender-specific <see cref="DefenderBtVersionNumber" />), as opposed to a genuine
+    ///     DualShock 4, which shares the same VID/PID but reports a different version number.
+    /// </summary>
+    private static bool IsDefenderBtCandidate(HIDD_ATTRIBUTES attributes)
+    {
+        return attributes.VendorID == SonyVendorId &&
+               attributes.ProductID == DualShock4ProductId &&
+               attributes.VersionNumber == DefenderBtVersionNumber;
     }
 
     private static SafeFileHandle OpenDevice(string devicePath)

--- a/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
+++ b/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
@@ -1,0 +1,151 @@
+using System.Runtime.InteropServices;
+
+using Windows.Win32;
+using Windows.Win32.Devices.HumanInterfaceDevice;
+using Windows.Win32.Foundation;
+using Windows.Win32.Storage.FileSystem;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Nefarius.DsHidMini.ControlApp.Models.Util;
+
+/// <summary>
+///     Outcome of an attempt to switch a Retro Fighters Defender Bluetooth Edition out of its default
+///     DualShock 4 USB identity into its DualShock 3 identity, which DsHidMini can bind to.
+/// </summary>
+public enum DefenderBtModeSwitchResult
+{
+    /// <summary>
+    ///     The supplied device path does not point to a Defender BT in DualShock 4 mode.
+    /// </summary>
+    NotADefenderBt,
+
+    /// <summary>
+    ///     The probe report was sent successfully; the device is expected to detach and re-enumerate as a
+    ///     DualShock 3 (<c>USB\VID_054C&amp;PID_0268</c>) shortly after.
+    /// </summary>
+    Sent,
+
+    /// <summary>
+    ///     A matching device was found but sending the probe report failed.
+    /// </summary>
+    Failed
+}
+
+/// <summary>
+///     Detects a Retro Fighters Defender Bluetooth Edition controller enumerated in its default DualShock 4
+///     USB identity (<c>USB\VID_054C&amp;PID_05C4</c>) and replays the same HID Feature report a real PS3
+///     sends it to make it detach and re-enumerate as a DualShock 3 (<c>USB\VID_054C&amp;PID_0268</c>), which
+///     DsHidMini already binds to via <c>driver/dshidmini.inf</c>.
+/// </summary>
+/// <remarks>
+///     See issue #282 and <c>docs/PS3_USB_STARTUP.md</c> ("Retro Fighters Defender") for how this sequence was
+///     derived from real PS3-to-Defender-BT USB captures. The report is a verbatim replay of what a genuine PS3
+///     periodically sends a real DualShock 4 as well (harmless no-op there), so sending it to a device that
+///     merely looks like a Defender BT but is not carries no risk beyond it being ignored.
+/// </remarks>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public static class DefenderBtModeSwitcher
+{
+    /// <summary>
+    ///     Sony's USB Vendor ID, shared by the genuine DualShock 3/4 and the Defender BT's DualShock 4 identity.
+    /// </summary>
+    public const ushort SonyVendorId = 0x054C;
+
+    /// <summary>
+    ///     Product ID the Defender BT (and a genuine DualShock 4) enumerates as by default.
+    /// </summary>
+    public const ushort DualShock4ProductId = 0x05C4;
+
+    /// <summary>
+    ///     Product ID the Defender BT (and a genuine DualShock 3) enumerates as after the probe below succeeds.
+    /// </summary>
+    public const ushort DualShock3ProductId = 0x0268;
+
+    /// <summary>
+    ///     The 17-byte <c>SET_REPORT Feature 0x14</c> payload a real PS3 sends every ~1 second while a
+    ///     DualShock-4-identity device is attached. On a Defender BT this makes it detach and re-enumerate as a
+    ///     DualShock 3; on a genuine DualShock 4 it is a harmless no-op (confirmed from capture).
+    /// </summary>
+    private static readonly byte[] Ps3ModeProbeReport =
+    {
+        0x14, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+
+    /// <summary>
+    ///     The HID device interface class GUID, used to enumerate/listen for HID device arrivals.
+    /// </summary>
+    public static Guid HidDeviceInterfaceGuid
+    {
+        get
+        {
+            PInvoke.HidD_GetHidGuid(out Guid guid);
+            return guid;
+        }
+    }
+
+    /// <summary>
+    ///     True if <paramref name="devicePath" /> points to a HID device currently reporting Sony's Defender-BT
+    ///     DualShock 4 identity (VID 0x054C, PID 0x05C4).
+    /// </summary>
+    public static bool IsDefenderBtInDs4Mode(string devicePath)
+    {
+        using SafeFileHandle handle = OpenDevice(devicePath);
+        return !handle.IsInvalid && TryGetAttributes(handle, out HIDD_ATTRIBUTES attributes) &&
+               attributes.VendorID == SonyVendorId && attributes.ProductID == DualShock4ProductId;
+    }
+
+    /// <summary>
+    ///     Sends the PS3 mode-switch probe to <paramref name="devicePath" /> if (and only if) it currently
+    ///     reports the Defender-BT DualShock 4 identity.
+    /// </summary>
+    public static unsafe DefenderBtModeSwitchResult TrySwitchToPs3Mode(string devicePath)
+    {
+        using SafeFileHandle handle = OpenDevice(devicePath);
+
+        if (handle.IsInvalid || !TryGetAttributes(handle, out HIDD_ATTRIBUTES attributes) ||
+            attributes.VendorID != SonyVendorId || attributes.ProductID != DualShock4ProductId)
+        {
+            return DefenderBtModeSwitchResult.NotADefenderBt;
+        }
+
+        Log.Logger.Information(
+            "Sending PS3 mode-switch probe to Defender BT candidate {DevicePath}", devicePath);
+
+        HANDLE rawHandle = new(handle.DangerousGetHandle());
+
+        fixed (byte* buffer = Ps3ModeProbeReport)
+        {
+            BOOLEAN ok = PInvoke.HidD_SetFeature(rawHandle, buffer, (uint)Ps3ModeProbeReport.Length);
+
+            if (!(bool)ok)
+            {
+                Log.Logger.Warning(
+                    "HidD_SetFeature failed for Defender BT candidate {DevicePath}, Win32 error {Error}",
+                    devicePath, Marshal.GetLastWin32Error());
+                return DefenderBtModeSwitchResult.Failed;
+            }
+        }
+
+        return DefenderBtModeSwitchResult.Sent;
+    }
+
+    private static SafeFileHandle OpenDevice(string devicePath)
+    {
+        return PInvoke.CreateFile(
+            devicePath,
+            (uint)(FILE_ACCESS_RIGHTS.FILE_GENERIC_READ | FILE_ACCESS_RIGHTS.FILE_GENERIC_WRITE),
+            FILE_SHARE_MODE.FILE_SHARE_READ | FILE_SHARE_MODE.FILE_SHARE_WRITE,
+            null,
+            FILE_CREATION_DISPOSITION.OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_NORMAL,
+            null
+        );
+    }
+
+    private static bool TryGetAttributes(SafeFileHandle handle, out HIDD_ATTRIBUTES attributes)
+    {
+        return PInvoke.HidD_GetAttributes(handle, out attributes);
+    }
+}

--- a/ControlApp/NativeMethods.txt
+++ b/ControlApp/NativeMethods.txt
@@ -5,3 +5,7 @@ CreateFile
 DeviceIoControl
 WIN32_ERROR
 FILE_ACCESS_RIGHTS
+HidD_GetAttributes
+HidD_GetHidGuid
+HidD_SetFeature
+HIDD_ATTRIBUTES

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -112,6 +112,28 @@ public class AppSnackbarMessagesService
         );
     }
 
+    public void ShowDefenderBtSwitchedToPs3ModeMessage()
+    {
+        _snackbarService.Show(
+            "Switch to PS3 mode requested",
+            "The controller should detach and reappear as a DualShock 3 in a moment. Use the normal pairing controls once it shows up.",
+            ControlAppearance.Success,
+            new SymbolIcon(SymbolRegular.CheckmarkCircle24),
+            TimeSpan.FromSeconds(5)
+        );
+    }
+
+    public void ShowDefenderBtSwitchToPs3ModeFailedMessage()
+    {
+        _snackbarService.Show(
+            "Failed to switch Defender BT to PS3 mode",
+            "The device may have been disconnected. Reconnect it in DualShock 4 mode and try again.",
+            ControlAppearance.Danger,
+            new SymbolIcon(SymbolRegular.DismissCircle24),
+            TimeSpan.FromSeconds(5)
+        );
+    }
+
     public void ShowPowerCyclingDeviceMessage(bool isWireless, bool isAppElevated, bool reconnectionResult)
     {
         if (!isWireless && !isAppElevated)

--- a/ControlApp/Services/ApplicationHostService.cs
+++ b/ControlApp/Services/ApplicationHostService.cs
@@ -18,14 +18,19 @@ namespace Nefarius.DsHidMini.ControlApp.Services;
 /// </summary>
 public class ApplicationHostService : IHostedService
 {
+    private readonly DefenderBtStatusService _defenderBtStatusService;
     private readonly DshmDevMan _dshmDevMan;
     private readonly IServiceProvider _serviceProvider;
     private INavigationWindow _navigationWindow;
 
-    public ApplicationHostService(IServiceProvider serviceProvider, DshmDevMan dshmDevMan)
+    public ApplicationHostService(
+        IServiceProvider serviceProvider,
+        DshmDevMan dshmDevMan,
+        DefenderBtStatusService defenderBtStatusService)
     {
         _serviceProvider = serviceProvider;
         _dshmDevMan = dshmDevMan;
+        _defenderBtStatusService = defenderBtStatusService;
     }
 
     /// <summary>
@@ -44,6 +49,7 @@ public class ApplicationHostService : IHostedService
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         _dshmDevMan.StopListeningForDshmDevices();
+        _defenderBtStatusService.StopListening();
         await Task.CompletedTask;
     }
 

--- a/ControlApp/Services/DefenderBtStatusService.cs
+++ b/ControlApp/Services/DefenderBtStatusService.cs
@@ -1,0 +1,155 @@
+using Nefarius.DsHidMini.ControlApp.Models;
+using Nefarius.DsHidMini.ControlApp.Models.Util;
+using Nefarius.Utilities.DeviceManagement.PnP;
+
+using Wpf.Ui.Controls;
+
+namespace Nefarius.DsHidMini.ControlApp.Services;
+
+/// <summary>
+///     Watches for a Retro Fighters Defender Bluetooth Edition controller enumerated in its default
+///     DualShock 4 USB identity and offers a one-click way to switch it into its DualShock 3 identity, which
+///     DsHidMini can bind to. See issue #282 and <c>docs/PS3_USB_STARTUP.md</c>.
+/// </summary>
+public partial class DefenderBtStatusService : ObservableObject, IDisposable
+{
+    private DeviceNotificationListener? _listener;
+
+    /// <summary>
+    ///     HID device path (symbolic link) of the currently detected Defender BT in DualShock 4 mode, if any.
+    /// </summary>
+    private string? _detectedDevicePath;
+
+    [ObservableProperty]
+    private bool _isDetected;
+
+    [ObservableProperty]
+    private bool _isSwitching;
+
+    [ObservableProperty]
+    private InfoBarSeverity _severity = InfoBarSeverity.Informational;
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private string _statusTitle = string.Empty;
+
+    /// <summary>
+    ///     True if a switch attempt can currently be made.
+    /// </summary>
+    public bool CanSwitch => IsDetected && !IsSwitching;
+
+    public void Dispose()
+    {
+        StopListening();
+    }
+
+    /// <summary>
+    ///     Starts watching for HID device arrivals/removals and performs an initial scan.
+    /// </summary>
+    public void StartListening()
+    {
+        if (_listener != null)
+        {
+            return;
+        }
+
+        Log.Logger.Information("Starting detection of Defender BT (DualShock 4 mode) devices");
+
+        _listener = new DeviceNotificationListener();
+        _listener.DeviceArrived += OnListenerDevicesArrivedOrRemoved;
+        _listener.DeviceRemoved += OnListenerDevicesArrivedOrRemoved;
+        _listener.StartListen(DefenderBtModeSwitcher.HidDeviceInterfaceGuid);
+
+        Rescan();
+    }
+
+    /// <summary>
+    ///     Stops watching for HID device arrivals/removals.
+    /// </summary>
+    public void StopListening()
+    {
+        Log.Logger.Information("Stopping detection of Defender BT (DualShock 4 mode) devices");
+        _listener?.StopListen();
+        _listener?.Dispose();
+        _listener = null;
+    }
+
+    /// <summary>
+    ///     Sends the PS3 mode-switch probe to the currently detected device, if any.
+    /// </summary>
+    public bool TrySwitchToPs3Mode()
+    {
+        if (_detectedDevicePath is null)
+        {
+            return false;
+        }
+
+        IsSwitching = true;
+
+        try
+        {
+            DefenderBtModeSwitchResult result =
+                DefenderBtModeSwitcher.TrySwitchToPs3Mode(_detectedDevicePath);
+
+            Log.Logger.Information(
+                "Defender BT PS3 mode-switch attempt for {DevicePath} resulted in {Result}",
+                _detectedDevicePath, result);
+
+            return result == DefenderBtModeSwitchResult.Sent;
+        }
+        finally
+        {
+            IsSwitching = false;
+        }
+    }
+
+    private void OnListenerDevicesArrivedOrRemoved(DeviceEventArgs e)
+    {
+        Application.Current?.Dispatcher.BeginInvoke(Rescan);
+    }
+
+    private void Rescan()
+    {
+        string? foundPath = null;
+
+        int instance = 0;
+        while (Devcon.FindByInterfaceGuid(
+                   DefenderBtModeSwitcher.HidDeviceInterfaceGuid, out string? path, out string? _, instance++))
+        {
+            if (path is null || !DefenderBtModeSwitcher.IsDefenderBtInDs4Mode(path))
+            {
+                continue;
+            }
+
+            foundPath = path;
+            break;
+        }
+
+        _detectedDevicePath = foundPath;
+        IsDetected = foundPath is not null;
+
+        if (IsDetected)
+        {
+            StatusTitle = "Retro Fighters Defender BT detected in DualShock 4 mode";
+            StatusMessage =
+                "Switch it to PS3 (DualShock 3) mode so DsHidMini can bind to it and Bluetooth pairing becomes available.";
+            Severity = InfoBarSeverity.Informational;
+
+            if (ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode)
+            {
+                Log.Logger.Information(
+                    "AutoSwitchDefenderBtToPs3Mode is enabled, automatically switching detected device");
+                TrySwitchToPs3Mode();
+            }
+        }
+        else
+        {
+            StatusTitle = string.Empty;
+            StatusMessage = string.Empty;
+        }
+
+        OnPropertyChanged(nameof(CanSwitch));
+    }
+}

--- a/ControlApp/Services/DefenderBtStatusService.cs
+++ b/ControlApp/Services/DefenderBtStatusService.cs
@@ -13,12 +13,30 @@ namespace Nefarius.DsHidMini.ControlApp.Services;
 /// </summary>
 public partial class DefenderBtStatusService : ObservableObject, IDisposable
 {
+    /// <summary>
+    ///     How long to wait after the last HID arrival/removal notification before actually rescanning, so a
+    ///     burst of notifications (e.g. whole-bus re-enumeration) coalesces into a single scan.
+    /// </summary>
+    private static readonly TimeSpan RescanDebounce = TimeSpan.FromMilliseconds(250);
+
     private DeviceNotificationListener? _listener;
 
     /// <summary>
     ///     HID device path (symbolic link) of the currently detected Defender BT in DualShock 4 mode, if any.
     /// </summary>
     private string? _detectedDevicePath;
+
+    /// <summary>
+    ///     Cancellation source for the pending debounced rescan, if any. Re-created (cancelling the previous
+    ///     one) every time a new notification arrives so only the latest one actually runs.
+    /// </summary>
+    private CancellationTokenSource? _debounceCts;
+
+    /// <summary>
+    ///     Incremented for every queued scan; used to discard results from a stale/out-of-order scan that
+    ///     completed after a newer one.
+    /// </summary>
+    private int _scanGeneration;
 
     [ObservableProperty]
     private bool _isDetected;
@@ -62,7 +80,7 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
         _listener.DeviceRemoved += OnListenerDevicesArrivedOrRemoved;
         _listener.StartListen(DefenderBtModeSwitcher.HidDeviceInterfaceGuid);
 
-        Rescan();
+        QueueRescan();
     }
 
     /// <summary>
@@ -74,10 +92,15 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
         _listener?.StopListen();
         _listener?.Dispose();
         _listener = null;
+
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = null;
     }
 
     /// <summary>
-    ///     Sends the PS3 mode-switch probe to the currently detected device, if any.
+    ///     Sends the PS3 mode-switch probe to the currently detected device, if any. Intended to be called from
+    ///     the UI thread (e.g. a button command), since it toggles <see cref="IsSwitching" />.
     /// </summary>
     public bool TrySwitchToPs3Mode()
     {
@@ -107,24 +130,94 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
 
     private void OnListenerDevicesArrivedOrRemoved(DeviceEventArgs e)
     {
-        Application.Current?.Dispatcher.BeginInvoke(Rescan);
+        QueueRescan();
     }
 
-    private void Rescan()
+    /// <summary>
+    ///     Coalesces bursts of HID arrival/removal notifications into a single debounced rescan. The actual HID
+    ///     enumeration and <c>CreateFile</c>/<c>HidD_GetAttributes</c> work happens on a thread-pool thread;
+    ///     only the resulting observable state update is marshaled back onto the WPF dispatcher.
+    /// </summary>
+    private void QueueRescan()
     {
-        string? foundPath = null;
+        CancellationTokenSource cts = new();
+        CancellationTokenSource? previous = Interlocked.Exchange(ref _debounceCts, cts);
+        previous?.Cancel();
+        previous?.Dispose();
 
+        int generation = Interlocked.Increment(ref _scanGeneration);
+        CancellationToken token = cts.Token;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(RescanDebounce, token).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            RunScan(generation);
+        }, token);
+    }
+
+    /// <summary>
+    ///     Runs on a thread-pool thread: enumerates HID devices, opens/queries each candidate, and - if a match
+    ///     is found and auto-switch is enabled - sends the mode-switch probe, all off the UI thread. Only the
+    ///     final observable state update is marshaled back to the dispatcher, guarded against staleness by
+    ///     <paramref name="generation" />.
+    /// </summary>
+    private void RunScan(int generation)
+    {
+        string? foundPath = FindDefenderBtCandidatePath();
+
+        if (foundPath is not null && ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode)
+        {
+            // A newer scan superseded this one; do not act on a stale result.
+            if (generation != Volatile.Read(ref _scanGeneration))
+            {
+                return;
+            }
+
+            Log.Logger.Information(
+                "AutoSwitchDefenderBtToPs3Mode is enabled, automatically switching detected device");
+            DefenderBtModeSwitcher.TrySwitchToPs3Mode(foundPath);
+        }
+
+        Application.Current?.Dispatcher.BeginInvoke(() => ApplyScanResult(generation, foundPath));
+    }
+
+    private static string? FindDefenderBtCandidatePath()
+    {
         int instance = 0;
         while (Devcon.FindByInterfaceGuid(
                    DefenderBtModeSwitcher.HidDeviceInterfaceGuid, out string? path, out string? _, instance++))
         {
-            if (path is null || !DefenderBtModeSwitcher.IsDefenderBtInDs4Mode(path))
+            if (path is not null && DefenderBtModeSwitcher.IsDefenderBtInDs4Mode(path))
             {
-                continue;
+                return path;
             }
+        }
 
-            foundPath = path;
-            break;
+        return null;
+    }
+
+    /// <summary>
+    ///     Runs on the UI thread. Applies the result of a background scan to observable state, unless a newer
+    ///     scan has since been queued or completed.
+    /// </summary>
+    private void ApplyScanResult(int generation, string? foundPath)
+    {
+        if (generation != _scanGeneration)
+        {
+            return;
         }
 
         _detectedDevicePath = foundPath;
@@ -136,13 +229,6 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
             StatusMessage =
                 "Switch it to PS3 (DualShock 3) mode so DsHidMini can bind to it and Bluetooth pairing becomes available.";
             Severity = InfoBarSeverity.Informational;
-
-            if (ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode)
-            {
-                Log.Logger.Information(
-                    "AutoSwitchDefenderBtToPs3Mode is enabled, automatically switching detected device");
-                TrySwitchToPs3Mode();
-            }
         }
         else
         {

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -49,6 +49,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
         IContentDialogService contentDialogService,
         AddressValidator addressValidator,
         BthPS3StatusService bthPs3,
+        DefenderBtStatusService defenderBt,
         INavigationService navigationService
     )
     {
@@ -60,11 +61,14 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
         _contentDialogService = contentDialogService;
         _addressValidator = addressValidator;
         BthPs3 = bthPs3;
+        DefenderBt = defenderBt;
         _navigationService = navigationService;
         RefreshDevicesList();
     }
 
     public BthPS3StatusService BthPs3 { get; }
+
+    public DefenderBtStatusService DefenderBt { get; }
 
 
     /// <summary>
@@ -108,6 +112,19 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
     private void GoToBthPs3Settings()
     {
         _navigationService.Navigate(typeof(SettingsPage));
+    }
+
+    [RelayCommand]
+    private void SwitchDefenderBtToPs3Mode()
+    {
+        if (DefenderBt.TrySwitchToPs3Mode())
+        {
+            _appSnackbarMessagesService.ShowDefenderBtSwitchedToPs3ModeMessage();
+        }
+        else
+        {
+            _appSnackbarMessagesService.ShowDefenderBtSwitchToPs3ModeFailedMessage();
+        }
     }
 
     private void OnDshmConfigUpdated(object? obj, EventArgs? eventArgs)

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -86,6 +86,35 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         }
     }
 
+    /// <summary>
+    ///     When enabled, a Retro Fighters Defender Bluetooth Edition detected in DualShock 4 mode is switched
+    ///     into PS3 (DualShock 3) mode automatically instead of requiring the "Switch to PS3 mode" button on the
+    ///     Devices page (see issue #282).
+    /// </summary>
+    public bool AutoSwitchDefenderBtToPs3Mode
+    {
+        get => ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode;
+        set
+        {
+            if (ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode == value)
+            {
+                return;
+            }
+
+            ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode = value;
+            try
+            {
+                ApplicationConfiguration.Instance.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error(ex, "Failed to persist AutoSwitchDefenderBtToPs3Mode.");
+            }
+
+            OnPropertyChanged();
+        }
+    }
+
     public Task OnNavigatedToAsync()
     {
         if (!_isInitialized)

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -654,6 +654,8 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
                           ➤ The BthPS3 driver is required to be installed and operating for Windows to allow paired controllers to connect.
 
                           ➤ If in "To this PC" mode, the PC's bluetooth adapter must be enabled and turned ON for pairing to succeed.
+
+                          ➤ Retro Fighters Defender Bluetooth Edition owners: plug the controller in via USB, then use the "Switch to PS3 mode" button on the Devices page (shown when it's detected in DualShock 4 mode) before pairing.
                           """,
                 PrimaryButtonText = "I need more help!",
                 CloseButtonText = "Close"

--- a/ControlApp/Views/Pages/DevicesPage.xaml
+++ b/ControlApp/Views/Pages/DevicesPage.xaml
@@ -37,6 +37,23 @@
                 Command="{Binding ViewModel.GoToBthPs3SettingsCommand}"
                 Content="Details" />
         </StackPanel>
+        <StackPanel
+            Margin="0,0,0,8"
+            DockPanel.Dock="Top"
+            Visibility="{Binding ViewModel.DefenderBt.IsDetected, Converter={StaticResource BoolToVis_TV_FC}}">
+            <ui:InfoBar
+                Title="{Binding ViewModel.DefenderBt.StatusTitle}"
+                IsClosable="False"
+                IsOpen="True"
+                Message="{Binding ViewModel.DefenderBt.StatusMessage}"
+                Severity="{Binding ViewModel.DefenderBt.Severity}" />
+            <ui:Button
+                Margin="0,4,0,0"
+                HorizontalAlignment="Left"
+                Command="{Binding ViewModel.SwitchDefenderBtToPs3ModeCommand}"
+                Content="Switch to PS3 mode"
+                IsEnabled="{Binding ViewModel.DefenderBt.CanSwitch}" />
+        </StackPanel>
         <Grid VerticalAlignment="Stretch">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="250" />

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -38,6 +38,15 @@
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                 Text="When enabled, Minimize and Close hide ControlApp to the notification area. Open the window from the tray icon, or choose Exit to quit."
                 TextWrapping="Wrap" />
+            <CheckBox
+                Margin="0,16,0,8"
+                Content="Automatically switch Retro Fighters Defender BT to PS3 mode"
+                IsChecked="{Binding ViewModel.AutoSwitchDefenderBtToPs3Mode, Mode=TwoWay}" />
+            <TextBlock
+                MaxWidth="600"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="When enabled, a Retro Fighters Defender Bluetooth Edition detected in DualShock 4 mode is switched into PS3 (DualShock 3) mode automatically, instead of requiring the 'Switch to PS3 mode' button on the Devices page."
+                TextWrapping="Wrap" />
 
             <ui:TextBlock
                 Margin="0,28,0,8"

--- a/ControlApp/Views/Windows/MainWindow.xaml.cs
+++ b/ControlApp/Views/Windows/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows.Controls;
 
 using Nefarius.DsHidMini.ControlApp.Models;
+using Nefarius.DsHidMini.ControlApp.Services;
 using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
 
 using Wpf.Ui;
@@ -14,10 +15,12 @@ namespace Nefarius.DsHidMini.ControlApp.Views.Windows;
 public partial class MainWindow : INavigationWindow
 {
     private readonly DshmDevMan _dshmDevMan;
+    private readonly DefenderBtStatusService _defenderBtStatusService;
 
     public MainWindow(
         MainWindowViewModel viewModel,
         DshmDevMan dshmDevMan, //
+        DefenderBtStatusService defenderBtStatusService,
         INavigationService navigationService,
         IServiceProvider serviceProvider,
         ISnackbarService snackbarService,
@@ -28,6 +31,7 @@ public partial class MainWindow : INavigationWindow
         DataContext = this;
 
         _dshmDevMan = dshmDevMan;
+        _defenderBtStatusService = defenderBtStatusService;
 
         SystemThemeWatcher.Watch(this);
 
@@ -67,6 +71,7 @@ public partial class MainWindow : INavigationWindow
         base.OnSourceInitialized(e);
 
         _dshmDevMan.StartListeningForDshmDevices();
+        _defenderBtStatusService.StartListening();
         ApplyMinimizeToTraySetting();
     }
 
@@ -96,6 +101,7 @@ public partial class MainWindow : INavigationWindow
         }
 
         _dshmDevMan.StopListeningForDshmDevices();
+        _defenderBtStatusService.StopListening();
         base.OnClosing(e);
     }
 

--- a/docs/PS3_USB_STARTUP.md
+++ b/docs/PS3_USB_STARTUP.md
@@ -88,10 +88,61 @@ re-derive them from the pcaps.
   pipe at all. This is the primary real-world case
   `DsUsb_PrepareHardware`'s pipe validation now tolerates (falls back to
   `DsUsbOutputReportTransportControlEndpoint`, see `driver/DsUsb.c` and
-  `driver/DsCommon.h`).
-- **Retro Fighters Defender (BT variant)**, when plugged into a PS3 over
-  USB, answers both `0xF2` and `0xF5` correctly, never STALLs `SET_IDLE`,
-  and starts streaming input reports before the console ever sends `0xF4`.
+  `driver/DsCommon.h`). `054C:0CDA` is not a DualShock 3 identity at all -
+  it is the **PlayStation Classic controller** identity (49-byte report
+  descriptor, one IN endpoint, digital buttons only). It already works on
+  Windows as a plain HID gamepad without DsHidMini, and binding DsHidMini
+  to it would misparse PS-Classic input reports as DS3 reports, so it is
+  intentionally **not** added to `dshidmini.inf`. The dongle's other two
+  modes, XInput (`045E:028E`) and generic ShanWan DirectInput
+  (`2563:0575`, 137-byte descriptor with the `0x2621` PS3 "magic" feature),
+  also already work without DsHidMini. Whether the OG dongle can ever
+  present a `054C:0268` DS3 identity on a real PS3 (like the BT variant
+  below) is unconfirmed and would need a hardware capture to settle.
+- **Retro Fighters Defender (Bluetooth Edition)** starts a PS3 USB session
+  enumerated as a **DualShock 4** (`054C:05C4`, `bcdDevice 0x0221`,
+  467-byte report descriptor - a genuine DS4 is `bcdDevice 0x0100` with a
+  483-byte descriptor, so the two are distinguishable without touching the
+  controller). In that identity it answers both `0xF2` and `0xF5`
+  correctly, never STALLs `SET_IDLE`, and starts streaming input reports
+  before the console ever sends `0xF4`. The actual host-detection trick,
+  confirmed from a real PS3 capture
+  (`2024-05-14_PS3-plugin-and-rumble.pcap`,
+  [CircumSpector/Research](https://github.com/CircumSpector/Research)), is
+  a DS4 HID feature report:
+  1. PS3 does `SET_PROTOCOL`, `SET_IDLE`, reads one interrupt IN report
+     from the DS4 identity, then sends
+     **`SET_REPORT Feature 0x14`, 17 bytes:
+     `14 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00`.**
+  2. The device stops answering interrupt IN, drops off the bus, and
+     roughly 1 second later re-enumerates as a **DualShock 3**
+     (`054C:0268`, `bcdUSB 1.10`, `bcdDevice 0x0100`, 148-byte descriptor,
+     interrupt EP1 IN + EP2 OUT).
+  3. In DS3 mode it answers `GET 0xF5` with its stored host MAC and
+     otherwise follows the normal DS3 startup sequence documented above
+     (`0xF4`, EP0 output report, interrupt OUT at ~16 ms).
+
+  `2024-05-14_DS4Rev1-on-PS3.pcap` confirms the PS3 sends the exact same
+  `0x14` report to a **genuine** DS4 every ~1 second for the whole
+  session - the DS4 simply ignores it - so replaying this report from a
+  Windows-side tool is harmless to real DS4 controllers.
+  `2024-05-04_Windows-PC-plugin-capture.pcapng` confirms Windows itself
+  never sends `Feature 0x14`, which is the only reason the Defender BT
+  never leaves DS4 mode when plugged into a PC; cycling the controller to
+  DS4 mode (hold Home ~3 s, per the manual) and then replaying the same
+  `0x14` report via `HidD_SetFeature` from user mode is enough to make it
+  re-enumerate as `USB\VID_054C&PID_0268`, which DsHidMini already binds
+  to via the existing `dshidmini.inf` entry. ControlApp's
+  `DefenderBtModeSwitcher` (see issue #282) automates exactly this replay
+  so Bluetooth pairing becomes reachable on Windows without resorting to a
+  PS3-first-pairing + MAC-spoofing workaround.
+
+  The relevant `tshark` filters used against the captures above (run
+  locally; see the `analyze_pcap` limitation note below):
+  ```
+  tshark -r 2024-05-14_PS3-plugin-and-rumble.pcap -Y "usb.device_address == <addr> && usb.control_transfer" -T fields -e frame.number -e usb.device_address -e usb.setup.bRequest -e usb.setup.wValue -e usb.capdata
+  tshark -r 2024-05-14_PS3-plugin-and-rumble.pcap -Y "usb.src == 'host' && usbll.data && usbll.pid == 0x2d" -T fields -e frame.number -e usbll.data
+  ```
 - **Linux `hid-sony`** and **SDL** both treat a failed `0xF2` as fatal to
   Bluetooth-address discovery (but not to basic HID functionality), never
   send `Feature 0xF4` over USB at all, force *all* USB output through EP0


### PR DESCRIPTION
- DefenderBtModeSwitcher: replays the PS3's DS4 Feature 0x14 probe via HidD_SetFeature so a Retro Fighters Defender Bluetooth Edition detaches and re-enumerates as a DualShock 3, which DsHidMini already binds to via dshidmini.inf.
- DefenderBtStatusService: HID arrival/removal listener that detects a Defender BT in DualShock 4 mode and exposes it to the UI.
- DevicesPage: InfoBar + 'Switch to PS3 mode' button, wired through a new DevicesViewModel command, with snackbar feedback.
- Opt-in AutoSwitchDefenderBtToPs3Mode setting (SettingsPage toggle) to switch automatically on arrival.
- Pairing help dialog now mentions the Defender BT workflow.
- docs/PS3_USB_STARTUP.md: documented the DS4-then-0x14-then-DS3 sequence (byte values, genuine-DS4 comparison, tshark filters) and clarified that the OG dongle's 054C:0CDA is a PlayStation Classic identity, not a DS3 emulation, so it is intentionally not added to dshidmini.inf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detection for Retro Fighters Defender Bluetooth Edition controllers in DualShock 4 mode.
  - Added a Devices page status panel with an option to switch compatible controllers to PS3 mode.
  - Added an optional setting to switch controllers automatically when detected.
  - Added success and failure notifications for mode switching.

- **Documentation**
  - Expanded controller setup guidance, including USB pairing and PS3 mode instructions.
  - Added technical documentation covering Defender Bluetooth mode switching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->