### PR TITLE
ci: sign and mirror XInput DLLs with ControlApp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
             bin/*.exe
 
   control-app:
-    name: 'Sign and mirror ControlApp'
+    name: 'Sign and mirror ControlApp and XInput'
     needs: build
     if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: windows-2022
@@ -296,6 +296,18 @@ jobs:
           name: dshidmini-x64
           path: .
 
+      - name: 'Download ARM64 artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: dshidmini-ARM64
+          path: .
+
+      - name: 'Download x86 artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: dshidmini-x86
+          path: .
+
       - name: 'Assert ControlApp is unsigned'
         shell: pwsh
         run: |
@@ -310,6 +322,26 @@ jobs:
           }
           Write-Output "Unsigned as required: $file"
 
+      - name: 'Assert XInput DLLs are unsigned'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $files = @(
+            'bin\x64\XInput1_3.dll',
+            'bin\x86\XInput1_3.dll',
+            'bin\ARM64\XInput1_3.dll'
+          )
+          foreach ($file in $files) {
+            if (-not (Test-Path -LiteralPath $file)) {
+              throw "File not found: $file"
+            }
+            $sig = Get-AuthenticodeSignature -LiteralPath $file
+            if ($sig.Status -ne 'NotSigned') {
+              throw "Expected unsigned $file but Get-AuthenticodeSignature returned $($sig.Status)."
+            }
+            Write-Output "Unsigned as required: $file"
+          }
+
       - name: 'Setup .NET'
         uses: actions/setup-dotnet@v4
         with:
@@ -322,6 +354,17 @@ jobs:
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}
           in-place: true
           files: bin/ControlApp.exe
+
+      - name: 'Sign XInput DLLs'
+        uses: nefarius/SignRelay@master
+        with:
+          server: ${{ env.SIGN_RELAY_SERVER }}
+          token: ${{ env.SIGN_RELAY_CI_TOKEN }}
+          in-place: true
+          files: |
+            bin/x64/XInput1_3.dll
+            bin/x86/XInput1_3.dll
+            bin/ARM64/XInput1_3.dll
 
       - name: 'Verify signed ControlApp'
         shell: pwsh
@@ -340,14 +383,53 @@ jobs:
           }
           Write-Output "Signed: $file (Status=$($sig.Status); Subject=$($sig.SignerCertificate.Subject))"
 
-      - name: 'Stage ControlApp'
+      - name: 'Verify signed XInput DLLs'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $dest = 'control-app-artifact\bin'
-          New-Item -ItemType Directory -Force -Path $dest | Out-Null
-          Copy-Item -Path 'bin\*.exe' -Destination $dest
-          Get-ChildItem -LiteralPath $dest | ForEach-Object { Write-Output $_.Name }
+          $files = @(
+            'bin\x64\XInput1_3.dll',
+            'bin\x86\XInput1_3.dll',
+            'bin\ARM64\XInput1_3.dll'
+          )
+          foreach ($file in $files) {
+            $sig = Get-AuthenticodeSignature -LiteralPath $file
+            if ($sig.Status -eq 'NotSigned' -or -not $sig.SignerCertificate) {
+              throw "File is not signed: $file (Status=$($sig.Status))."
+            }
+            if ($sig.Status -eq 'HashMismatch') {
+              throw "File signature is invalid: $file (Status=$($sig.Status))."
+            }
+            if ($sig.Status -ne 'Valid') {
+              throw "File signature is not Valid: $file (Status=$($sig.Status))."
+            }
+            Write-Output "Signed: $file (Status=$($sig.Status); Subject=$($sig.SignerCertificate.Subject))"
+          }
+
+      - name: 'Stage ControlApp and XInput'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = 'control-app-artifact'
+          New-Item -ItemType Directory -Force -Path "$root\bin" | Out-Null
+          Copy-Item -Path 'bin\*.exe' -Destination "$root\bin"
+
+          $copies = @(
+            @{ Src = 'bin\x64\XInput1_3.dll'; Dest = "$root\bin\x64\XInput1_3.dll" }
+            @{ Src = 'bin\x86\XInput1_3.dll'; Dest = "$root\bin\x86\XInput1_3.dll" }
+            @{ Src = 'bin\ARM64\XInput1_3.dll'; Dest = "$root\bin\arm64\XInput1_3.dll" }
+          )
+          foreach ($copy in $copies) {
+            if (-not (Test-Path -LiteralPath $copy.Src)) {
+              throw "File not found: $($copy.Src)"
+            }
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $copy.Dest) | Out-Null
+            Copy-Item -LiteralPath $copy.Src -Destination $copy.Dest
+          }
+
+          Get-ChildItem -LiteralPath $root -Recurse -File | ForEach-Object {
+            Write-Output $_.FullName.Substring((Resolve-Path $root).Path.Length + 1)
+          }
 
       - name: 'Upload ControlApp'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Restore the public buildbot latest/bin/{x64,x86,arm64}/XInput1_3.dll download URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release builds now include digitally signed ControlApp packages and compatible XInput components for x64, x86, and ARM64 platforms.
  * Published artifacts are bundled together for easier distribution and use across supported architectures.
  * Added signature verification to help ensure packaged components are authentic and intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->