### PR TITLE
Consume DeviceManagement 6.1.0 so ControlApp can read identification …

### DIFF
--- a/ControlApp/ControlApp.csproj
+++ b/ControlApp/ControlApp.csproj
@@ -34,7 +34,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Nefarius.Utilities.Bluetooth" Version="1.8.2"/>
-        <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="5.2.0"/>
+        <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="6.1.0"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -193,7 +193,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     {
         get
         {
-            string? name = Device.GetProperty<string>(DevicePropertyKey.Device_FriendlyName);
+            string? name = Device.GetProperty<string>(DevicePropertyKey.NAME);
 
             return string.IsNullOrEmpty(name) ? "DS3 Compatible HID Device" : name;
         }
@@ -393,8 +393,9 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
                 byte[]? raw = Device.GetProperty<byte[]>(DsHidMiniDriver.IdentificationDataProperty);
                 return raw is { Length: > 0 };
             }
-            catch
+            catch (Exception ex)
             {
+                Log.Logger.Warning(ex, "Failed to read identification data of device '{Address}'", DeviceAddress);
                 return false;
             }
         }
@@ -412,9 +413,9 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
                     return parsed;
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Property absent or blob too short to decode.
+                Log.Logger.Warning(ex, "Failed to read identification data of device '{Address}'", DeviceAddress);
             }
 
             return null;

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -408,9 +408,16 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             try
             {
                 byte[]? raw = Device.GetProperty<byte[]>(DsHidMiniDriver.IdentificationDataProperty);
-                if (raw is { Length: > 0 } && DsIdentification.TryParse(raw, out DsIdentificationInfo? parsed))
+                if (raw is { Length: > 0 })
                 {
-                    return parsed;
+                    if (DsIdentification.TryParse(raw, out DsIdentificationInfo? parsed))
+                    {
+                        return parsed;
+                    }
+
+                    Log.Logger.Warning(
+                        "Failed to parse identification data of device '{Address}'",
+                        DeviceAddress);
                 }
             }
             catch (Exception ex)

--- a/SDK/Nefarius.DsHidMini.IPC/Nefarius.DsHidMini.IPC.csproj
+++ b/SDK/Nefarius.DsHidMini.IPC/Nefarius.DsHidMini.IPC.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="MinVer" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="5.2.0" />
+    <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="6.1.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>


### PR DESCRIPTION
…blobs.

The v6 bump also replaces Device_FriendlyName with NAME and logs failed identification reads instead of swallowing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device names are now displayed using the current device name property.
  * Improved handling of device identification data read and parsing failures, with warning logs while preserving existing fallback behavior.
* **Maintenance**
  * Updated the device management component to version 6.1.0 across the application and SDK.
  * Improved diagnostic reporting for identification issues to make troubleshooting device information problems easier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->