### PR TITLE
Polish ControlApp window chrome and settings editor spacing.

### DIFF
--- a/ControlApp.Tests/ApplicationConfigurationAndTrayPolicyTests.cs
+++ b/ControlApp.Tests/ApplicationConfigurationAndTrayPolicyTests.cs
@@ -37,6 +37,106 @@ public class ApplicationConfigurationAndTrayPolicyTests
         Assert.False(config.MinimizeToTray);
     }
 
+    [Fact]
+    public void ApplicationConfiguration_JsonRoundTrip_PreservesWindowPlacement()
+    {
+        ApplicationConfiguration original = new()
+        {
+            WindowLeft = -1100,
+            WindowTop = 100,
+            WindowWidth = 1280,
+            WindowHeight = 800,
+            WindowState = WindowState.Maximized
+        };
+
+        string json = JsonConvert.SerializeObject(original);
+        ApplicationConfiguration? loaded = JsonConvert.DeserializeObject<ApplicationConfiguration>(json);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(-1100, loaded.WindowLeft);
+        Assert.Equal(100, loaded.WindowTop);
+        Assert.Equal(1280, loaded.WindowWidth);
+        Assert.Equal(800, loaded.WindowHeight);
+        Assert.Equal(WindowState.Maximized, loaded.WindowState);
+    }
+
+    [Fact]
+    public void WindowPlacementPolicy_TryRead_RejectsMissingSize()
+    {
+        Assert.False(WindowPlacementPolicy.TryRead(new ApplicationConfiguration(), out _));
+    }
+
+    [Fact]
+    public void WindowPlacementPolicy_Resolve_KeepsPlacementWhenTitleBarIsOnAMonitor()
+    {
+        WindowPlacementSnapshot saved = new(1920, 80, 1200, 700, WindowState.Normal, true);
+        Rect primary = new(0, 0, 1920, 1080);
+        Rect secondary = new(1920, 0, 1920, 1080);
+
+        WindowPlacementSnapshot resolved = WindowPlacementPolicy.Resolve(saved, [primary, secondary], primary);
+
+        Assert.Equal(1920, resolved.Left);
+        Assert.Equal(80, resolved.Top);
+        Assert.Equal(1200, resolved.Width);
+        Assert.Equal(700, resolved.Height);
+        Assert.Equal(WindowState.Normal, resolved.State);
+    }
+
+    [Fact]
+    public void WindowPlacementPolicy_Resolve_RecentersWhenSavedMonitorIsGone()
+    {
+        WindowPlacementSnapshot saved = new(2560, 100, 1280, 800, WindowState.Normal, true);
+        Rect primary = new(0, 0, 1920, 1080);
+
+        WindowPlacementSnapshot resolved = WindowPlacementPolicy.Resolve(saved, [primary], primary);
+
+        Assert.Equal((1920 - 1280) / 2.0, resolved.Left);
+        Assert.Equal((1080 - 800) / 2.0, resolved.Top);
+        Assert.Equal(1280, resolved.Width);
+        Assert.Equal(800, resolved.Height);
+    }
+
+    [Fact]
+    public void WindowPlacementPolicy_Resolve_ClampsSizeToFallbackWorkAreaWhenRelocating()
+    {
+        WindowPlacementSnapshot saved = new(4000, 0, 2000, 1200, WindowState.Maximized, true);
+        Rect primary = new(0, 0, 1366, 768);
+
+        WindowPlacementSnapshot resolved = WindowPlacementPolicy.Resolve(saved, [primary], primary);
+
+        Assert.Equal(1366, resolved.Width);
+        Assert.Equal(768, resolved.Height);
+        Assert.Equal(0, resolved.Left);
+        Assert.Equal(0, resolved.Top);
+        Assert.Equal(WindowState.Maximized, resolved.State);
+    }
+
+    [Fact]
+    public void WindowPlacementPolicy_Write_StoresNormalBoundsAndDropsMinimizedState()
+    {
+        ApplicationConfiguration config = new();
+
+        WindowPlacementPolicy.Write(
+            config,
+            WindowState.Minimized,
+            new Rect(40, 50, 1300, 720));
+
+        Assert.Equal(40, config.WindowLeft);
+        Assert.Equal(50, config.WindowTop);
+        Assert.Equal(1300, config.WindowWidth);
+        Assert.Equal(720, config.WindowHeight);
+        Assert.Equal(WindowState.Normal, config.WindowState);
+    }
+
+    [Fact]
+    public void WindowPlacementPolicy_IsVisibleOnAMonitor_FalseWhenFullyOffDisplays()
+    {
+        Rect window = new(4000, 2000, 1100, 650);
+        Rect primary = new(0, 0, 1920, 1080);
+
+        Assert.False(WindowPlacementPolicy.IsVisibleOnAMonitor(window, [primary]));
+    }
+
     [Theory]
     [InlineData(true, false, true)]
     [InlineData(true, true, false)]

--- a/ControlApp/Models/ApplicationConfiguration.cs
+++ b/ControlApp/Models/ApplicationConfiguration.cs
@@ -48,6 +48,31 @@ public class ApplicationConfiguration
     private bool _minimizeToTray;
 
     /// <summary>
+    ///     Last restored window left, in WPF device-independent pixels.
+    /// </summary>
+    public double? WindowLeft { get; set; }
+
+    /// <summary>
+    ///     Last restored window top, in WPF device-independent pixels.
+    /// </summary>
+    public double? WindowTop { get; set; }
+
+    /// <summary>
+    ///     Last restored window width, in WPF device-independent pixels.
+    /// </summary>
+    public double? WindowWidth { get; set; }
+
+    /// <summary>
+    ///     Last restored window height, in WPF device-independent pixels.
+    /// </summary>
+    public double? WindowHeight { get; set; }
+
+    /// <summary>
+    ///     Last non-minimized window state (Normal or Maximized).
+    /// </summary>
+    public WindowState WindowState { get; set; } = WindowState.Normal;
+
+    /// <summary>
     ///     When true, Minimize and Close hide the window to the system tray instead of exiting.
     /// </summary>
     public bool MinimizeToTray

--- a/ControlApp/Models/DisplayWorkAreas.cs
+++ b/ControlApp/Models/DisplayWorkAreas.cs
@@ -1,0 +1,103 @@
+using System.Runtime.InteropServices;
+
+namespace Nefarius.DsHidMini.ControlApp.Models;
+
+/// <summary>
+///     Connected-monitor working areas in WPF device-independent pixels.
+/// </summary>
+internal static class DisplayWorkAreas
+{
+    public static IReadOnlyList<Rect> GetDipWorkingAreas()
+    {
+        List<Rect> areas = [];
+        try
+        {
+            NativeMethods.EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
+                (IntPtr monitor, IntPtr _, ref NativeMethods.RECT _, IntPtr _) =>
+                {
+                    NativeMethods.MONITORINFO info = new()
+                    {
+                        cbSize = Marshal.SizeOf<NativeMethods.MONITORINFO>()
+                    };
+                    if (!NativeMethods.GetMonitorInfo(monitor, ref info))
+                    {
+                        return true;
+                    }
+
+                    uint dpiX = 96;
+                    uint dpiY = 96;
+                    if (NativeMethods.GetDpiForMonitor(monitor, NativeMethods.MdtEffectiveDpi, out uint x,
+                            out uint y) == 0)
+                    {
+                        dpiX = x == 0 ? 96 : x;
+                        dpiY = y == 0 ? 96 : y;
+                    }
+
+                    NativeMethods.RECT work = info.rcWork;
+                    areas.Add(new Rect(
+                        work.left * 96.0 / dpiX,
+                        work.top * 96.0 / dpiY,
+                        (work.right - work.left) * 96.0 / dpiX,
+                        (work.bottom - work.top) * 96.0 / dpiY));
+                    return true;
+                }, IntPtr.Zero);
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to enumerate display monitors.");
+        }
+
+        if (areas.Count == 0)
+        {
+            areas.Add(SystemParameters.WorkArea);
+        }
+
+        return areas;
+    }
+
+    private static class NativeMethods
+    {
+        public const int MdtEffectiveDpi = 0;
+
+        public delegate bool MonitorEnumProc(
+            IntPtr hMonitor,
+            IntPtr hdcMonitor,
+            ref RECT lprcMonitor,
+            IntPtr dwData);
+
+        [DllImport("user32.dll")]
+        public static extern bool EnumDisplayMonitors(
+            IntPtr hdc,
+            IntPtr lprcClip,
+            MonitorEnumProc lpfnEnum,
+            IntPtr dwData);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
+
+        [DllImport("shcore.dll")]
+        public static extern int GetDpiForMonitor(
+            IntPtr hMonitor,
+            int dpiType,
+            out uint dpiX,
+            out uint dpiY);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MONITORINFO
+        {
+            public int cbSize;
+            public RECT rcMonitor;
+            public RECT rcWork;
+            public int dwFlags;
+        }
+    }
+}

