### PR TITLE
Parse Feature 0x01 and expose identification in the SDK and ControlApp.

### DIFF
--- a/ControlApp.Tests/ControlApp.Tests.csproj
+++ b/ControlApp.Tests/ControlApp.Tests.csproj
@@ -24,6 +24,7 @@
     <ItemGroup>
         <Using Include="System.IO" />
         <ProjectReference Include="..\ControlApp\ControlApp.csproj" />
+        <ProjectReference Include="..\SDK\Nefarius.DsHidMini.IPC\Nefarius.DsHidMini.IPC.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ControlApp.Tests/IdentificationParseTests.cs
+++ b/ControlApp.Tests/IdentificationParseTests.cs
@@ -1,0 +1,153 @@
+using Nefarius.DsHidMini.IPC.Models.Drivers;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class IdentificationParseTests
+{
+    // Feature 0x01 dumps from docs/MOTION.md / research/ds3-motion/dumps
+
+    private const string Ds3A1a =
+        "00 01 04 00 08 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 03 00 01 02 00 00 17 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string Ds3A1b =
+        "00 01 04 00 08 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 04 00 01 02 07 00 17 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string Ds3A2 =
+        "00 01 04 00 0b 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 04 00 01 02 07 00 17 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string Ds3E =
+        "00 01 04 00 06 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 03 00 01 02 00 00 17 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string B1 =
+        "00 01 04 01 03 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 03 00 01 02 00 00 17 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string Sixaxis1 =
+        "00 01 02 00 03 08 01 02 17 17 17 17 09 0a 00 00 " +
+        "00 00 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 01 06 00 00 00 00 00 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string Sixaxis2 =
+        "00 01 03 00 04 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 01 06 00 00 00 00 00 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string Obigben =
+        "00 01 03 00 05 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 02 01 02 00 64 00 17 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    private const string FakeDs3 =
+        "00 01 03 00 05 0c 01 02 18 18 18 18 09 0a 10 11 " +
+        "12 13 00 00 00 00 04 00 02 02 02 02 00 00 00 04 " +
+        "04 04 04 00 00 02 01 02 00 64 00 17 00 00 00 00 " +
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
+
+    [Theory]
+    [InlineData("DS3-A1a", Ds3A1a, 0x00040008, 0x18, DsIdentificationMotionPath.PlainZero, false)]
+    [InlineData("DS3-A1b", Ds3A1b, 0x00040008, 0x18, DsIdentificationMotionPath.HwCal, false)]
+    [InlineData("DS3-A2", Ds3A2, 0x0004000B, 0x18, DsIdentificationMotionPath.HwCal, false)]
+    [InlineData("DS3-E", Ds3E, 0x00040006, 0x18, DsIdentificationMotionPath.PlainZero, false)]
+    [InlineData("B1", B1, 0x00040103, 0x18, DsIdentificationMotionPath.PlainZero, false)]
+    [InlineData("SIXAXIS-1", Sixaxis1, 0x00020003, 0x17, DsIdentificationMotionPath.Sixaxis, false)]
+    [InlineData("SIXAXIS-2", Sixaxis2, 0x00030004, 0x18, DsIdentificationMotionPath.Sixaxis, false)]
+    [InlineData("Obigben", Obigben, 0x00030005, 0x18, DsIdentificationMotionPath.PlainZero, true)]
+    [InlineData("Fake DS3", FakeDs3, 0x00030005, 0x18, DsIdentificationMotionPath.PlainZero, true)]
+    public void TryParse_KnownDumps_MatchMotionPathAndCloneHeuristic(
+        string name,
+        string hex,
+        uint firmware,
+        byte padType,
+        DsIdentificationMotionPath path,
+        bool clone)
+    {
+        byte[] report = ParseHex(hex);
+
+        Assert.False(string.IsNullOrEmpty(name));
+        Assert.True(DsIdentification.TryParse(report, out DsIdentificationInfo? info));
+        Assert.NotNull(info);
+        Assert.Equal(firmware, info!.Firmware);
+        Assert.Equal(padType, info.PadType);
+        Assert.Equal(path, info.MotionPath);
+        Assert.Equal(clone, info.CloneHeuristic);
+    }
+
+    [Fact]
+    public void TryParse_HwCalWinsOverPlainZero()
+    {
+        byte[] report = ParseHex(Ds3A1b);
+
+        Assert.True(DsIdentification.TryParse(report, out DsIdentificationInfo? info));
+        Assert.Equal(new byte[] { 0x00, 0x01, 0x02, 0x07 }, info!.CalibrationFields);
+        Assert.Equal(DsIdentificationMotionPath.HwCal, info.MotionPath);
+        Assert.False(info.CloneHeuristic);
+    }
+
+    [Fact]
+    public void TryParse_Sixaxis2UsesFieldListNotTypeBytes()
+    {
+        byte[] report = ParseHex(Sixaxis2);
+
+        Assert.True(DsIdentification.TryParse(report, out DsIdentificationInfo? info));
+        Assert.Equal(0x18, info!.PadType);
+        Assert.Equal(new byte[] { 0x06 }, info.CalibrationFields);
+        Assert.Equal(DsIdentificationMotionPath.Sixaxis, info.MotionPath);
+    }
+
+    [Fact]
+    public void TryParse_RejectsTooShortBuffer()
+    {
+        Assert.False(DsIdentification.TryParse(new byte[0x20], out DsIdentificationInfo? info));
+        Assert.Null(info);
+    }
+
+    [Fact]
+    public void TryParse_RejectsZeroFieldCount()
+    {
+        byte[] report = ParseHex(Ds3A1a);
+        report[0x25] = 0;
+
+        Assert.False(DsIdentification.TryParse(report, out _));
+    }
+
+    [Fact]
+    public void FirmwareDisplay_FormatsRevisionBytes()
+    {
+        byte[] report = ParseHex(Ds3A2);
+
+        Assert.True(DsIdentification.TryParse(report, out DsIdentificationInfo? info));
+        Assert.Equal("04 00 0B", info!.FirmwareDisplay);
+    }
+
+    private static byte[] ParseHex(string hex)
+    {
+        string[] parts = hex.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        byte[] bytes = new byte[parts.Length];
+        for (int i = 0; i < parts.Length; i++)
+        {
+            bytes[i] = Convert.ToByte(parts[i], 16);
+        }
+
+        Assert.Equal(DsIdentification.ReportLength, bytes.Length);
+        return bytes;
+    }
+}

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -381,6 +381,94 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         Device.GetProperty<string>(DevicePropertyKey.Device_DriverVersion)!.ToUpperInvariant();
 
     /// <summary>
