### PR TITLE
Build a synthetic dual-arch INF for the partner CAB so one submission…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -541,6 +541,8 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path bin\partner | Out-Null
+          & .\build\New-PartnerSubmissionInf.ps1 -InputInf bin\x64\dshidmini\dshidmini.inf -OutputInf bin\partner\dshidmini.inf
           & makecab.exe /f .\DsHidMini_combined.ddf
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
           $cabName = "dshidmini_$env:BUILD_VERSION.cab"

--- a/DsHidMini_combined.ddf
+++ b/DsHidMini_combined.ddf
@@ -8,17 +8,13 @@
 .Set CompressionType=MSZIP
 .Set Cabinet=on
 .Set Compress=on
-.Set UniqueFiles=OFF
 .Set CabinetNameTemplate=dshidmini.cab
-; x64
-.Set DestinationDir=dshidmini_x64
-LICENSE
+; Single dual-arch package. CAB root must stay empty.
+.Set DestinationDir=dshidmini
+bin\partner\dshidmini.inf
+.Set DestinationDir=dshidmini\x64
 bin\x64\dshidmini.pdb
-bin\x64\dshidmini\dshidmini.inf
 bin\x64\dshidmini\dshidmini.dll
-; ARM64
-.Set DestinationDir=dshidmini_ARM64
-LICENSE
+.Set DestinationDir=dshidmini\ARM64
 bin\ARM64\dshidmini.pdb
-bin\ARM64\dshidmini\dshidmini.inf
 bin\ARM64\dshidmini\dshidmini.dll

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -342,8 +342,8 @@ class Build : NukeBuild
             string artifactsDir = ResolvedArtifactsPath;
             string[] patterns =
             [
-                Path.Combine(artifactsDir, "drivers", "dshidmini_ARM64", "*.dll"),
-                Path.Combine(artifactsDir, "drivers", "dshidmini_x64", "*.dll")
+                Path.Combine(artifactsDir, "drivers", "ARM64", "*.dll"),
+                Path.Combine(artifactsDir, "drivers", "x64", "*.dll")
             ];
             List<string> files = new();
             foreach (string pattern in patterns)