--- a/ControlApp/Models/WindowPlacementPolicy.cs
+++ b/ControlApp/Models/WindowPlacementPolicy.cs
@@ -1,0 +1,152 @@
+namespace Nefarius.DsHidMini.ControlApp.Models;
+
+/// <summary>
+///     Saved window rectangle and state. Geometry is in WPF device-independent pixels.
+/// </summary>
+internal readonly record struct WindowPlacementSnapshot(
+    double Left,
+    double Top,
+    double Width,
+    double Height,
+    WindowState State,
+    bool HasPosition);
+
+/// <summary>
+///     Pure placement rules so restore can be tested without a live window or display.
+/// </summary>
+internal static class WindowPlacementPolicy
+{
+    public const double DefaultWidth = 1100;
+    public const double DefaultHeight = 650;
+    public const double MinWidth = 1100;
+    public const double MinHeight = 650;
+
+    private const double TitleBarProbeX = 40;
+    private const double TitleBarProbeY = 16;
+    private const double MinOverlapWidth = 80;
+    private const double MinOverlapHeight = 40;
+
+    public static void Write(ApplicationConfiguration config, WindowState state, Rect normalBounds)
+    {
+        config.WindowLeft = normalBounds.Left;
+        config.WindowTop = normalBounds.Top;
+        config.WindowWidth = normalBounds.Width;
+        config.WindowHeight = normalBounds.Height;
+        config.WindowState = state == WindowState.Minimized ? WindowState.Normal : state;
+    }
+
+    public static bool TryRead(ApplicationConfiguration config, out WindowPlacementSnapshot snapshot)
+    {
+        if (config.WindowWidth is not { } width ||
+            config.WindowHeight is not { } height ||
+            double.IsNaN(width) ||
+            double.IsNaN(height) ||
+            width <= 0 ||
+            height <= 0)
+        {
+            snapshot = default;
+            return false;
+        }
+
+        bool hasPosition = config.WindowLeft is { } left &&
+                           config.WindowTop is { } top &&
+                           !double.IsNaN(left) &&
+                           !double.IsNaN(top);
+
+        snapshot = new WindowPlacementSnapshot(
+            config.WindowLeft ?? 0,
+            config.WindowTop ?? 0,
+            width,
+            height,
+            config.WindowState,
+            hasPosition);
+        return true;
+    }
+
+    public static WindowPlacementSnapshot Resolve(
+        WindowPlacementSnapshot saved,
+        IReadOnlyList<Rect> monitorWorkAreas,
+        Rect fallbackWorkArea)
+    {
+        IReadOnlyList<Rect> monitors = monitorWorkAreas.Count > 0
+            ? monitorWorkAreas
+            : [fallbackWorkArea];
+
+        double width = Math.Max(MinWidth, saved.Width);
+        double height = Math.Max(MinHeight, saved.Height);
+
+        if (saved.HasPosition)
+        {
+            Rect window = new(saved.Left, saved.Top, width, height);
+            if (IsVisibleOnAMonitor(window, monitors))
+            {
+                return saved with { Width = width, Height = height };
+            }
+        }
+
+        Rect host = fallbackWorkArea.Width > 0 && fallbackWorkArea.Height > 0
+            ? fallbackWorkArea
+            : monitors[0];
+        width = ClampDimension(width, MinWidth, host.Width);
+        height = ClampDimension(height, MinHeight, host.Height);
+        Rect centered = CenterIn(host, width, height);
+        return new WindowPlacementSnapshot(
+            centered.Left,
+            centered.Top,
+            centered.Width,
+            centered.Height,
+            saved.State,
+            true);
+    }
+
+    public static bool IsVisibleOnAMonitor(Rect window, IReadOnlyList<Rect> monitorWorkAreas)
+    {
+        if (monitorWorkAreas.Count == 0 || window.Width <= 0 || window.Height <= 0)
+        {
+            return false;
+        }
+
+        Point titleBarProbe = new(
+            window.Left + Math.Min(TitleBarProbeX, window.Width / 2),
+            window.Top + Math.Min(TitleBarProbeY, window.Height / 2));
+
+        foreach (Rect monitor in monitorWorkAreas)
+        {
+            if (monitor.Contains(titleBarProbe))
+            {
+                return true;
+            }
+        }
+
+        foreach (Rect monitor in monitorWorkAreas)
+        {
+            Rect overlap = Rect.Intersect(window, monitor);
+            if (!overlap.IsEmpty &&
+                overlap.Width >= MinOverlapWidth &&
+                overlap.Height >= MinOverlapHeight)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static double ClampDimension(double value, double min, double hostSize)
+    {
+        double clamped = Math.Max(min, value);
+        if (hostSize >= min)
+        {
+            clamped = Math.Min(clamped, hostSize);
+        }
+
+        return clamped;
+    }
+
+    private static Rect CenterIn(Rect host, double width, double height)
+    {
+        double left = host.Left + Math.Max(0, (host.Width - width) / 2);
+        double top = host.Top + Math.Max(0, (host.Height - height) / 2);
+        return new Rect(left, top, width, height);
+    }
+}

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -35,6 +35,12 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
     [ObservableProperty]
     private bool _anyDeviceSelected;
 
+    /// <summary>
+    ///     True when at least one DsHidMini device is in the list.
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasConnectedDevices;
+
 
     /// <summary>
     ///     Currently selected device, if any.
@@ -231,6 +237,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
                 SelectedDevice = null;
                 List<DeviceViewModel> previous = Devices.ToList();
                 Devices.Clear();
+                HasConnectedDevices = false;
                 foreach (DeviceViewModel oldDev in previous)
                 {
                     oldDev.Dispose();
@@ -252,6 +259,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
                     }
 
                     Devices.Add(newDev);
+                    HasConnectedDevices = true;
                     await newDev.RefreshDeviceSettings();
                     if (selectedAddress is not null &&
                         string.Equals(newDev.DeviceAddress, selectedAddress,

--- a/ControlApp/ViewModels/Pages/ProfilesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/ProfilesViewModel.cs
@@ -21,6 +21,9 @@ public partial class ProfilesViewModel : ObservableObject, INavigationAware
     private bool _anyProfileSelected;
 
     [ObservableProperty]
+    private bool _hasProfiles;
+
+    [ObservableProperty]
     private List<ProfileViewModel> _profilesViewModels;
 
     [ObservableProperty]
@@ -77,6 +80,7 @@ public partial class ProfilesViewModel : ObservableObject, INavigationAware
         }
 
         ProfilesViewModels = newList;
+        HasProfiles = newList.Count > 0;
         UpdateGlobalProfileCheck();
 
         if (selectedGuid is Guid guid)

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -1,8 +1,7 @@
-﻿using System.Reflection;
-
-using Nefarius.DsHidMini.ControlApp.Models;
+﻿using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Services;
+using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
 
 using Wpf.Ui.Abstractions.Controls;
 using Wpf.Ui.Appearance;
@@ -135,15 +134,9 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private void InitializeViewModel()
     {
         CurrentTheme = ApplicationThemeManager.GetAppTheme();
-        AppVersion = $"Dshm_ControlApp_WpfUi - {GetAssemblyVersion()}";
+        AppVersion = $"DsHidMini ControlApp {MainWindowViewModel.GetDisplayVersion()}";
 
         _isInitialized = true;
-    }
-
-    private string GetAssemblyVersion()
-    {
-        return Assembly.GetExecutingAssembly().GetName().Version?.ToString()
-               ?? string.Empty;
     }
 
     [RelayCommand]

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -117,6 +117,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         _addressValidator = addressValidator;
         _batteryQuery = new Timer(UpdateBatteryStatus, null, 10000, 10000);
         _deviceUserData = _dshmConfigManager.GetDeviceData(DeviceAddress);
+        _pairingMode = _deviceUserData.BluetoothPairingMode;
         // Loads correspondent controller data based on controller's MAC address 
 
 
@@ -274,7 +275,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     public bool IsCustomPairingAddressVisible => PairingMode == BluetoothPairingMode.Custom;
 
     /// <summary>
-    ///     Index of the desired Bluetooth pairing mode
+    ///     Desired Bluetooth pairing mode. Defaults to pairing to this PC.
     /// </summary>
     public BluetoothPairingMode PairingMode
     {
@@ -369,10 +370,40 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             : SymbolRegular.Bluetooth24;
 
     /// <summary>
+    ///     Tooltip for the list-card restart / disconnect button.
+    /// </summary>
+    public string RestartDeviceToolTip =>
+        IsWireless
+            ? "Disconnect this wireless controller"
+            : "Restart this USB controller. Requires running as Administrator.";
+
+    /// <summary>
     ///     Last time this device has been seen connected (applies to Bluetooth connected devices only).
     /// </summary>
     public DateTimeOffset LastConnected =>
         Device.GetProperty<DateTimeOffset>(DsHidMiniDriver.BluetoothLastConnectedTimeProperty);
+
+    /// <summary>
+    ///     Display text for <see cref="LastConnected" />. USB sessions have no Bluetooth timestamp.
+    /// </summary>
+    public string LastConnectedDisplay
+    {
+        get
+        {
+            if (!IsWireless)
+            {
+                return "Only available when connected wirelessly";
+            }
+
+            DateTimeOffset lastConnected = LastConnected;
+            if (lastConnected == default || lastConnected.Year < 2000)
+            {
+                return "Unknown";
+            }
+
+            return lastConnected.ToLocalTime().ToString("g");
+        }
+    }
 
     /// <summary>
     ///     The driver version of the device

--- a/ControlApp/ViewModels/Windows/MainWindowViewModel.cs
+++ b/ControlApp/ViewModels/Windows/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Reflection;
 
 using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Services;
@@ -13,7 +14,7 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly AppSnackbarMessagesService _appSnackbarMessagesService;
 
     [ObservableProperty]
-    private string _applicationTitle = "DsHidMini ControlApp";
+    private string _applicationTitle = $"DsHidMini ControlApp {GetDisplayVersion()}";
 
     [ObservableProperty]
     private ObservableCollection<object> _footerMenuItems = new()
@@ -58,6 +59,21 @@ public partial class MainWindowViewModel : ObservableObject
     public ApplicationConfiguration AppConfig => ApplicationConfiguration.Instance;
 
     public event EventHandler? OpenFromTrayRequested;
+
+    internal static string GetDisplayVersion()
+    {
+        string? informational = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        if (!string.IsNullOrWhiteSpace(informational))
+        {
+            int metadataSeparator = informational.IndexOf('+');
+            return metadataSeparator >= 0 ? informational[..metadataSeparator] : informational;
+        }
+
+        return Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
+    }
 
     [RelayCommand]
     public void RestartAsAdmin()

--- a/ControlApp/Views/Pages/DevicesPage.xaml
+++ b/ControlApp/Views/Pages/DevicesPage.xaml
@@ -17,9 +17,6 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     ScrollViewer.CanContentScroll="False"
     mc:Ignorable="d">
-    <Page.Resources>
-        <DataTemplate x:Key="MyKey_DeviceStatusSummary" DataType="{x:Type viewuserctrls:DeviceUserControl}" />
-    </Page.Resources>
     <DockPanel>
         <StackPanel
             Margin="0,0,0,8"
@@ -83,7 +80,7 @@
                     <DataTemplate>
                         <ui:Card Padding="5,5,5,5">
                             <Viewbox>
-                                <Grid Width="200" ShowGridLines="False">
+                                <Grid Width="200">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="20" />
                                         <RowDefinition Height="Auto" />
@@ -146,7 +143,7 @@
 
                                             <!--  Power cycle/Reconnect button  -->
                                             <Viewbox Margin="0" DockPanel.Dock="Left">
-                                                <Button
+                                                <ui:Button
                                                     Width="50"
                                                     Height="50"
                                                     Padding="5"
@@ -154,8 +151,10 @@
                                                     VerticalAlignment="Stretch"
                                                     HorizontalContentAlignment="Stretch"
                                                     Command="{Binding RestartDeviceCommand}"
-                                                    FontStyle="Normal">
-                                                    <Button.Content>
+                                                    FontStyle="Normal"
+                                                    ToolTip="{Binding RestartDeviceToolTip}"
+                                                    ToolTipService.InitialShowDelay="200">
+                                                    <ui:Button.Content>
                                                         <Viewbox>
                                                             <ui:SymbolIcon
                                                                 Margin="0"
@@ -178,10 +177,10 @@
                                                             </ui:SymbolIcon>
                                                         </Viewbox>
 
-                                                    </Button.Content>
+                                                    </ui:Button.Content>
 
 
-                                                </Button>
+                                                </ui:Button>
 
                                             </Viewbox>
 
@@ -226,8 +225,34 @@
                     Visibility="{Binding ViewModel.AnyDeviceSelected, Converter={StaticResource BoolToVis}}">
                     <viewuserctrls:DeviceUserControl DataContext="{Binding ViewModel.SelectedDevice}" />
                 </ContentControl>
-
-
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Visibility="{Binding ViewModel.AnyDeviceSelected, Converter={StaticResource BoolToVis_TC_FV}}">
+                    <ui:SymbolIcon
+                        HorizontalAlignment="Center"
+                        FontSize="40"
+                        Opacity="0.45"
+                        Symbol="XboxController48" />
+                    <ui:TextBlock
+                        MaxWidth="280"
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="Click a device for details and settings"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding ViewModel.HasConnectedDevices, Converter={StaticResource BoolToVis_TV_FC}}" />
+                    <ui:TextBlock
+                        MaxWidth="280"
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="Connect a DualShock 3 to see it here"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding ViewModel.HasConnectedDevices, Converter={StaticResource BoolToVis_TC_FV}}" />
+                </StackPanel>
             </Grid>
 
         </ui:Card>

--- a/ControlApp/Views/Pages/ProfilesPage.xaml
+++ b/ControlApp/Views/Pages/ProfilesPage.xaml
@@ -18,18 +18,12 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     ScrollViewer.CanContentScroll="False"
     mc:Ignorable="d">
-    <Page.Resources>
-        <helpers:BooleanToReverseConverter x:Key="BooleanToReverseConverterKey" />
-        <BooleanToVisibilityConverter x:Key="BoolToVis" />
-    </Page.Resources>
-
-
     <DockPanel VerticalAlignment="Stretch">
         <DockPanel
             Width="250"
             MaxWidth="250"
             DockPanel.Dock="Left"
-            IsEnabled="{Binding ViewModel.SelectedProfileVM.IsEditEnabled, FallbackValue=True, TargetNullValue=False, Converter={StaticResource BooleanToReverseConverterKey}}">
+            IsEnabled="{Binding ViewModel.SelectedProfileVM.IsEditEnabled, FallbackValue=True, TargetNullValue=False, Converter={StaticResource BoolInverter}}">
             <DockPanel.Style>
                 <Style TargetType="DockPanel">
                     <Style.Setters>
@@ -55,40 +49,40 @@
                     <ColumnDefinition Width="3*" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <Button
+                <ui:Button
                     Grid.Column="0"
                     Margin="2"
                     Padding="0"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     Command="{Binding ViewModel.CreateProfileCommand}">
-                    <Button.Content>
+                    <ui:Button.Content>
                         <ui:SymbolIcon Symbol="Add24" />
-                    </Button.Content>
-                </Button>
-                <Button
+                    </ui:Button.Content>
+                </ui:Button>
+                <ui:Button
                     Grid.Column="1"
                     Margin="2"
                     Padding="0"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     Command="{Binding ViewModel.SelectedProfileVM.EnableEditingCommand}">
-                    <Button.Content>
+                    <ui:Button.Content>
                         <ui:TextBlock Text="Edit" />
-                    </Button.Content>
-                </Button>
-                <Button
+                    </ui:Button.Content>
+                </ui:Button>
+                <ui:Button
                     Grid.Column="2"
                     Margin="2"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     Command="{Binding ViewModel.SetProfileAsGlobalCommand}"
                     CommandParameter="{Binding ViewModel.SelectedProfileVM}">
-                    <Button.Content>
+                    <ui:Button.Content>
                         <ui:TextBlock Text="Set as global" />
-                    </Button.Content>
-                </Button>
-                <Button
+                    </ui:Button.Content>
+                </ui:Button>
+                <ui:Button
                     Grid.Column="3"
                     Margin="2"
                     Padding="0"
@@ -96,10 +90,10 @@
                     VerticalAlignment="Stretch"
                     Command="{Binding ViewModel.DeleteProfileCommand}"
                     CommandParameter="{Binding ViewModel.SelectedProfileVM}">
-                    <Button.Content>
+                    <ui:Button.Content>
                         <ui:SymbolIcon HorizontalAlignment="Center" Symbol="Delete28" />
-                    </Button.Content>
-                </Button>
+                    </ui:Button.Content>
+                </ui:Button>
             </Grid>
 
             <ui:ListView
@@ -159,14 +153,44 @@
         </DockPanel>
 
         <ui:Card
+            Padding="10"
             VerticalAlignment="Stretch"
             VerticalContentAlignment="Stretch"
             DockPanel.Dock="Right">
-            <Grid Visibility="{Binding ViewModel.AnyProfileSelected, Converter={StaticResource BoolToVis}}">
-                <viewuserctrls:ProfileUserControl DataContext="{Binding ViewModel.SelectedProfileVM}" />
+            <Grid>
+                <ContentControl
+                    Visibility="{Binding ViewModel.AnyProfileSelected, Converter={StaticResource BoolToVis}}">
+                    <viewuserctrls:ProfileUserControl DataContext="{Binding ViewModel.SelectedProfileVM}" />
+                </ContentControl>
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Visibility="{Binding ViewModel.AnyProfileSelected, Converter={StaticResource BoolToVis_TC_FV}}">
+                    <ui:SymbolIcon
+                        HorizontalAlignment="Center"
+                        FontSize="40"
+                        Opacity="0.45"
+                        Symbol="DocumentOnePage20" />
+                    <ui:TextBlock
+                        MaxWidth="280"
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="Click a profile for details and settings"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding ViewModel.HasProfiles, Converter={StaticResource BoolToVis_TV_FC}}" />
+                    <ui:TextBlock
+                        MaxWidth="280"
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="Create a profile to get started"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding ViewModel.HasProfiles, Converter={StaticResource BoolToVis_TC_FV}}" />
+                </StackPanel>
             </Grid>