+    ///     <see langword="true"/> if Feature 0x01 identification was published (USB pads
+    ///     that answered GET). Bluetooth instances do not have this property.
+    /// </summary>
+    public bool HasIdentification
+    {
+        get
+        {
+            try
+            {
+                byte[]? raw = Device.GetProperty<byte[]>(DsHidMiniDriver.IdentificationDataProperty);
+                return raw is { Length: > 0 };
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    private DsIdentificationInfo? IdentificationInfo
+    {
+        get
+        {
+            try
+            {
+                byte[]? raw = Device.GetProperty<byte[]>(DsHidMiniDriver.IdentificationDataProperty);
+                if (raw is { Length: > 0 } && DsIdentification.TryParse(raw, out DsIdentificationInfo? parsed))
+                {
+                    return parsed;
+                }
+            }
+            catch
+            {
+                // Property absent or blob too short to decode.
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Feature 0x01 firmware/board revision, e.g. <c>04 00 08</c>.
+    /// </summary>
+    public string IdentificationFirmware => IdentificationInfo?.FirmwareDisplay ?? "Unknown";
+
+    /// <summary>
+    ///     Feature 0x01 pad/sensor type byte. Informational; not a gyro-path test.
+    /// </summary>
+    public string IdentificationPadType
+    {
+        get
+        {
+            if (IdentificationInfo is null)
+            {
+                return "Unknown";
+            }
+
+            return IdentificationInfo.PadType switch
+            {
+                0x18 => "DualShock 3-class (0x18)",
+                0x17 => "SIXAXIS-class (0x17)",
+                byte value => $"Unknown (0x{value:X2})"
+            };
+        }
+    }
+
+    /// <summary>
+    ///     Feature 0x01 motion path derived from the calibration field list.
+    /// </summary>
+    public string IdentificationMotionPath =>
+        IdentificationInfo?.MotionPath switch
+        {
+            DsIdentificationMotionPath.HwCal => "Hardware-calibrated gyro",
+            DsIdentificationMotionPath.PlainZero => "Software zero",
+            DsIdentificationMotionPath.Sixaxis => "SIXAXIS",
+            _ => "Unknown"
+        };
+
+    /// <summary>
+    ///     Feature 0x01 clone heuristic (field list <c>01 02</c> and byte <c>0x29 == 0x64</c>).
+    ///     Not the OUI genuine check.
+    /// </summary>
+    public bool IdentificationCloneHeuristic => IdentificationInfo?.CloneHeuristic ?? false;
+
+    public string IdentificationCloneHeuristicText =>
+        IdentificationCloneHeuristic ? "Likely counterfeit" : "No match";
+
+    /// <summary>
     ///     The device Instance ID.
     /// </summary>
     public string InstanceId => Device.InstanceId;

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -466,7 +466,11 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     public bool IdentificationCloneHeuristic => IdentificationInfo?.CloneHeuristic ?? false;
 
     public string IdentificationCloneHeuristicText =>
-        IdentificationCloneHeuristic ? "Likely counterfeit" : "No match";
+        IdentificationInfo is null
+            ? "Unknown"
+            : IdentificationCloneHeuristic
+                ? "Likely counterfeit"
+                : "No match";
 
     /// <summary>
     ///     The device Instance ID.

--- a/ControlApp/Views/UserControls/DeviceUserControl.xaml
+++ b/ControlApp/Views/UserControls/DeviceUserControl.xaml
@@ -108,6 +108,64 @@
                                 DockPanel.Dock="Right"
                                 Text="{Binding BatteryStatusInText}" />
                         </DockPanel>
+                        <!--  Feature 0x01 identification (USB only)  -->
+                        <DockPanel
+                            DockPanel.Dock="Top"
+                            LastChildFill="False"
+                            Visibility="{Binding HasIdentification, Converter={StaticResource BoolToVis_TV_FC}}">
+                            <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
+                                <ui:TextBlock
+                                    DockPanel.Dock="Left"
+                                    Style="{StaticResource MyKey_InfoDescriptionTextbox}"
+                                    Text="Firmware revision:" />
+                                <ui:TextBlock
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    DockPanel.Dock="Right"
+                                    Text="{Binding IdentificationFirmware}" />
+                            </DockPanel>
+                            <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
+                                <ui:TextBlock
+                                    DockPanel.Dock="Left"
+                                    Style="{StaticResource MyKey_InfoDescriptionTextbox}"
+                                    Text="Controller type:" />
+                                <ui:TextBlock
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    DockPanel.Dock="Right"
+                                    Text="{Binding IdentificationPadType}" />
+                            </DockPanel>
+                            <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
+                                <ui:TextBlock
+                                    DockPanel.Dock="Left"
+                                    Style="{StaticResource MyKey_InfoDescriptionTextbox}"
+                                    Text="Motion path:" />
+                                <ui:TextBlock
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    DockPanel.Dock="Right"
+                                    Text="{Binding IdentificationMotionPath}" />
+                            </DockPanel>
+                            <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
+                                <ui:TextBlock
+                                    DockPanel.Dock="Left"
+                                    Style="{StaticResource MyKey_InfoDescriptionTextbox}"
+                                    Text="Clone heuristic:" />
+                                <ui:SymbolIcon
+                                    DockPanel.Dock="Right"
+                                    FontSize="{StaticResource MyKey_SymbolFontSize}"
+                                    Foreground="Yellow"
+                                    Style="{StaticResource MyKey_StatusSymbol}"
+                                    Symbol="Warning24"
+                                    ToolTip="Feature 0x01 matches a known counterfeit signature (field list 01 02 and byte 0x29 = 0x64). This is a heuristic, not a verdict. The OUI/MAC genuine check is separate."
+                                    Visibility="{Binding IdentificationCloneHeuristic, Converter={StaticResource BoolToVis_TV_FH}}" />
+                                <ui:TextBlock
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    DockPanel.Dock="Right"
+                                    Text="{Binding IdentificationCloneHeuristicText}" />
+                            </DockPanel>
+                        </DockPanel>
                         <!--  Current HID mode  -->
                         <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
                             <ui:TextBlock

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Drivers/DsHidMiniDriver.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Drivers/DsHidMiniDriver.cs
@@ -30,6 +30,13 @@ public static class DsHidMiniDriver
         Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 3,
         typeof(int));
 
+    /// <summary>
+    ///     Raw 64-byte <c>GET Feature 0x01</c> identification blob. USB only; see issue #50.
+    /// </summary>
+    public static DevicePropertyKey IdentificationDataProperty => CustomDeviceProperty.CreateCustomDeviceProperty(
+        Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 4,
+        typeof(byte[]));
+
     public static DevicePropertyKey LastHostRequestStatusProperty => CustomDeviceProperty.CreateCustomDeviceProperty(
         Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 5,
         typeof(int));
@@ -48,6 +55,35 @@ public static class DsHidMiniDriver
     /// </summary>
     public static DevicePropertyKey DeviceAddressSynthesizedProperty => CustomDeviceProperty.CreateCustomDeviceProperty(
         Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 7,
+        typeof(bool));
+
+    /// <summary>
+    ///     Feature 0x01 firmware/board revision packed as <c>b2&lt;&lt;16 | b3&lt;&lt;8 | b4</c>.
+    /// </summary>
+    public static DevicePropertyKey IdentificationFirmwareProperty => CustomDeviceProperty.CreateCustomDeviceProperty(
+        Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 8,
+        typeof(uint));
+
+    /// <summary>
+    ///     Feature 0x01 pad/sensor type byte (offset 8). Informational only; not a gyro-path test.
+    /// </summary>
+    public static DevicePropertyKey IdentificationPadTypeProperty => CustomDeviceProperty.CreateCustomDeviceProperty(
+        Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 9,
+        typeof(byte));
+
+    /// <summary>
+    ///     Feature 0x01 motion path derived from the calibration field list.
+    /// </summary>
+    public static DevicePropertyKey IdentificationMotionPathProperty => CustomDeviceProperty.CreateCustomDeviceProperty(
+        Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 10,
+        typeof(byte));
+
+    /// <summary>
+    ///     <see langword="true"/> if Feature 0x01 matches the clone heuristic (field list
+    ///     <c>01 02</c> and byte <c>0x29 == 0x64</c>). Heuristic, not a verdict.
+    /// </summary>
+    public static DevicePropertyKey IdentificationCloneHeuristicProperty => CustomDeviceProperty.CreateCustomDeviceProperty(
+        Guid.Parse("{3FECF510-CC94-4FBE-8839-738201F84D59}"), 11,
         typeof(bool));
 
     #endregion
@@ -140,6 +176,40 @@ public enum DsBatteryStatus : byte
     /// </summary>
     [Description("Charged")]
     Charged = 0xEF
+}
+
+/// <summary>
+///     Gyro / motion code path derived from the Feature 0x01 calibration field list.
+///     Type bytes 8-11 must not be used to pick this path (SIXAXIS-2 reports 0x18).
+/// </summary>
+[TypeConverter(typeof(EnumDescriptionTypeConverter))]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public enum DsIdentificationMotionPath : byte
+{
+    /// <summary>
+    ///     Report missing or field list could not be parsed.
+    /// </summary>
+    [Description("Unknown")]
+    Unknown = 0,
+
+    /// <summary>
+    ///     Software zero against the EEPROM gyro zero. Field list starts <c>01 02</c>
+    ///     at index 0 or 1 and does not contain field <c>0x07</c>.
+    /// </summary>
+    [Description("Software zero")]
+    PlainZero = 1,
+
+    /// <summary>
+    ///     Hardware-calibrated gyro. Field list contains <c>0x07</c>.
+    /// </summary>
+    [Description("Hardware-calibrated gyro")]
+    HwCal = 2,
+
+    /// <summary>
+    ///     Original SIXAXIS path. <c>PLAIN_ZERO</c> is clear (typically a single field <c>06</c>).
+    /// </summary>
+    [Description("SIXAXIS")]
+    Sixaxis = 3
 }
 
 /// <summary>

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Drivers/DsIdentification.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Drivers/DsIdentification.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nefarius.DsHidMini.IPC.Models.Drivers;
+
+/// <summary>
+///     Decoded DualShock 3 / SIXAXIS Feature 0x01 identification report.
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public sealed class DsIdentificationInfo
+{
+    public DsIdentificationInfo(
+        uint firmware,
+        byte padType,
+        DsIdentificationMotionPath motionPath,
+        bool cloneHeuristic,
+        byte[] calibrationFields)
+    {
+        Firmware = firmware;
+        PadType = padType;
+        MotionPath = motionPath;
+        CloneHeuristic = cloneHeuristic;
+        CalibrationFields = calibrationFields;
+    }
+
+    /// <summary>
+    ///     Firmware/board revision packed as <c>b2&lt;&lt;16 | b3&lt;&lt;8 | b4</c>.
+    /// </summary>
+    public uint Firmware { get; }
+
+    /// <summary>
+    ///     First of the four pad/sensor type bytes at offsets 8-11. Informational only.
+    /// </summary>
+    public byte PadType { get; }
+
+    /// <summary>
+    ///     Motion path derived from the calibration field list. Field <c>0x07</c> wins
+    ///     over <c>PLAIN_ZERO</c>.
+    /// </summary>
+    public DsIdentificationMotionPath MotionPath { get; }
+
+    /// <summary>
+    ///     <see langword="true"/> if the field list is exactly <c>01 02</c> and byte
+    ///     <c>0x29</c> is <c>0x64</c>. Heuristic, not a verdict.
+    /// </summary>
+    public bool CloneHeuristic { get; }
+
+    /// <summary>
+    ///     Calibration field IDs from offset <c>0x26</c>.
+    /// </summary>
+    public byte[] CalibrationFields { get; }
+
+    /// <summary>
+    ///     Firmware bytes formatted as space-separated hex, e.g. <c>04 00 08</c>.
+    /// </summary>
+    public string FirmwareDisplay =>
+        $"{(Firmware >> 16) & 0xFF:X2} {(Firmware >> 8) & 0xFF:X2} {Firmware & 0xFF:X2}";
+}
+
+/// <summary>
+///     Parses the 64-byte Feature 0x01 identification blob. Rules match
+///     <c>DsIdentification_Parse</c> in the driver and <c>docs/MOTION.md</c>.
+/// </summary>
+public static class DsIdentification
+{
+    public const int ReportLength = 64;
+    public const int MinParseLength = 0x2A;
+    public const int FieldCountOffset = 0x25;
+    public const int FieldListOffset = 0x26;
+    public const int CloneByteOffset = 0x29;
+    public const int MaxFields = 8;
+
+    public static bool TryParse(ReadOnlySpan<byte> report, out DsIdentificationInfo? info)
+    {
+        info = null;
+
+        if (report.Length < MinParseLength)
+        {
+            return false;
+        }
+
+        byte fieldCount = report[FieldCountOffset];
+        if (fieldCount == 0 || fieldCount > MaxFields)
+        {
+            return false;
+        }
+
+        int fieldEnd = FieldListOffset + fieldCount;
+        if (fieldEnd > report.Length)
+        {
+            return false;
+        }
+
+        byte[] fields = new byte[fieldCount];
+        bool hasHwCal = false;
+        for (int i = 0; i < fieldCount; i++)
+        {
+            fields[i] = report[FieldListOffset + i];
+            if (fields[i] == 0x07)
+            {
+                hasHwCal = true;
+            }
+        }
+
+        bool plainZero = fieldCount >= 2 && fields[0] == 0x01 && fields[1] == 0x02
+                         || fieldCount >= 3 && fields[1] == 0x01 && fields[2] == 0x02;
+
+        DsIdentificationMotionPath path;
+        if (hasHwCal)
+        {
+            path = DsIdentificationMotionPath.HwCal;
+        }
+        else if (!plainZero)
+        {
+            path = DsIdentificationMotionPath.Sixaxis;
+        }
+        else
+        {
+            path = DsIdentificationMotionPath.PlainZero;
+        }
+
+        bool clone = fieldCount == 2
+                     && fields[0] == 0x01
+                     && fields[1] == 0x02
+                     && report[CloneByteOffset] == 0x64;
+
+        info = new DsIdentificationInfo(
+            ((uint)report[2] << 16) | ((uint)report[3] << 8) | report[4],
+            report[8],
+            path,
+            clone,
+            fields);
+
+        return true;
+    }
+}

--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -1,9 +1,10 @@
 # DualShock 3 / SIXAXIS motion sensors
 
 Research notes for [issue #217](https://github.com/nefarius/DsHidMini/issues/217)
-(motion support). This is the foundation for a later driver implementation;
-**nothing in here is implemented in DsHidMini yet** beyond the SIXAXIS.SYS
-byte-swap described in [What DsHidMini does today](#what-dshidmini-does-today).
+(motion support). Feature `0x01` is parsed and published as device properties
+(see [What DsHidMini publishes](#what-dshidmini-publishes)); motion output is
+**not** implemented yet beyond the SIXAXIS.SYS byte-swap described in
+[What DsHidMini does today](#what-dshidmini-does-today).
 
 Sources of truth used, in order of authority:
 
@@ -136,6 +137,26 @@ A SIXAXIS (single field `06`) matches neither, so it gets `PLAIN_ZERO` clear and
 EEPROM gyro cal-byte slot reads `0`; rajkosto's `UsbDs3.cs` encodes the same
 decision tree.
 
+When DsHidMini (and the SDK parser) collapse those flags to a single motion
+path, **`HW_CAL` wins** if field `0x07` is present. Those pads also match
+`PLAIN_ZERO` because the list is `00 01 02 07` (`01 02` starts at index 1):
+
+| Motion path | Set when | Pads |
+| --- | --- | --- |
+| `HW_CAL` | the field list contains `0x07` | DS3-A1b, DS3-A2 |
+| `SIXAXIS` | `PLAIN_ZERO` is clear (typically a single field `06`) | SIXAXIS-1, SIXAXIS-2 |
+| `PLAIN_ZERO` | the field list starts `01 02` at index 0 or 1 | B1, DS3-A1a, DS3-E, both counterfeits |
+
+### Clone heuristic
+
+A **heuristic**, not a verdict. Both known counterfeits (Obigben, Fake DS3) and
+no genuine pad in the [pad matrix](#pad-matrix) match:
+
+- the calibration field list is exactly `01 02` (count 2, no leading `00`), **and**
+- byte `0x29` is `0x64`
+
+This is independent of the OUI / MAC genuine check used elsewhere.
+
 Two observations from the [pad matrix](#pad-matrix) constrain how this may be
 implemented:
 
@@ -146,6 +167,25 @@ implemented:
   `18 18 18 18` (DS3-class) with a single field `06`, so it takes the SIXAXIS
   path and wants its cal byte at `[3]/[4]` despite claiming to be a DS3. Only
   the field list decides.
+
+### What DsHidMini publishes
+
+On USB, `DsUsb_PrepareHardware` GETs Feature `0x01` (see
+[issue #50](https://github.com/nefarius/DsHidMini/issues/50)) and writes the
+raw 64-byte blob plus the decoded fields as read-only device properties on
+`{3FECF510-CC94-4FBE-8839-738201F84D59}`:
+
+| PID | Key | Type |
+| --- | --- | --- |
+| 4 | `DEVPKEY_DsHidMini_RO_IdentificationData` | BINARY 64 |
+| 8 | `DEVPKEY_DsHidMini_RO_IdentificationFirmware` | UINT32, packed `b2<<16 \| b3<<8 \| b4` |
+| 9 | `DEVPKEY_DsHidMini_RO_IdentificationPadType` | BYTE (first of offsets 8-11; informational) |
+| 10 | `DEVPKEY_DsHidMini_RO_IdentificationMotionPath` | BYTE (`Unknown` / `PlainZero` / `HwCal` / `Sixaxis`) |
+| 11 | `DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic` | BOOLEAN |
+
+Bluetooth instances are not queried. A GET success with a parse failure still
+keeps the raw blob and leaves the decoded keys unset. Publishing these
+properties does **not** change HID mode, output reports, or rumble.
 
 ## Calibration EEPROM: `Feature 0xEF`, `0xF8`, `0xF7`
 

--- a/driver/Device.h
+++ b/driver/Device.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <DmfModule.h>
+#include "DsIdentification.h"
 
 
 EXTERN_C_START
@@ -307,13 +308,20 @@ typedef struct _DEVICE_CONTEXT
 	// 
 	BOOLEAN DeviceAddressSynthesized;
 
-	//
-	// TRUE once GET Feature 0xF2 (device address) has succeeded at least once
-	// this power-up. Gates host-address discovery, Bluetooth pairing and the
-	// wireless-instance disconnect signal, none of which are meaningful for a
-	// device that never reported a Bluetooth MAC of its own. See issue #321.
-	// 
-	BOOLEAN SupportsBluetoothAddressReports;
+		//
+		// TRUE once GET Feature 0xF2 (device address) has succeeded at least once
+		// this power-up. Gates host-address discovery, Bluetooth pairing and the
+		// wireless-instance disconnect signal, none of which are meaningful for a
+		// device that never reported a Bluetooth MAC of its own. See issue #321.
+		// 
+		BOOLEAN SupportsBluetoothAddressReports;
+
+		//
+		// Feature 0x01 identification decoded at USB PrepareHardware. Present is
+		// FALSE for Bluetooth instances and when GET or parse failed. See issue #50.
+		// 
+		BOOLEAN IdentificationPresent;
+		DS_IDENTIFICATION_INFO Identification;
 
 	//
 	// Current reported battery status

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -74,7 +74,8 @@ NTSTATUS DsUsb_Ds3RequestHostAddress(WDFDEVICE Device)
 		Ds3FeatureHostAddress,
 		0,
 		controlTransferBuffer,
-		CONTROL_TRANSFER_BUFFER_LENGTH
+		CONTROL_TRANSFER_BUFFER_LENGTH,
+		NULL
 	)))
 	{
 		/*
@@ -186,7 +187,8 @@ NTSTATUS DsUsb_Ds3Init(PDEVICE_CONTEXT Context)
 		Ds3FeatureDeviceState,
 		0,
 		hidCommandEnable,
-		ARRAYSIZE(hidCommandEnable)
+		ARRAYSIZE(hidCommandEnable),
+		NULL
 	);
 
 	FuncExit(TRACE_DS3, "status=%!STATUS!", status);
@@ -213,7 +215,8 @@ NTSTATUS DsUsb_Ds3Shutdown(PDEVICE_CONTEXT Context)
 		Ds3FeatureDeviceState,
 		0,
 		hidCommandEnable,
-		ARRAYSIZE(hidCommandEnable)
+		ARRAYSIZE(hidCommandEnable),
+		NULL
 	);
 
 	FuncExit(TRACE_DS3, "status=%!STATUS!", status);
@@ -240,7 +243,8 @@ NTSTATUS DsUsb_Ds3SendOutputReportControl(PDEVICE_CONTEXT Context, PUCHAR Buffer
 		Dss3FeatureOutputReport,
 		0,
 		Buffer,
-		BufferLength
+		BufferLength,
+		NULL
 	);
 
 	if (!NT_SUCCESS(status))
@@ -375,7 +379,8 @@ NTSTATUS DsUsb_Ds3RequestDeviceAddress(WDFDEVICE Device)
 			Ds3FeatureDeviceAddress,
 			0,
 			controlTransferBuffer,
-			CONTROL_TRANSFER_BUFFER_LENGTH
+			CONTROL_TRANSFER_BUFFER_LENGTH,
+			NULL
 		)))
 		{
 			break;
@@ -574,7 +579,8 @@ NTSTATUS DsUsb_Ds3SendPairingRequest(WDFDEVICE Device, BD_ADDR NewHostAddress)
 		Ds3FeatureHostAddress,
 		0,
 		controlBuffer,
-		SET_HOST_BD_ADDR_CONTROL_BUFFER_LENGTH
+		SET_HOST_BD_ADDR_CONTROL_BUFFER_LENGTH,
+		NULL
 	)))
 	{
 		TraceError(

--- a/driver/DsIdentification.c
+++ b/driver/DsIdentification.c
@@ -1,0 +1,163 @@
+#include "Driver.h"
+#include "DsIdentification.tmh"
+
+BOOLEAN
+DsIdentification_Parse(
+	_In_reads_(ReportLength) const UCHAR* Report,
+	_In_ SIZE_T ReportLength,
+	_Out_ PDS_IDENTIFICATION_INFO Info
+)
+{
+	UCHAR fieldCount;
+	SIZE_T fieldEnd;
+	BOOLEAN hasHwCal = FALSE;
+	BOOLEAN plainZero = FALSE;
+	UCHAR i;
+
+	if (Report == NULL || Info == NULL)
+	{
+		return FALSE;
+	}
+
+	RtlZeroMemory(Info, sizeof(*Info));
+
+	if (ReportLength < DS_IDENTIFICATION_MIN_PARSE_SIZE)
+	{
+		return FALSE;
+	}
+
+	fieldCount = Report[DS_IDENTIFICATION_FIELD_COUNT_OFFSET];
+	if (fieldCount == 0 || fieldCount > DS_IDENTIFICATION_MAX_FIELDS)
+	{
+		return FALSE;
+	}
+
+	fieldEnd = (SIZE_T)DS_IDENTIFICATION_FIELD_LIST_OFFSET + fieldCount;
+	if (fieldEnd > ReportLength)
+	{
+		return FALSE;
+	}
+
+	Info->Firmware[0] = Report[2];
+	Info->Firmware[1] = Report[3];
+	Info->Firmware[2] = Report[4];
+	Info->FirmwarePacked =
+		((UINT32)Report[2] << 16) |
+		((UINT32)Report[3] << 8) |
+		(UINT32)Report[4];
+	Info->PadType = Report[8];
+	Info->FieldCount = fieldCount;
+
+	for (i = 0; i < fieldCount; i++)
+	{
+		Info->Fields[i] = Report[DS_IDENTIFICATION_FIELD_LIST_OFFSET + i];
+		if (Info->Fields[i] == 0x07)
+		{
+			hasHwCal = TRUE;
+		}
+	}
+
+	if (fieldCount >= 2 &&
+		Info->Fields[0] == 0x01 &&
+		Info->Fields[1] == 0x02)
+	{
+		plainZero = TRUE;
+	}
+	else if (fieldCount >= 3 &&
+		Info->Fields[1] == 0x01 &&
+		Info->Fields[2] == 0x02)
+	{
+		plainZero = TRUE;
+	}
+
+	if (hasHwCal)
+	{
+		Info->MotionPath = DsIdentificationMotionPathHwCal;
+	}
+	else if (!plainZero)
+	{
+		Info->MotionPath = DsIdentificationMotionPathSixaxis;
+	}
+	else
+	{
+		Info->MotionPath = DsIdentificationMotionPathPlainZero;
+	}
+
+	if (fieldCount == 2 &&
+		Info->Fields[0] == 0x01 &&
+		Info->Fields[1] == 0x02 &&
+		Report[DS_IDENTIFICATION_CLONE_BYTE_OFFSET] == 0x64)
+	{
+		Info->CloneHeuristic = TRUE;
+	}
+
+	return TRUE;
+}
+
+VOID
+DsIdentification_AssignDeviceProperties(
+	_In_ WDFDEVICE Device,
+	_In_ PDS_IDENTIFICATION_INFO Info
+)
+{
+	WDF_DEVICE_PROPERTY_DATA propertyData;
+	UCHAR padType;
+	UCHAR motionPath;
+	BOOLEAN cloneHeuristic;
+
+	if (Info == NULL)
+	{
+		return;
+	}
+
+	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationFirmware);
+	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
+	propertyData.Lcid = LOCALE_NEUTRAL;
+
+	(void)WdfDeviceAssignProperty(
+		Device,
+		&propertyData,
+		DEVPROP_TYPE_UINT32,
+		sizeof(UINT32),
+		&Info->FirmwarePacked
+	);
+
+	padType = Info->PadType;
+	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationPadType);
+	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
+	propertyData.Lcid = LOCALE_NEUTRAL;
+
+	(void)WdfDeviceAssignProperty(
+		Device,
+		&propertyData,
+		DEVPROP_TYPE_BYTE,
+		sizeof(UCHAR),
+		&padType
+	);
+
+	motionPath = (UCHAR)Info->MotionPath;
+	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationMotionPath);
+	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
+	propertyData.Lcid = LOCALE_NEUTRAL;
+
+	(void)WdfDeviceAssignProperty(
+		Device,
+		&propertyData,
+		DEVPROP_TYPE_BYTE,
+		sizeof(UCHAR),
+		&motionPath
+	);
+
+	cloneHeuristic = Info->CloneHeuristic;
+	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic);
+	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
+	propertyData.Lcid = LOCALE_NEUTRAL;
+
+	(void)WdfDeviceAssignProperty(
+		Device,
+		&propertyData,
+		DEVPROP_TYPE_BOOLEAN,
+		sizeof(BOOLEAN),
+		&cloneHeuristic
+	);
+}

--- a/driver/DsIdentification.c
+++ b/driver/DsIdentification.c
@@ -94,70 +94,136 @@ DsIdentification_Parse(
 	return TRUE;
 }
 
+static VOID
+DsIdentification_AssignProperty(
+	_In_ WDFDEVICE Device,
+	_In_ const DEVPROPKEY* Key,
+	_In_ DEVPROPTYPE Type,
+	_In_ ULONG Size,
+	_In_opt_ PVOID Buffer,
+	_In_ PCWSTR KeyName
+)
+{
+	WDF_DEVICE_PROPERTY_DATA propertyData;
+	NTSTATUS status;
+
+	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, Key);
+	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
+	propertyData.Lcid = LOCALE_NEUTRAL;
+
+	status = WdfDeviceAssignProperty(
+		Device,
+		&propertyData,
+		Type,
+		Size,
+		Buffer
+	);
+
+	if (!NT_SUCCESS(status))
+	{
+		TraceError(
+			TRACE_DSUSB,
+			"WdfDeviceAssignProperty(%ls) failed with %!STATUS!",
+			KeyName,
+			status
+		);
+	}
+}
+
+VOID
+DsIdentification_ResetDecodedProperties(
+	_In_ WDFDEVICE Device
+)
+{
+	//
+	// BufferLength 0 deletes a previously persisted value so a failed GET or
+	// parse cannot leave stale decoded keys from an earlier power-up.
+	// 
+	DsIdentification_AssignProperty(
+		Device,
+		&DEVPKEY_DsHidMini_RO_IdentificationFirmware,
+		DEVPROP_TYPE_UINT32,
+		0,
+		NULL,
+		L"DEVPKEY_DsHidMini_RO_IdentificationFirmware"
+	);
+	DsIdentification_AssignProperty(
+		Device,
+		&DEVPKEY_DsHidMini_RO_IdentificationPadType,
+		DEVPROP_TYPE_BYTE,
+		0,
+		NULL,
+		L"DEVPKEY_DsHidMini_RO_IdentificationPadType"
+	);
+	DsIdentification_AssignProperty(
+		Device,
+		&DEVPKEY_DsHidMini_RO_IdentificationMotionPath,
+		DEVPROP_TYPE_BYTE,
+		0,
+		NULL,
+		L"DEVPKEY_DsHidMini_RO_IdentificationMotionPath"
+	);
+	DsIdentification_AssignProperty(
+		Device,
+		&DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic,
+		DEVPROP_TYPE_BOOLEAN,
+		0,
+		NULL,
+		L"DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic"
+	);
+}
+
 VOID
 DsIdentification_AssignDeviceProperties(
 	_In_ WDFDEVICE Device,
 	_In_ PDS_IDENTIFICATION_INFO Info
 )
 {
-	WDF_DEVICE_PROPERTY_DATA propertyData;
 	UCHAR padType;
 	UCHAR motionPath;
-	BOOLEAN cloneHeuristic;
+	DEVPROP_BOOLEAN cloneHeuristic;
 
 	if (Info == NULL)
 	{
 		return;
 	}
 
-	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationFirmware);
-	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
-	propertyData.Lcid = LOCALE_NEUTRAL;
-
-	(void)WdfDeviceAssignProperty(
+	DsIdentification_AssignProperty(
 		Device,
-		&propertyData,
+		&DEVPKEY_DsHidMini_RO_IdentificationFirmware,
 		DEVPROP_TYPE_UINT32,
 		sizeof(UINT32),
-		&Info->FirmwarePacked
+		&Info->FirmwarePacked,
+		L"DEVPKEY_DsHidMini_RO_IdentificationFirmware"
 	);
 
 	padType = Info->PadType;
-	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationPadType);
-	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
-	propertyData.Lcid = LOCALE_NEUTRAL;
-
-	(void)WdfDeviceAssignProperty(
+	DsIdentification_AssignProperty(
 		Device,
-		&propertyData,
+		&DEVPKEY_DsHidMini_RO_IdentificationPadType,
 		DEVPROP_TYPE_BYTE,
 		sizeof(UCHAR),
-		&padType
+		&padType,
+		L"DEVPKEY_DsHidMini_RO_IdentificationPadType"
 	);
 
 	motionPath = (UCHAR)Info->MotionPath;
-	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationMotionPath);
-	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
-	propertyData.Lcid = LOCALE_NEUTRAL;
-
-	(void)WdfDeviceAssignProperty(
+	DsIdentification_AssignProperty(
 		Device,
-		&propertyData,
+		&DEVPKEY_DsHidMini_RO_IdentificationMotionPath,
 		DEVPROP_TYPE_BYTE,
 		sizeof(UCHAR),
-		&motionPath
+		&motionPath,
+		L"DEVPKEY_DsHidMini_RO_IdentificationMotionPath"
 	);
 
-	cloneHeuristic = Info->CloneHeuristic;
-	WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic);
-	propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
-	propertyData.Lcid = LOCALE_NEUTRAL;
-
-	(void)WdfDeviceAssignProperty(
+	cloneHeuristic = Info->CloneHeuristic ? DEVPROP_TRUE : DEVPROP_FALSE;
+	DsIdentification_AssignProperty(
 		Device,
-		&propertyData,
+		&DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic,
 		DEVPROP_TYPE_BOOLEAN,
-		sizeof(BOOLEAN),
-		&cloneHeuristic
+		sizeof(DEVPROP_BOOLEAN),
+		&cloneHeuristic,
+		L"DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic"
 	);
 }

--- a/driver/DsIdentification.h
+++ b/driver/DsIdentification.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#define DS_IDENTIFICATION_REPORT_SIZE          64
+#define DS_IDENTIFICATION_MIN_PARSE_SIZE       0x2A
+#define DS_IDENTIFICATION_FIELD_COUNT_OFFSET   0x25
+#define DS_IDENTIFICATION_FIELD_LIST_OFFSET    0x26
+#define DS_IDENTIFICATION_CLONE_BYTE_OFFSET    0x29
+#define DS_IDENTIFICATION_MAX_FIELDS           8
+
+typedef enum _DS_IDENTIFICATION_MOTION_PATH
+{
+	DsIdentificationMotionPathUnknown = 0,
+	DsIdentificationMotionPathPlainZero = 1,
+	DsIdentificationMotionPathHwCal = 2,
+	DsIdentificationMotionPathSixaxis = 3,
+} DS_IDENTIFICATION_MOTION_PATH, * PDS_IDENTIFICATION_MOTION_PATH;
+
+typedef struct _DS_IDENTIFICATION_INFO
+{
+	UCHAR Firmware[3];
+	UINT32 FirmwarePacked;
+	UCHAR PadType;
+	DS_IDENTIFICATION_MOTION_PATH MotionPath;
+	BOOLEAN CloneHeuristic;
+	UCHAR FieldCount;
+	UCHAR Fields[DS_IDENTIFICATION_MAX_FIELDS];
+} DS_IDENTIFICATION_INFO, * PDS_IDENTIFICATION_INFO;
+
+BOOLEAN
+DsIdentification_Parse(
+	_In_reads_(ReportLength) const UCHAR* Report,
+	_In_ SIZE_T ReportLength,
+	_Out_ PDS_IDENTIFICATION_INFO Info
+);
+
+VOID
+DsIdentification_AssignDeviceProperties(
+	_In_ WDFDEVICE Device,
+	_In_ PDS_IDENTIFICATION_INFO Info
+);

--- a/driver/DsIdentification.h
+++ b/driver/DsIdentification.h
@@ -34,6 +34,11 @@ DsIdentification_Parse(
 );
 
 VOID
+DsIdentification_ResetDecodedProperties(
+	_In_ WDFDEVICE Device
+);
+
+VOID
 DsIdentification_AssignDeviceProperties(
 	_In_ WDFDEVICE Device,
 	_In_ PDS_IDENTIFICATION_INFO Info

--- a/driver/DsUsb.c
+++ b/driver/DsUsb.c
@@ -14,16 +14,22 @@ USB_SendControlRequest(
 	_In_ USHORT Value,
 	_In_ USHORT Index,
 	_Inout_ PVOID Buffer,
-	_In_ ULONG BufferLength
+	_In_ ULONG BufferLength,
+	_Out_opt_ PULONG BytesTransferred
 )
 {
 	NTSTATUS status;
 	WDF_USB_CONTROL_SETUP_PACKET controlSetupPacket;
 	WDF_REQUEST_SEND_OPTIONS sendOptions;
 	WDF_MEMORY_DESCRIPTOR memDesc;
-	ULONG bytesTransferred;
+	ULONG bytesTransferred = 0;
 
 	FuncEntry(TRACE_DSUSB);
+
+	if (BytesTransferred != NULL)
+	{
+		*BytesTransferred = 0;
+	}
 
 	WDF_REQUEST_SEND_OPTIONS_INIT(
 		&sendOptions,
@@ -73,6 +79,11 @@ USB_SendControlRequest(
 			status,
 			bytesTransferred
 		);
+	}
+
+	if (BytesTransferred != NULL)
+	{
+		*BytesTransferred = bytesTransferred;
 	}
 
 	FuncExit(TRACE_DSUSB, "status=%!STATUS!", status);
@@ -469,6 +480,13 @@ NTSTATUS DsUsb_PrepareHardware(WDFDEVICE Device)
 		// Moved ahead of MAC discovery to mirror the order the PS3 itself
 		// queries a freshly plugged-in pad (GET Feature 0x01 before 0xF2).
 		// 
+		ULONG identificationLength = 0;
+
+		RtlZeroMemory(identification, sizeof(identification));
+		pDevCtx->IdentificationPresent = FALSE;
+		RtlZeroMemory(&pDevCtx->Identification, sizeof(pDevCtx->Identification));
+		DsIdentification_ResetDecodedProperties(Device);
+
 		if (NT_SUCCESS(USB_SendControlRequest(
 			pDevCtx,
 			BmRequestDeviceToHost,
@@ -477,9 +495,15 @@ NTSTATUS DsUsb_PrepareHardware(WDFDEVICE Device)
 			0x0301,
 			0,
 			identification,
-			ARRAYSIZE(identification)
+			ARRAYSIZE(identification),
+			&identificationLength
 		)))
 		{
+			if (identificationLength > ARRAYSIZE(identification))
+			{
+				identificationLength = ARRAYSIZE(identification);
+			}
+
 			WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_IdentificationData);
 			propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
 			propertyData.Lcid = LOCALE_NEUTRAL;
@@ -488,13 +512,13 @@ NTSTATUS DsUsb_PrepareHardware(WDFDEVICE Device)
 				Device,
 				&propertyData,
 				DEVPROP_TYPE_BINARY,
-				ARRAYSIZE(identification),
+				identificationLength,
 				identification
 			);
 
 			if (DsIdentification_Parse(
 				identification,
-				ARRAYSIZE(identification),
+				identificationLength,
 				&pDevCtx->Identification))
 			{
 				pDevCtx->IdentificationPresent = TRUE;

--- a/driver/DsUsb.c
+++ b/driver/DsUsb.c
@@ -491,6 +491,33 @@ NTSTATUS DsUsb_PrepareHardware(WDFDEVICE Device)
 				ARRAYSIZE(identification),
 				identification
 			);
+
+			if (DsIdentification_Parse(
+				identification,
+				ARRAYSIZE(identification),
+				&pDevCtx->Identification))
+			{
+				pDevCtx->IdentificationPresent = TRUE;
+				DsIdentification_AssignDeviceProperties(Device, &pDevCtx->Identification);
+
+				TraceVerbose(
+					TRACE_DSUSB,
+					"Feature 0x01 firmware %02X %02X %02X type %02X path %d clone %!BOOLEAN!",
+					pDevCtx->Identification.Firmware[0],
+					pDevCtx->Identification.Firmware[1],
+					pDevCtx->Identification.Firmware[2],
+					pDevCtx->Identification.PadType,
+					pDevCtx->Identification.MotionPath,
+					pDevCtx->Identification.CloneHeuristic
+				);
+			}
+			else
+			{
+				TraceWarning(
+					TRACE_DSUSB,
+					"Feature 0x01 identification blob could not be parsed"
+				);
+			}
 		}
 
 #pragma endregion

--- a/driver/DsUsb.h
+++ b/driver/DsUsb.h
@@ -12,7 +12,8 @@ USB_SendControlRequest(
     _In_ USHORT Value,
     _In_ USHORT Index,
     _Inout_ PVOID Buffer,
-    _In_ ULONG BufferLength
+    _In_ ULONG BufferLength,
+    _Out_opt_ PULONG BytesTransferred
 );
 
 NTSTATUS

--- a/driver/dshidmini.vcxproj
+++ b/driver/dshidmini.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="DsBth.Timers.c" />
     <ClCompile Include="DsHid.c" />
     <ClCompile Include="DsHidMiniDrv.c" />
+    <ClCompile Include="DsIdentification.c" />
     <ClCompile Include="DsLed.c" />
     <ClCompile Include="DsUsb.c" />
     <ClCompile Include="HID.FeatureReport.c" />
@@ -53,6 +54,7 @@
     <ClInclude Include="DsCommon.h" />
     <ClInclude Include="DsHid.h" />
     <ClInclude Include="DsHidMiniDrv.h" />
+    <ClInclude Include="DsIdentification.h" />
     <ClInclude Include="DsInternal.h" />
     <ClInclude Include="DsLed.h" />
     <ClInclude Include="DsUsb.h" />

--- a/driver/dshidmini.vcxproj.filters
+++ b/driver/dshidmini.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="DsHidMiniDrv.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DsIdentification.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Power.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -189,6 +192,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DsHidMiniDrv.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DsIdentification.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DsLed.c">

--- a/include/DsHidMini/dshmguid.h
+++ b/include/DsHidMini/dshmguid.h
@@ -55,3 +55,23 @@ DEFINE_DEVPROPKEY(DEVPKEY_DsHidMini_RO_IpcSlotIndex,
 // {3FECF510-CC94-4FBE-8839-738201F84D59}
 DEFINE_DEVPROPKEY(DEVPKEY_DsHidMini_RO_DeviceAddressSynthesized,
 	0x3fecf510, 0xcc94, 0x4fbe, 0x88, 0x39, 0x73, 0x82, 0x1, 0xf8, 0x4d, 0x59, 7); // DEVPROP_TYPE_BOOLEAN
+
+// Feature 0x01 firmware/board revision packed as b2<<16 | b3<<8 | b4
+// {3FECF510-CC94-4FBE-8839-738201F84D59}
+DEFINE_DEVPROPKEY(DEVPKEY_DsHidMini_RO_IdentificationFirmware,
+	0x3fecf510, 0xcc94, 0x4fbe, 0x88, 0x39, 0x73, 0x82, 0x1, 0xf8, 0x4d, 0x59, 8); // DEVPROP_TYPE_UINT32
+
+// Feature 0x01 pad/sensor type byte (offset 8); informational only, not a gyro-path test
+// {3FECF510-CC94-4FBE-8839-738201F84D59}
+DEFINE_DEVPROPKEY(DEVPKEY_DsHidMini_RO_IdentificationPadType,
+	0x3fecf510, 0xcc94, 0x4fbe, 0x88, 0x39, 0x73, 0x82, 0x1, 0xf8, 0x4d, 0x59, 9); // DEVPROP_TYPE_BYTE
+
+// Feature 0x01 motion path derived from the calibration field list
+// {3FECF510-CC94-4FBE-8839-738201F84D59}
+DEFINE_DEVPROPKEY(DEVPKEY_DsHidMini_RO_IdentificationMotionPath,
+	0x3fecf510, 0xcc94, 0x4fbe, 0x88, 0x39, 0x73, 0x82, 0x1, 0xf8, 0x4d, 0x59, 10); // DEVPROP_TYPE_BYTE
+
+// TRUE if Feature 0x01 matches the clone heuristic (field list 01 02 and byte 0x29 == 0x64)
+// {3FECF510-CC94-4FBE-8839-738201F84D59}
+DEFINE_DEVPROPKEY(DEVPKEY_DsHidMini_RO_IdentificationCloneHeuristic,
+	0x3fecf510, 0xcc94, 0x4fbe, 0x88, 0x39, 0x73, 0x82, 0x1, 0xf8, 0x4d, 0x59, 11); // DEVPROP_TYPE_BOOLEAN


### PR DESCRIPTION
The driver already stored the raw blob; decode firmware, motion path, and the clone heuristic so support and later motion work can use them without guessing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USB-connected devices now display firmware revision, controller type, motion path, and identification status.
  * Added an indicator and tooltip when identification data suggests a likely counterfeit controller.
  * Device identification information is available through read-only device properties, including firmware, controller type, motion path, and detection status.

* **Documentation**
  * Updated motion documentation to describe identification data, motion-path classification, clone detection, and parsing behavior.
  * Clarified that motion output, HID, and rumble behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->