--- a/build/New-PartnerSubmissionInf.ps1
+++ b/build/New-PartnerSubmissionInf.ps1
@@ -1,0 +1,153 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Expands a stampinf-processed x64 dshidmini.inf into a dual-arch Partner Center INF.
+
+.DESCRIPTION
+    Partner Center requires every driver folder in a CAB to declare every requested
+    architecture. This takes the already-stamped x64 INF (DriverVer and UMDF version
+    filled) and emits NTARM64 model sections plus SourceDisksFiles.amd64/.arm64 so
+    one package folder can carry both DLLs.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $InputInf,
+
+    [Parameter(Mandatory)]
+    [string] $OutputInf
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$InputInf = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($InputInf)
+$OutputInf = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($OutputInf)
+
+if (-not (Test-Path -LiteralPath $InputInf)) {
+    throw "Input INF not found: $InputInf"
+}
+
+$text = [System.IO.File]::ReadAllText($InputInf)
+if ([string]::IsNullOrWhiteSpace($text)) {
+    throw "Input INF is empty: $InputInf"
+}
+
+if ($text -match '\$ARCH\$' -or $text -match 'NT\$ARCH\$' -or $text -match '\$UMDFVERSION\$') {
+    throw "Input INF is not stampinf-processed (unexpanded `$ARCH`$ or `$UMDFVERSION`$ remain): $InputInf"
+}
+
+$newline = if ($text.Contains("`r`n")) { "`r`n" } else { "`n" }
+
+$headerMatches = [regex]::Matches($text, '(?m)^(\[[^\]]+\])\r?\n')
+if ($headerMatches.Count -eq 0) {
+    throw "No INF sections found in $InputInf"
+}
+
+$preamble = $text.Substring(0, $headerMatches[0].Index)
+$sections = [System.Collections.Generic.List[object]]::new()
+for ($i = 0; $i -lt $headerMatches.Count; $i++) {
+    $header = $headerMatches[$i].Groups[1].Value
+    $bodyStart = $headerMatches[$i].Index + $headerMatches[$i].Length
+    $bodyEnd = if ($i + 1 -lt $headerMatches.Count) { $headerMatches[$i + 1].Index } else { $text.Length }
+    $sections.Add([pscustomobject]@{
+            Header = $header
+            Body   = $text.Substring($bodyStart, $bodyEnd - $bodyStart)
+        })
+}
+
+function ConvertTo-Arm64Decoration([string] $Value) {
+    return (($Value -creplace 'NTAMD64', 'NTARM64') -creplace 'NTamd64', 'NTarm64')
+}
+
+$outSections = [System.Collections.Generic.List[object]]::new()
+$clonedModels = 0
+$replacedSourceDisks = $false
+
+foreach ($section in $sections) {
+    if ($section.Header -eq '[Manufacturer]') {
+        if ($section.Body -notmatch 'NTAMD64' -and $section.Body -notmatch 'NTamd64') {
+            throw "[Manufacturer] does not contain NTAMD64 decorations; expected a stamped x64 INF."
+        }
+        if ($section.Body -notmatch 'NTARM64' -and $section.Body -notmatch 'NTarm64') {
+            $section.Body = [regex]::Replace($section.Body, '(?m)^(.+=Nefarius,\s*)(.+)$', {
+                    param($match)
+                    $decorations = $match.Groups[2].Value.TrimEnd()
+                    $armDecorations = ConvertTo-Arm64Decoration $decorations
+                    $match.Groups[1].Value + $decorations + ', ' + $armDecorations
+                })
+        }
+        $outSections.Add($section)
+        continue
+    }
+
+    if ($section.Header -eq '[SourceDisksFiles]') {
+        if ($section.Body -notmatch '(?im)^dshidmini\.dll=1\s*$') {
+            throw "[SourceDisksFiles] does not contain the expected 'dshidmini.dll=1' entry."
+        }
+        $amdBody = [regex]::Replace($section.Body, '(?im)^(dshidmini\.dll=)1(\s*)$', '${1}1,x64$2')
+        $armBody = [regex]::Replace($section.Body, '(?im)^(dshidmini\.dll=)1(\s*)$', '${1}1,ARM64$2')
+        $outSections.Add([pscustomobject]@{ Header = '[SourceDisksFiles.amd64]'; Body = $amdBody })
+        $outSections.Add([pscustomobject]@{ Header = '[SourceDisksFiles.arm64]'; Body = $armBody })
+        $replacedSourceDisks = $true
+        continue
+    }
+
+    if ($section.Header -match '^\[SourceDisksFiles\.') {
+        throw "Input INF already has decorated $($section.Header); expected undecorated [SourceDisksFiles] from a per-arch WDK build."
+    }
+
+    $outSections.Add($section)
+
+    if ($section.Header -match '^\[Nefarius\.NTAMD64\.' -or $section.Header -match '^\[Nefarius\.NTamd64\.') {
+        $armHeader = ConvertTo-Arm64Decoration $section.Header
+        $outSections.Add([pscustomobject]@{ Header = $armHeader; Body = $section.Body })
+        $clonedModels++
+    }
+}
+
+if (-not $replacedSourceDisks) {
+    throw "Input INF is missing [SourceDisksFiles]."
+}
+if ($clonedModels -lt 2) {
+    throw "Expected to clone at least two NTAMD64 model sections; cloned $clonedModels."
+}
+
+$builder = New-Object System.Text.StringBuilder
+[void]$builder.Append($preamble)
+foreach ($section in $outSections) {
+    [void]$builder.Append($section.Header)
+    [void]$builder.Append($newline)
+    [void]$builder.Append($section.Body)
+}
+
+$result = $builder.ToString()
+
+$required = @(
+    '[Nefarius.NTAMD64.10.0...17763]',
+    '[Nefarius.NTAMD64.10.0...22000]',
+    '[Nefarius.NTARM64.10.0...17763]',
+    '[Nefarius.NTARM64.10.0...22000]',
+    '[SourceDisksFiles.amd64]',
+    '[SourceDisksFiles.arm64]'
+)
+foreach ($header in $required) {
+    if (-not [regex]::IsMatch($result, '(?im)^' + [regex]::Escape($header) + '\r?$')) {
+        throw "Generated INF is missing required section $header"
+    }
+}
+if ([regex]::IsMatch($result, '(?m)^\[SourceDisksFiles\]\s*$')) {
+    throw "Generated INF still has undecorated [SourceDisksFiles]."
+}
+if ($result -match '\$ARCH\$' -or $result -match '\$UMDFVERSION\$') {
+    throw "Generated INF still contains unexpanded tokens."
+}
+
+$outputDir = Split-Path -Parent $OutputInf
+if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+$utf8 = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($OutputInf, $result, $utf8)
+Write-Output "Wrote dual-arch partner INF: $OutputInf"