-
-
         </ui:Card>
 
 

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -14,11 +14,11 @@
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    ScrollViewer.CanContentScroll="False"
     mc:Ignorable="d">
-    <Page.Resources>
-    </Page.Resources>
-
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <ScrollViewer
+        HorizontalScrollBarVisibility="Disabled"
+        VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="20">
             <CheckBox
                 Margin="0,0,0,8"
@@ -93,6 +93,13 @@
                     Icon="{ui:SymbolIcon QuestionCircle24}"
                     NavigateUri="https://docs.nefarius.at/projects/BthPS3/" />
             </StackPanel>
+            <ui:TextBlock
+                Margin="0,28,0,8"
+                FontTypography="Subtitle"
+                Text="About" />
+            <ui:TextBlock
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="{Binding ViewModel.AppVersion}" />
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
+++ b/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
@@ -15,24 +15,43 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
     <UserControl.Resources>
+        <Style x:Key="SettingsFieldLabel" TargetType="ui:TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="Margin" Value="0,0,12,0" />
+        </Style>
+        <Style x:Key="SettingsSliderLabel" TargetType="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        </Style>
+        <Style x:Key="SettingsSliderValue" TargetType="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="MinWidth" Value="36" />
+            <Setter Property="Margin" Value="10,0,16,0" />
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        </Style>
+        <Style x:Key="SettingsSliderRow" TargetType="Grid">
+            <Setter Property="MinHeight" Value="40" />
+            <Setter Property="Margin" Value="0,0,0,16" />
+        </Style>
         <DataTemplate x:Key="ModeSetting" DataType="{x:Type deviceSettings:DeviceSettingsViewModel}">
-            <ui:Card Margin="10,0,10,5" DockPanel.Dock="Top">
-                <DockPanel>
+            <ui:Card
+                Margin="0,0,0,14"
+                Padding="20,18"
+                DockPanel.Dock="Top">
+                <DockPanel Margin="2,0">
                     <!--  Outer settings container with override button  -->
-                    <Grid Margin="0,0,0,20" DockPanel.Dock="Top">
+                    <Grid Margin="0,0,0,12" DockPanel.Dock="Top">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="6*" />
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ui:TextBlock
-                            Grid.Column="1"
-                            HorizontalAlignment="Center"
                             VerticalAlignment="Center"
                             FontTypography="Subtitle"
                             Text="{Binding Header}" />
                         <ui:Button
-                            Grid.Column="2"
+                            Grid.Column="1"
+                            Margin="12,0,0,0"
                             HorizontalAlignment="Right"
                             Command="{Binding ResetGroupToOriginalDefaultsCommand}"
                             Content="Reset"
@@ -50,7 +69,7 @@
                         DockPanel.Dock="Top"
                         IsClosable="False"
                         IsOpen="{Binding IsGroupLocked}"
-                        Message="Settings locked by another option to prevent conflitcs"
+                        Message="Settings locked by another option to prevent conflicts"
                         Severity="Informational" />
                 </DockPanel>
             </ui:Card>
@@ -59,10 +78,11 @@
             <DockPanel LastChildFill="False">
                 <DockPanel DockPanel.Dock="Top" LastChildFill="False">
                     <!--  DataContext="{Binding VariableRightEmulToggleCombo}"  -->
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         VerticalAlignment="Center"
-                        Content="Buttons combo:"
-                        DockPanel.Dock="Left" />
+                        DockPanel.Dock="Left"
+                        Text="Buttons combo:" />
                     <ComboBox
                         Width="100"
                         DockPanel.Dock="Left"
@@ -70,26 +90,27 @@
                         SelectedItem="{Binding Button1, Delay=100}" />
                     <ComboBox
                         Width="100"
-                        Margin="5,0,0,0"
+                        Margin="8,0,0,0"
                         DockPanel.Dock="Left"
                         ItemsSource="{Binding Source={helpers:EnumBindingSource {x:Type enums:Button}}}"
                         SelectedItem="{Binding Button2, Delay=100}" />
                     <ComboBox
                         Width="100"
-                        Margin="5,0,0,0"
+                        Margin="8,0,0,0"
                         DockPanel.Dock="Left"
                         ItemsSource="{Binding Source={helpers:EnumBindingSource {x:Type enums:Button}}}"
                         SelectedItem="{Binding Button3, Delay=100}" />
 
                 </DockPanel>
                 <DockPanel
-                    Margin="0,5,0,0"
+                    Margin="0,8,0,0"
                     DockPanel.Dock="Top"
                     LastChildFill="False">
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         VerticalAlignment="Center"
-                        Content="Seconds holding combo for activation:"
-                        DockPanel.Dock="Left" />
+                        DockPanel.Dock="Left"
+                        Text="Seconds holding combo for activation:" />
                     <DockPanel LastChildFill="False">
                         <ui:NumberBox
                             MinWidth="80"
@@ -107,7 +128,7 @@
             <Setter Property="Margin" Value="0,2,0,0" />
             <Setter Property="ContentTemplate" Value="{StaticResource ModeSetting}" />
         </Style>
-        <Thickness x:Key="MyKey_NextLineSpacement" Bottom="10" />
+        <Thickness x:Key="MyKey_NextLineSpacement" Bottom="16" />
 
         <!--#region ===================================================================SubSettingsTemplates=======================================-->
 
@@ -115,11 +136,12 @@
         <DataTemplate DataType="{x:Type deviceSettings:HidModeSettingsViewModel}">
             <StackPanel>
                 <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}">
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
-                        Content="HID Emulation Mode:"
-                        DockPanel.Dock="Left" />
+                        DockPanel.Dock="Left"
+                        Text="HID Emulation Mode:" />
                     <ComboBox
                         VerticalAlignment="Center"
                         DockPanel.Dock="Right"
@@ -136,11 +158,12 @@
                 <!--  Pressure buttons mode  -->
                 <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}"
                            Visibility="{Binding Path=Context, Converter={StaticResource VisibilityPerHIDModeConverterKey}, ConverterParameter=11}">
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
-                        Content="Pressure buttons mode:"
-                        DockPanel.Dock="Left" />
+                        DockPanel.Dock="Left"
+                        Text="Pressure buttons mode:" />
                     <ComboBox
                         VerticalAlignment="Center"
                         DockPanel.Dock="Right"
@@ -150,11 +173,12 @@
                 <!--  DPAD modes  -->
                 <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}"
                            Visibility="{Binding Path=Context, Converter={StaticResource VisibilityPerHIDModeConverterKey}, ConverterParameter=11}">
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
-                        Content="Expose D-Pad as:"
-                        DockPanel.Dock="Left" />
+                        DockPanel.Dock="Left"
+                        Text="Expose D-Pad as:" />
                     <ComboBox
                         VerticalAlignment="Center"
                         DockPanel.Dock="Right"
@@ -174,10 +198,11 @@
                         Content="Allow apps and games to take over LEDs control"
                         IsChecked="{Binding AllowLedsOverride}" />
                     <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}">
-                        <Label
+                        <ui:TextBlock
+                            Style="{StaticResource SettingsFieldLabel}"
                             VerticalAlignment="Center"
-                            Content="LEDs control mode:"
-                            DockPanel.Dock="Left" />
+                            DockPanel.Dock="Left"
+                            Text="LEDs control mode:" />
                         <ComboBox
                             x:Name="LEDModeComboBox"
                             VerticalAlignment="Center"