--- a/setup/InstallScript.cs
+++ b/setup/InstallScript.cs
@@ -48,7 +48,7 @@ internal class InstallScript
     {
         // grab main app version
         Version version = Version.Parse(BuildVariables.SetupVersion);
-        const string driverPath = @"..\artifacts\drivers\dshidmini_x64\dshidmini.dll";
+        const string driverPath = @"..\artifacts\drivers\x64\dshidmini.dll";
         Version driverVersion = Version.Parse(FileVersionInfo.GetVersionInfo(driverPath).FileVersion);
 
         const string filterPath = @"..\artifacts\igfilter\nssmkig_x64\nssmkig.sys";
@@ -299,12 +299,10 @@ public static class CustomActions
         string nefconcPath = Path.Combine(nefconDir, archShortName, "nefconc.exe");
         session.Log($"nefconcPath = {nefconcPath}");
 
-        string dshidminiDriverDir = Path.Combine(driversDir, $"dshidmini_{archShortName}");
-        session.Log($"dshidminiDriverDir = {dshidminiDriverDir}");
         string igfilterDriverDir = Path.Combine(driversDir, $"nssmkig_{archShortName}");
         session.Log($"igfilterDriverDir = {igfilterDriverDir}");
 
-        string dshidminiInfPath = Path.Combine(dshidminiDriverDir, "dshidmini.inf");
+        string dshidminiInfPath = Path.Combine(driversDir, "dshidmini.inf");
         session.Log($"dshidminiInfPath = {dshidminiInfPath}");
         string igfilterInfPath = Path.Combine(igfilterDriverDir, "igfilter.inf");
         session.Log($"igfilterInfPath = {igfilterInfPath}");

--- a/setup/README.md
+++ b/setup/README.md
@@ -14,9 +14,9 @@ Commands/scripts are to be run from solution root directory.
   ```  
   to download the tagged release (the run ID is the numeric ID in the workflow run URL)
 - Submit the partner CAB (`dshidmini-partner-submission` artifact) to MS Partner Portal for signing. Tick both x64 and ARM64; the CAB is one dual-arch package
-- Extract the signed package into `.\artifacts\drivers` so the layout is:
+- Extract the signed package. Copy the contents of the `dshidmini` folder (not the folder itself) into `.\artifacts\drivers` so the layout is:
 
-  ```
+  ```text
   artifacts/drivers/
     dshidmini.inf
     dshidmini.cat

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,4 +1,4 @@
-﻿# DsHidMini setup
+# DsHidMini setup
 
 This project generates an MSI package containing x64 and ARM64 driver editions using [WixSharp](https://github.com/oleg-shilo/wixsharp).
 
@@ -13,8 +13,18 @@ Commands/scripts are to be run from solution root directory.
   nuke download-ci-artifacts -buildversion "<workflow-run-id>"
   ```  
   to download the tagged release (the run ID is the numeric ID in the workflow run URL)
-- Submit the `*.cab` files to MS Partner Portal for signing
-- Place the signed files in `.\artifacts\drivers` directory
+- Submit the partner CAB (`dshidmini-partner-submission` artifact) to MS Partner Portal for signing. Tick both x64 and ARM64; the CAB is one dual-arch package
+- Extract the signed package into `.\artifacts\drivers` so the layout is:
+
+  ```
+  artifacts/drivers/
+    dshidmini.inf
+    dshidmini.cat
+    x64/dshidmini.dll
+    ARM64/dshidmini.dll
+  ```
+
+  The catalog is bound to the dual-arch INF. Do not split it back into per-arch INFs.
 - Run  
   ```PowerShell
   nuke sign-production-binaries


### PR DESCRIPTION
… can cover x64 and ARM64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a combined driver package supporting both x64 and ARM64 systems.
  - Partner submissions now include a generated dual-architecture installation file.
  - Updated package contents to use a shared driver layout for both architectures.

- **Bug Fixes**
  - Updated driver signing and installation workflows to locate files in the revised package structure.

- **Documentation**
  - Updated release instructions for extracting and submitting the combined x64/ARM64 package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->