@@ -235,90 +260,102 @@
                                         Margin="{StaticResource MyKey_NextLineSpacement}"
                                         Content="Use advanced effects"
                                         IsChecked="{Binding UseEffects}" />
-                                    <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}">
-                                        <Label
-                                            HorizontalAlignment="Left"
+                                    <Grid Style="{StaticResource SettingsSliderRow}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock
                                             VerticalAlignment="Center"
-                                            Content="Duration:"
-                                            DockPanel.Dock="Left" />
+                                            Style="{StaticResource SettingsSliderLabel}"
+                                            Text="Duration:" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource SettingsSliderValue}"
+                                            Text="{Binding Duration}" />
                                         <Slider
-                                            Width="400"
-                                            HorizontalAlignment="Right"
+                                            Grid.Column="2"
+                                            Height="24"
                                             VerticalAlignment="Center"
-                                            DockPanel.Dock="Right"
                                             Maximum="255"
                                             Minimum="0"
                                             SmallChange="1"
                                             Value="{Binding Duration}" />
-                                        <Label
-                                            HorizontalAlignment="Right"
-                                            Content="{Binding Duration}"
-                                            DockPanel.Dock="Right" />
-                                    </DockPanel>
-                                    <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}">
-                                        <Label
-                                            HorizontalAlignment="Left"
+                                    </Grid>
+                                    <Grid Style="{StaticResource SettingsSliderRow}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock
                                             VerticalAlignment="Center"
-                                            Content="Interval duration:"
-                                            DockPanel.Dock="Left" />
+                                            Style="{StaticResource SettingsSliderLabel}"
+                                            Text="Interval duration:" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource SettingsSliderValue}"
+                                            Text="{Binding IntervalDuration}" />
                                         <Slider
-                                            Width="400"
-                                            HorizontalAlignment="Right"
+                                            Grid.Column="2"
+                                            Height="24"
                                             VerticalAlignment="Center"
-                                            HorizontalContentAlignment="Right"
-                                            ClipToBounds="True"
-                                            DockPanel.Dock="Right"
                                             Maximum="65535"
                                             Minimum="0"
                                             SmallChange="1"
                                             Value="{Binding IntervalDuration}" />
-                                        <Label
-                                            HorizontalAlignment="Right"
-                                            Content="{Binding IntervalDuration}"
-                                            DockPanel.Dock="Right" />
-                                    </DockPanel>
-                                    <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}">
-                                        <Label
-                                            HorizontalAlignment="Left"
+                                    </Grid>
+                                    <Grid Style="{StaticResource SettingsSliderRow}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock
                                             VerticalAlignment="Center"
-                                            Content="Interval ON portion:"
-                                            DockPanel.Dock="Left" />
+                                            Style="{StaticResource SettingsSliderLabel}"
+                                            Text="Interval ON portion:" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource SettingsSliderValue}"
+                                            Text="{Binding IntervalPortionON}" />
                                         <Slider
-                                            Width="400"
+                                            Grid.Column="2"
+                                            Height="24"
                                             VerticalAlignment="Center"
-                                            ClipToBounds="True"
-                                            DockPanel.Dock="Right"
                                             Maximum="255"
                                             Minimum="0"
                                             SmallChange="1"
-                                            ToolTip="{Binding Value, RelativeSource={RelativeSource Self}}"
                                             Value="{Binding IntervalPortionON}" />
-                                        <Label
-                                            HorizontalAlignment="Right"
-                                            Content="{Binding IntervalPortionON}"
-                                            DockPanel.Dock="Right" />
-
-                                    </DockPanel>
-                                    <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}">
-                                        <Label
-                                            HorizontalAlignment="Left"
+                                    </Grid>
+                                    <Grid Style="{StaticResource SettingsSliderRow}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock
                                             VerticalAlignment="Center"
-                                            Content="Interval OFF portion:"
-                                            DockPanel.Dock="Left" />
+                                            Style="{StaticResource SettingsSliderLabel}"
+                                            Text="Interval OFF portion:" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource SettingsSliderValue}"
+                                            Text="{Binding IntervalPortionOFF}" />
                                         <Slider
-                                            Width="400"
+                                            Grid.Column="2"
+                                            Height="24"
                                             VerticalAlignment="Center"
-                                            ClipToBounds="True"
-                                            DockPanel.Dock="Right"
                                             Maximum="255"
                                             Minimum="0"
                                             SmallChange="1"
                                             Value="{Binding IntervalPortionOFF}" />
-                                        <Label
-                                            HorizontalAlignment="Right"
-                                            Content="{Binding IntervalPortionOFF}"
-                                            DockPanel.Dock="Right" />
-                                    </DockPanel>
+                                    </Grid>
                                 </StackPanel>
                             </StackPanel>
                         </TabItem>
@@ -339,26 +376,35 @@
                     Content="Disconnect the controller after idle period"
                     DockPanel.Dock="Top"
                     IsChecked="{Binding IsWirelessIdleDisconnectEnabled}" />
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <Label
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        Content="Idle disconnect period (in minutes):"
-                        DockPanel.Dock="Left" />
-                    <Label
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="Idle disconnect period (in minutes):" />
+                    <TextBlock
+                        Grid.Column="1"
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="{Binding WirelessIdleDisconnectTime}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding WirelessIdleDisconnectTime}" />
                     <Slider
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         AutoToolTipPlacement="TopLeft"
-                        DockPanel.Dock="Left"
                         IsEnabled="{Binding IsWirelessIdleDisconnectEnabled}"
                         IsSnapToTickEnabled="True"
                         Maximum="60"
                         Minimum="1"
                         TickFrequency="1"
                         Value="{Binding WirelessIdleDisconnectTime}" />
-                </DockPanel>
+                </Grid>
                 <ui:ToggleSwitch
                     x:Name="EnableQuickDisconnectComboCheckbox"
                     Margin="{StaticResource MyKey_NextLineSpacement}"
@@ -388,35 +434,38 @@
                         <ColumnDefinition Width="2*" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <!--  Row 0: Labels  -->
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         Grid.Row="0"
                         Grid.Column="1"
-                        HorizontalContentAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="Left Stick" />
-                    <Label
+                        Margin="4,0,4,8"
+                        HorizontalAlignment="Center"
+                        Text="Left Stick" />
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         Grid.Row="0"
                         Grid.Column="2"
-                        HorizontalContentAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="Right Stick" />
+                        Margin="4,0,4,8"
+                        HorizontalAlignment="Center"
+                        Text="Right Stick" />
                     <!--  Row 1: DeadZone  -->
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         Grid.Row="1"
                         Grid.Column="0"
-                        HorizontalContentAlignment="Left"
-                        VerticalContentAlignment="Center"
-                        Content="DeadZone (%):" />
+                        Margin="0,6,12,6"
+                        HorizontalAlignment="Left"
+                        Text="DeadZone (%):" />
                     <ui:NumberBox
                         Grid.Row="1"
                         Grid.Column="1"
+                        Margin="4,6"
                         ClearButtonEnabled="False"
                         ClipToBounds="True"
                         Maximum="142"
@@ -425,43 +474,50 @@
                     <ui:NumberBox
                         Grid.Row="1"
                         Grid.Column="2"
+                        Margin="4,6"
                         ClearButtonEnabled="False"
                         ClipToBounds="True"
                         Maximum="142"
                         Minimum="0"
                         Value="{Binding RightStickDeadZone, UpdateSourceTrigger=PropertyChanged}" />
                     <!--  Row 2: Invert X  -->
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         Grid.Row="2"
                         Grid.Column="0"
-                        HorizontalContentAlignment="Left"
-                        VerticalContentAlignment="Center"
-                        Content="Invert horizontally (X-Axis):" />
+                        Margin="0,6,12,6"
+                        HorizontalAlignment="Left"
+                        Text="Invert horizontally (X-Axis):" />
                     <ui:ToggleSwitch
                         Grid.Row="2"
                         Grid.Column="1"
+                        Margin="4,6"
                         HorizontalAlignment="Center"
                         IsChecked="{Binding InvertLSX}" />
                     <ui:ToggleSwitch
                         Grid.Row="2"
                         Grid.Column="2"
+                        Margin="4,6"
                         HorizontalAlignment="Center"
                         IsChecked="{Binding InvertRSX}" />
                     <!--  Row 3: Invert Y  -->
-                    <Label
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
                         Grid.Row="3"
                         Grid.Column="0"
-                        HorizontalContentAlignment="Left"
-                        VerticalContentAlignment="Center"
-                        Content="Invert vertically (Y-Axis):" />
+                        Margin="0,6,12,6"
+                        HorizontalAlignment="Left"
+                        Text="Invert vertically (Y-Axis):" />
                     <ui:ToggleSwitch
                         Grid.Row="3"
                         Grid.Column="1"
+                        Margin="4,6"
                         HorizontalAlignment="Center"
                         IsChecked="{Binding InvertLSY}" />
                     <ui:ToggleSwitch
                         Grid.Row="3"
                         Grid.Column="2"
+                        Margin="4,6"
                         HorizontalAlignment="Center"
                         IsChecked="{Binding InvertRSY}" />
                 </Grid>
@@ -520,10 +576,9 @@
                                Visibility="{Binding AltModeToggleButtonCombo.IsEnabled, Converter={StaticResource BoolToVis_TV_FH}}">
                         <ui:ToggleSwitch
                             Margin="{StaticResource MyKey_NextLineSpacement}"
+                            Content="Start in normal mode"
                             DockPanel.Dock="Top"
-                            IsChecked="{Binding AlwaysStartInNormalRumbleMode}">
-                            <Label Content="Start in normal mode" />
-                        </ui:ToggleSwitch>
+                            IsChecked="{Binding AlwaysStartInNormalRumbleMode}" />
                         <ui:ToggleSwitch
                             Margin="{StaticResource MyKey_NextLineSpacement}"
                             Content="Disable left motor (heavy) when in normal mode"
@@ -548,30 +603,42 @@
                 <!--  Output rate enabler  -->
                 <ui:ToggleSwitch
                     Margin="{StaticResource MyKey_NextLineSpacement}"
+                    VerticalContentAlignment="Center"
                     Content="Limit maximum output rate when wireless"
                     DockPanel.Dock="Top"
                     IsChecked="{Binding IsOutputReportRateControlEnabled}" />
                 <!--  Max output rate adjuster  -->
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <Label
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        Content="Max output rate  (in ms):"
-                        DockPanel.Dock="Left" />
-                    <Label
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="Max output rate (in ms):" />
+                    <TextBlock
+                        Grid.Column="1"
                         VerticalAlignment="Center"
-                        Content="{Binding MaxOutputRate}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding MaxOutputRate}" />
                     <Slider
-                        DockPanel.Dock="Left"
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         IsSnapToTickEnabled="True"
                         Maximum="255"
                         Minimum="1"
                         TickFrequency="1"
                         Value="{Binding MaxOutputRate}" />
-                </DockPanel>
+                </Grid>
                 <!--  Output report detuplicator  -->
                 <ui:ToggleSwitch
                     Margin="{StaticResource MyKey_NextLineSpacement}"
+                    VerticalContentAlignment="Center"
                     Content="Enable output report deduplicator"
                     DockPanel.Dock="Top"
                     IsChecked="{Binding IsOutputReportDeduplicatorEnabled}" />
@@ -584,49 +651,65 @@
                 <!--  Left motor str rescaling ui:ToggleSwitch  -->
                 <ui:ToggleSwitch
                     Margin="{StaticResource MyKey_NextLineSpacement}"
+                    VerticalContentAlignment="Center"
                     Content="Enable rescaling of left motor strength"
                     DockPanel.Dock="Top"
                     IsChecked="{Binding IsLeftMotorStrRescalingEnabled}" />
                 <!--  Upper range controls  -->
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <Label
-                        HorizontalAlignment="Left"
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        Content="New upper range:"
-                        DockPanel.Dock="Left" />
-                    <Label
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="New upper range:" />
+                    <TextBlock
+                        Grid.Column="1"
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="{Binding LeftMotorStrRescalingUpperRange}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding LeftMotorStrRescalingUpperRange}" />
                     <Slider
-                        DockPanel.Dock="Right"
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         IsSnapToTickEnabled="True"
                         Maximum="255"
                         Minimum="2"
                         TickFrequency="1"
                         Value="{Binding LeftMotorStrRescalingUpperRange}" />
-                </DockPanel>
-                <!--  lower range controls  -->
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <Label
-                        HorizontalAlignment="Left"
+                </Grid>
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        Content="New lower range:"
-                        DockPanel.Dock="Left" />
-                    <Label
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="New lower range:" />
+                    <TextBlock
+                        Grid.Column="1"
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="{Binding LeftMotorStrRescalingLowerRange}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding LeftMotorStrRescalingLowerRange}" />
                     <Slider
-                        DockPanel.Dock="Right"
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         IsSnapToTickEnabled="True"
                         Maximum="254"
                         Minimum="1"
                         TickFrequency="1"
                         Value="{Binding LeftMotorStrRescalingLowerRange}" />
-                </DockPanel>
+                </Grid>
             </DockPanel>
         </DataTemplate>
 
@@ -634,112 +717,150 @@
         <DataTemplate DataType="{x:Type deviceSettings:AltRumbleModeSettingsViewModel}">
             <DockPanel>
                 <!--  Conversion upper range  -->
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <Label
-                        HorizontalAlignment="Left"
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        Content="Conversion upper range:"
-                        DockPanel.Dock="Left" />
-                    <Label
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="Conversion upper range:" />
+                    <TextBlock
+                        Grid.Column="1"
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="{Binding RightRumbleConversionUpperRange}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding RightRumbleConversionUpperRange}" />
                     <Slider
-                        DockPanel.Dock="Right"
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         IsSnapToTickEnabled="True"
                         Maximum="255"
                         Minimum="2"
                         TickFrequency="1"
                         Value="{Binding RightRumbleConversionUpperRange}" />
-                </DockPanel>
-                <!--  Conversion lower range  -->
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <Label
-                        HorizontalAlignment="Left"
+                </Grid>
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        Content="Conversion lower range:"
-                        DockPanel.Dock="Left" />
-                    <Label
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="Conversion lower range:" />
+                    <TextBlock
+                        Grid.Column="1"
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="{Binding RightRumbleConversionLowerRange}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding RightRumbleConversionLowerRange}" />
                     <Slider
-                        DockPanel.Dock="Right"
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         IsSnapToTickEnabled="True"
                         Maximum="254"
                         Minimum="1"
                         TickFrequency="1"
                         Value="{Binding RightRumbleConversionLowerRange}" />
-                </DockPanel>
-                <Label
+                </Grid>
+                <ui:TextBlock
+                    Style="{StaticResource SettingsFieldLabel}"
                     Margin="{StaticResource MyKey_NextLineSpacement}"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
-                    Content="Force activate right motor when above..."
-                    DockPanel.Dock="Top" />
-                <!--  Forced right motor activation / light rumble threshold  -->
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <ui:ToggleSwitch
-                        x:Name="ForcedRMLeftThresholdCheckbox"
-                        Content="Left rumble threshold:"
-                        DockPanel.Dock="Left"
-                        IsChecked="{Binding IsForcedRightMotorHeavyThresholdEnabled}" />
-                    <Label
+                    DockPanel.Dock="Top"
+                    Text="Force activate right motor when above..." />
+                <ui:ToggleSwitch
+                    x:Name="ForcedRMLeftThresholdCheckbox"
+                    Margin="{StaticResource MyKey_NextLineSpacement}"
+                    Content="Enable left rumble threshold"
+                    DockPanel.Dock="Top"
+                    IsChecked="{Binding IsForcedRightMotorHeavyThresholdEnabled}" />
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top"
+                    IsEnabled="{Binding IsForcedRightMotorHeavyThresholdEnabled}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="{Binding ForcedRightMotorHeavyThreshold}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="Left rumble threshold:" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding ForcedRightMotorHeavyThreshold}" />
                     <Slider
-                        DockPanel.Dock="Right"
-                        IsEnabled="{Binding IsForcedRightMotorHeavyThresholdEnabled}"
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         IsSnapToTickEnabled="True"
                         Maximum="255"
                         Minimum="1"
                         TickFrequency="1"
                         Value="{Binding ForcedRightMotorHeavyThreshold}" />
-                </DockPanel>
-                <!--  Forced right motor activation / heavy rumble threshold  -->
-                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
-                    <ui:ToggleSwitch
-                        x:Name="ForcedRMRightThresholdCheckbox"
+                </Grid>
+                <ui:ToggleSwitch
+                    x:Name="ForcedRMRightThresholdCheckbox"
+                    Margin="{StaticResource MyKey_NextLineSpacement}"
+                    VerticalAlignment="Center"
+                    VerticalContentAlignment="Center"
+                    Content="Enable right rumble threshold"
+                    DockPanel.Dock="Top"
+                    IsChecked="{Binding IsForcedRightMotorLightThresholdEnabled}" />
+                <Grid
+                    Style="{StaticResource SettingsSliderRow}"
+                    DockPanel.Dock="Top"
+                    IsEnabled="{Binding IsForcedRightMotorLightThresholdEnabled}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="Right rumble threshold:"
-                        DockPanel.Dock="Left"
-                        IsChecked="{Binding IsForcedRightMotorLightThresholdEnabled}" />
-                    <Label
+                        Style="{StaticResource SettingsSliderLabel}"
+                        Text="Right rumble threshold:" />
+                    <TextBlock
+                        Grid.Column="1"
                         VerticalAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Content="{Binding ForcedRightMotorLightThreshold}"
-                        DockPanel.Dock="Left" />
+                        Style="{StaticResource SettingsSliderValue}"
+                        Text="{Binding ForcedRightMotorLightThreshold}" />
                     <Slider
-                        DockPanel.Dock="Right"
-                        IsEnabled="{Binding IsForcedRightMotorLightThresholdEnabled}"
+                        Grid.Column="2"
+                        Height="24"
+                        VerticalAlignment="Center"
                         IsSnapToTickEnabled="True"
                         Maximum="255"
                         Minimum="1"
                         TickFrequency="1"
                         Value="{Binding ForcedRightMotorLightThreshold}" />
-                </DockPanel>
+                </Grid>
             </DockPanel>
         </DataTemplate>
 
 
         <!--#endregion-->
-        <Style BasedOn="{StaticResource {x:Type Label}}" TargetType="Label">
-            <Setter Property="VerticalAlignment" Value="Center" />
-            <Setter Property="VerticalContentAlignment" Value="Center" />
-            <Setter Property="Margin" Value="0,0,10,0" />
-        </Style>
     </UserControl.Resources>
     <ui:DynamicScrollViewer>
         <DockPanel
+            Margin="4,0,8,8"
             HorizontalAlignment="Stretch"
-            VerticalAlignment="Stretch"
+            VerticalAlignment="Top"
             IsEnabled="{Binding AllowEditing}"
-            LastChildFill="True">
+            LastChildFill="False">
 
             <ItemsControl DockPanel.Dock="Top" ItemsSource="{Binding PrimaryGroups}">
                 <ItemsControl.ItemTemplate>
@@ -748,14 +869,15 @@
             </ItemsControl>
 
             <ui:CardExpander
-                Margin="10"
+                Margin="0,4,0,12"
+                Padding="16,8"
                 DockPanel.Dock="Top"
                 Header="Advanced settings">
                 <ui:CardExpander.Content>
-                    <DockPanel>
+                    <DockPanel Margin="0,8,0,0">
                         <ui:InfoBar
                             Title="Advanced settings ahead!"
-                            Margin="10"
+                            Margin="0,0,0,12"
                             DockPanel.Dock="Top"
                             IsClosable="False"
                             IsOpen="True"

--- a/ControlApp/Views/UserControls/DeviceUserControl.xaml
+++ b/ControlApp/Views/UserControls/DeviceUserControl.xaml
@@ -30,22 +30,34 @@
     </UserControl.Resources>
     <DockPanel>
         <DockPanel DockPanel.Dock="Bottom">
-            <UniformGrid Columns="2">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
                 <ui:Button
+                    Grid.Column="0"
                     HorizontalAlignment="Stretch"
+                    Appearance="Primary"
                     Command="{Binding ApplyChangesCommand}"
                     Content="Apply changes" />
                 <ui:Button
+                    Grid.Column="2"
                     HorizontalAlignment="Stretch"
+                    Appearance="Secondary"
                     Command="{Binding RefreshDeviceSettingsCommand}"
                     Content="Cancel" />
-            </UniformGrid>
+            </Grid>
 
         </DockPanel>
 
         <TabControl Margin="{StaticResource MyKey_NextLineSpacement}" VerticalAlignment="Stretch">
             <TabItem Header="Info">
                 <!--  Device info  -->
+                <ScrollViewer
+                    HorizontalScrollBarVisibility="Disabled"
+                    VerticalScrollBarVisibility="Auto">
                 <DockPanel
                     Margin="10"
                     HorizontalAlignment="Stretch"
@@ -58,11 +70,6 @@
                                 DockPanel.Dock="Left"
                                 Style="{StaticResource MyKey_InfoDescriptionTextbox}"
                                 Text="Device name:" />
-                            <ui:SymbolIcon
-                                DockPanel.Dock="Right"
-                                FontSize="{StaticResource MyKey_SymbolFontSize}"
-                                Style="{StaticResource MyKey_StatusSymbol}"
-                                ToolTipService.ToolTip="Yu" />
                             <ui:TextBox
                                 HorizontalAlignment="Stretch"
                                 DockPanel.Dock="Left"
@@ -98,10 +105,6 @@
                                 DockPanel.Dock="Left"
                                 Style="{StaticResource MyKey_InfoDescriptionTextbox}"
                                 Text="Battery status:" />
-                            <ui:SymbolIcon
-                                DockPanel.Dock="Right"
-                                FontSize="{StaticResource MyKey_SymbolFontSize}"
-                                Style="{StaticResource MyKey_StatusSymbol}" />
                             <ui:TextBlock
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
@@ -179,7 +182,7 @@
                                 Style="{StaticResource MyKey_StatusSymbol}"
                                 Symbol="Warning24"
                                 Visibility="{Binding IsHidModeMismatched, Converter={StaticResource BoolToVis_TV_FH}}" />
-                            <TextBlock
+                            <ui:TextBlock
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 DockPanel.Dock="Right"
@@ -206,10 +209,6 @@
                                 DockPanel.Dock="Left"
                                 Style="{StaticResource MyKey_InfoDescriptionTextbox}"
                                 Text="Paired to (host address):" />
-                            <ui:SymbolIcon
-                                DockPanel.Dock="Right"
-                                FontSize="{StaticResource MyKey_SymbolFontSize}"
-                                Style="{StaticResource MyKey_StatusSymbol}" />
                             <ui:TextBox
                                 DockPanel.Dock="Right"
                                 IsReadOnly="True"
@@ -251,10 +250,11 @@
                                 x:Name="PairingModeComboBox"
                                 VerticalAlignment="Stretch"
                                 IsEnabled="{Binding SupportsBluetoothPairing}"
-                                SelectedIndex="{Binding PairingMode}">
-                                <ComboBoxItem Content="To this PC" />
-                                <ComboBoxItem Content="Custom MAC address" />
-                                <ComboBoxItem Content="Disabled" />
+                                SelectedValue="{Binding PairingMode}"
+                                SelectedValuePath="Tag">
+                                <ComboBoxItem Content="To this PC" Tag="{x:Static enums:BluetoothPairingMode.Auto}" />
+                                <ComboBoxItem Content="Custom MAC address" Tag="{x:Static enums:BluetoothPairingMode.Custom}" />
+                                <ComboBoxItem Content="Disabled" Tag="{x:Static enums:BluetoothPairingMode.Disabled}" />
                             </ComboBox>
 
                         </DockPanel>
@@ -278,10 +278,6 @@
                                 DockPanel.Dock="Left"
                                 Style="{StaticResource MyKey_InfoDescriptionTextbox}"
                                 Text="Custom pairing address:" />
-                            <ui:SymbolIcon
-                                DockPanel.Dock="Right"
-                                FontSize="{StaticResource MyKey_SymbolFontSize}"
-                                Style="{StaticResource MyKey_StatusSymbol}" />
                             <ui:TextBox
                                 DockPanel.Dock="Right"
                                 MaxLength="20"
@@ -297,14 +293,20 @@
                                 DockPanel.Dock="Left"
                                 Style="{StaticResource MyKey_InfoDescriptionTextbox}"
                                 Text="Wireless connection time:" />
-                            <ui:SymbolIcon
-                                DockPanel.Dock="Right"
-                                FontSize="{StaticResource MyKey_SymbolFontSize}"
-                                Style="{StaticResource MyKey_StatusSymbol}" />
                             <ui:TextBlock
                                 VerticalAlignment="Center"
                                 DockPanel.Dock="Right"
-                                Text="{Binding LastConnected, Mode=OneWay}" />
+                                Text="{Binding LastConnectedDisplay, Mode=OneWay}">
+                                <ui:TextBlock.Style>
+                                    <Style TargetType="ui:TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsWireless}" Value="False">
+                                                <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ui:TextBlock.Style>
+                            </ui:TextBlock>
                         </DockPanel>
 
                         <!--  Instance ID  -->
@@ -313,10 +315,6 @@
                                 DockPanel.Dock="Left"
                                 Style="{StaticResource MyKey_InfoDescriptionTextbox}"
                                 Text="Driver version:" />
-                            <ui:SymbolIcon
-                                DockPanel.Dock="Right"
-                                FontSize="{StaticResource MyKey_SymbolFontSize}"
-                                Style="{StaticResource MyKey_StatusSymbol}" />
                             <ui:TextBox
                                 DockPanel.Dock="Right"
                                 IsReadOnly="True"
@@ -329,10 +327,6 @@
                                 DockPanel.Dock="Left"
                                 Style="{StaticResource MyKey_InfoDescriptionTextbox}"
                                 Text="Instance ID:" />
-                            <ui:SymbolIcon
-                                DockPanel.Dock="Right"
-                                FontSize="{StaticResource MyKey_SymbolFontSize}"
-                                Style="{StaticResource MyKey_StatusSymbol}" />
                             <ui:TextBox
                                 DockPanel.Dock="Right"
                                 IsReadOnly="True"
@@ -343,6 +337,7 @@
                     </DockPanel>
 
                 </DockPanel>
+                </ScrollViewer>
 
 
             </TabItem>
@@ -391,7 +386,6 @@
 
                     <ContentControl Visibility="{Binding IsEditorVisible, Converter={StaticResource BoolToVis}}">
                         <local:DeviceSettingsEditor
-                            Height="auto"
                             VerticalAlignment="Stretch"
                             DataContext="{Binding DeviceCustomsVM}"
                             DockPanel.Dock="Top" />

--- a/ControlApp/Views/UserControls/ProfileUserControl.xaml
+++ b/ControlApp/Views/UserControls/ProfileUserControl.xaml
@@ -12,13 +12,14 @@
     d:DesignHeight="600"
     d:DesignWidth="800"
     mc:Ignorable="d">
-    <UserControl.Resources>
-    </UserControl.Resources>
-    <DockPanel>
-        <ui:Card DockPanel.Dock="Top">
+    <DockPanel Margin="4,0,4,0">
+        <ui:Card
+            Margin="0,0,0,12"
+            Padding="20,18"
+            DockPanel.Dock="Top">
             <DockPanel>
                 <ui:TextBlock
-                    Margin="0,0,10,0"
+                    Margin="0,0,12,0"
                     VerticalAlignment="Center"
                     Text="Profile name:" />
                 <ui:TextBox
@@ -27,21 +28,32 @@
                     Text="{Binding Name}" />
             </DockPanel>
         </ui:Card>
-        <DockPanel DockPanel.Dock="Bottom" IsEnabled="{Binding IsEditEnabled}">
-            <UniformGrid Columns="2">
+        <DockPanel
+            Margin="0,4,0,0"
+            DockPanel.Dock="Bottom"
+            IsEnabled="{Binding IsEditEnabled}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
                 <ui:Button
+                    Grid.Column="0"
                     HorizontalAlignment="Stretch"
+                    Appearance="Primary"
                     Command="{Binding SaveChangesCommand}"
                     Content="Save changes" />
                 <ui:Button
+                    Grid.Column="2"
                     HorizontalAlignment="Stretch"
+                    Appearance="Secondary"
                     Command="{Binding CancelChangesCommand}"
                     Content="Cancel" />
-            </UniformGrid>
+            </Grid>
         </DockPanel>
         <local:DeviceSettingsEditor
-            Height="auto"
-            Margin="0,10,0,10"
+            Margin="0,0,0,8"
             VerticalAlignment="Stretch"
             DataContext="{Binding VmGroupsCont}"
             DockPanel.Dock="Top" />

--- a/ControlApp/Views/Windows/MainWindow.xaml
+++ b/ControlApp/Views/Windows/MainWindow.xaml
@@ -10,6 +10,8 @@
     Title="{Binding ViewModel.ApplicationTitle, Mode=OneWay}"
     Width="1100"
     Height="650"
+    MinWidth="1100"
+    MinHeight="650"
     d:DataContext="{d:DesignInstance local:MainWindow,
                                      IsDesignTimeCreatable=True}"
     d:DesignHeight="450"
@@ -57,14 +59,9 @@
             </ui:TitleBar>
         </DockPanel>
 
-        <Grid DockPanel.Dock="Top">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="23*" />
-                <ColumnDefinition Width="9*" />
-            </Grid.ColumnDefinitions>
+        <Grid>
             <ui:NavigationView
                 x:Name="RootNavigation"
-                Grid.ColumnSpan="2"
                 Padding="10,0,10,0"
                 FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
                 FrameMargin="0"
@@ -73,16 +70,6 @@
                 MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
                 OpenPaneLength="100"
                 PaneDisplayMode="Left">
-
-                <!--<ui:NavigationView.AutoSuggestBox>
-                <ui:AutoSuggestBox x:Name="AutoSuggestBox" PlaceholderText="Search">
-                    <ui:AutoSuggestBox.Icon>
-                        <ui:IconSourceElement>
-                            <ui:SymbolIconSource Symbol="Search24" />
-                        </ui:IconSourceElement>
-                    </ui:AutoSuggestBox.Icon>
-                </ui:AutoSuggestBox>
-            </ui:NavigationView.AutoSuggestBox>-->
                 <ui:NavigationView.ContentOverlay>
                     <Grid>
                         <ui:SnackbarPresenter x:Name="SnackbarPresenter" Margin="0" />
@@ -90,10 +77,7 @@
                 </ui:NavigationView.ContentOverlay>
             </ui:NavigationView>
 
-            <ui:ContentDialogHost
-                x:Name="RootContentDialog"
-                Grid.Row="0"
-                Grid.ColumnSpan="2" />
+            <ui:ContentDialogHost x:Name="RootContentDialog" />
         </Grid>
 
 

--- a/ControlApp/Views/Windows/MainWindow.xaml.cs
+++ b/ControlApp/Views/Windows/MainWindow.xaml.cs
@@ -38,6 +38,7 @@ public partial class MainWindow : INavigationWindow
         ApplicationThemeManager.Apply(ApplicationTheme.Dark);
 
         InitializeComponent();
+        ApplySavedPlacement();
 
         navigationService.SetNavigationControl(RootNavigation);
         snackbarService.SetSnackbarPresenter(SnackbarPresenter);
@@ -81,12 +82,15 @@ public partial class MainWindow : INavigationWindow
 
         if (TrayWindowPolicy.ShouldHideOnMinimize(ViewModel.AppConfig.MinimizeToTray, WindowState))
         {
+            PersistWindowPlacement();
             HideToTray();
         }
     }
 
     protected override void OnClosing(CancelEventArgs e)
     {
+        PersistWindowPlacement();
+
         if (TrayWindowPolicy.ShouldHideInsteadOfClose(ViewModel.AppConfig.MinimizeToTray, App.IsExiting))
         {
             e.Cancel = true;
@@ -142,6 +146,51 @@ public partial class MainWindow : INavigationWindow
     {
         Hide();
         ShowInTaskbar = false;
+    }
+
+    private void ApplySavedPlacement()
+    {
+        if (!WindowPlacementPolicy.TryRead(ViewModel.AppConfig, out WindowPlacementSnapshot saved))
+        {
+            return;
+        }
+
+        WindowPlacementSnapshot resolved = WindowPlacementPolicy.Resolve(
+            saved,
+            DisplayWorkAreas.GetDipWorkingAreas(),
+            SystemParameters.WorkArea);
+
+        WindowStartupLocation = WindowStartupLocation.Manual;
+        Left = resolved.Left;
+        Top = resolved.Top;
+        Width = resolved.Width;
+        Height = resolved.Height;
+        if (resolved.State == WindowState.Maximized)
+        {
+            WindowState = WindowState.Maximized;
+        }
+    }
+
+    private void PersistWindowPlacement()
+    {
+        Rect bounds = WindowState == WindowState.Normal
+            ? new Rect(Left, Top, Width, Height)
+            : RestoreBounds;
+        if (bounds.Width <= 0 || bounds.Height <= 0 ||
+            double.IsNaN(bounds.Left) || double.IsNaN(bounds.Top))
+        {
+            return;
+        }
+
+        WindowPlacementPolicy.Write(ViewModel.AppConfig, WindowState, bounds);
+        try
+        {
+            ViewModel.AppConfig.Save();
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Error(ex, "Failed to persist window placement.");
+        }
     }
 
 


### PR DESCRIPTION
Raise the minimum size, persist placement, show the version, keep pages scrollable, and space slider rows so labels and values no longer collide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Window size, position, and maximized state are restored between launches, with invalid or off-screen placements safely corrected.
  - Added contextual empty states for devices and profiles.
  - Device details now show connection status information and context-sensitive restart guidance.
  - Application version is displayed in the window title and Settings “About” section.

- **UI Improvements**
  - Refined device, profile, and settings layouts, controls, spacing, and scrolling.
  - Added a minimum main-window size and improved device action button presentation.
  - Improved Bluetooth pairing mode selection and settings editor readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->