### PR TITLE
Add opt-in Bluetooth interrupt output so rumble can be tested without…

### DIFF
--- a/ControlApp.Tests/DriverConfigContractTests.cs
+++ b/ControlApp.Tests/DriverConfigContractTests.cs
@@ -138,6 +138,74 @@ public class DriverConfigContractTests
         Assert.True(restored.GeneralRumble.IsAltRumbleModeEnabled);
         Assert.True(restored.GeneralRumble.AlwaysStartInNormalMode);
         Assert.Equal(90, restored.AltRumbleAdjusts.RightRumbleConversionUpperRange);
+        Assert.Equal(BluetoothOutputReportTransport.Control, restored.OutputReport.BluetoothOutputReportTransport);
+    }
+
+    [Fact]
+    public void Serialize_DefaultSettings_EmitsControlBluetoothOutputTransport()
+    {
+        JsonNode global = JsonNode.Parse(SerializeDefaultProfile(SettingsContext.XInput))!["Global"]!;
+        Assert.Equal("Control", global["BluetoothOutputReportTransport"]!.GetValue<string>());
+    }
+
+    [Theory]
+    [InlineData(BluetoothOutputReportTransport.Control, "Control")]
+    [InlineData(BluetoothOutputReportTransport.Interrupt, "Interrupt")]
+    public void RoundTrip_BluetoothOutputReportTransport_PreservesValue(
+        BluetoothOutputReportTransport transport,
+        string expectedName)
+    {
+        DeviceSettings original = new();
+        original.OutputReport.BluetoothOutputReportTransport = transport;
+
+        DshmDeviceSettings driver = new();
+        DshmManagerToDriverConversion.ConvertDeviceSettingsToDriverFormat(original, driver);
+        string json = DshmConfigSerialization.Serialize(new DshmConfiguration { Global = driver });
+        JsonNode global = JsonNode.Parse(json)!["Global"]!;
+        Assert.Equal(expectedName, global["BluetoothOutputReportTransport"]!.GetValue<string>());
+
+        DshmConfiguration parsed = DshmConfigSerialization.Deserialize(json);
+        DeviceSettings restored = new();
+        DshmManagerToDriverConversion.ConvertDriverFormatToDeviceSettings(parsed.Global, restored);
+        Assert.Equal(transport, restored.OutputReport.BluetoothOutputReportTransport);
+    }
+
+    [Fact]
+    public void Deserialize_LegacyConfigWithoutBluetoothTransport_KeepsControlDefault()
+    {
+        const string json = """
+            {
+              "Global": {
+                "HidDeviceMode": "XInput",
+                "IsOutputRateControlEnabled": true,
+                "OutputRateControlPeriodMs": 150
+              },
+              "Devices": {}
+            }
+            """;
+
+        DshmConfiguration parsed = DshmConfigSerialization.Deserialize(json);
+        Assert.Null(parsed.Global.BluetoothOutputReportTransport);
+
+        DeviceSettings restored = new();
+        DshmManagerToDriverConversion.ConvertDriverFormatToDeviceSettings(parsed.Global, restored);
+        Assert.Equal(BluetoothOutputReportTransport.Control, restored.OutputReport.BluetoothOutputReportTransport);
+    }
+
+    [Fact]
+    public void Overlay_BluetoothOutputReportTransport_OverridesBaseline()
+    {
+        DshmDeviceSettings baseline = new()
+        {
+            BluetoothOutputReportTransport = BluetoothOutputReportTransport.Control
+        };
+        DshmDeviceSettings overlay = new()
+        {
+            BluetoothOutputReportTransport = BluetoothOutputReportTransport.Interrupt
+        };
+
+        DshmDeviceSettings merged = DshmManagerToDriverConversion.OverlayDeviceSettings(baseline, overlay);
+        Assert.Equal(BluetoothOutputReportTransport.Interrupt, merged.BluetoothOutputReportTransport);
     }
 
     [Fact]

--- a/ControlApp.Tests/SettingsCopyAndBindingTests.cs
+++ b/ControlApp.Tests/SettingsCopyAndBindingTests.cs
@@ -41,6 +41,8 @@ public class SettingsCopyAndBindingTests
         original.GeneralRumble.IsAltRumbleModeEnabled = true;
         original.GeneralRumble.AltModeToggleButtonCombo.IsEnabled = true;
         original.OutputReport.MaxOutputRate = 80;
+        original.OutputReport.BluetoothOutputReportTransport =
+            Models.DshmConfigManager.DshmConfig.Enums.BluetoothOutputReportTransport.Interrupt;
         original.LeftMotorRescaling.LeftMotorStrRescalingLowerRange = 40;
         original.AltRumbleAdjusts.ForcedRightMotorHeavyThreshold = 200;
 
@@ -56,6 +58,8 @@ public class SettingsCopyAndBindingTests
         Assert.Equal(original.GeneralRumble.AlwaysStartInNormalMode, copy.GeneralRumble.AlwaysStartInNormalMode);
         Assert.True(copy.GeneralRumble.IsAltModeToggleButtonComboEnabled);
         Assert.Equal(original.OutputReport.MaxOutputRate, copy.OutputReport.MaxOutputRate);
+        Assert.Equal(original.OutputReport.BluetoothOutputReportTransport,
+            copy.OutputReport.BluetoothOutputReportTransport);
         Assert.Equal(original.LeftMotorRescaling.LeftMotorStrRescalingLowerRange,
             copy.LeftMotorRescaling.LeftMotorStrRescalingLowerRange);
         Assert.Equal(original.AltRumbleAdjusts.ForcedRightMotorHeavyThreshold,

--- a/ControlApp/Models/DshmConfigManager/DeviceSettings.cs
+++ b/ControlApp/Models/DshmConfigManager/DeviceSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
+using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.DshmConfig.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.Enums;
 
 using Button = Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.Enums.Button;
@@ -322,6 +323,8 @@ public class OutputReportSettings : DeviceSubSettings
     public bool IsOutputReportRateControlEnabled { get; set; } = true;
     public int MaxOutputRate { get; set; } = 150;
     public bool IsOutputReportDeduplicatorEnabled { get; set; }
+    public BluetoothOutputReportTransport BluetoothOutputReportTransport { get; set; } =
+        BluetoothOutputReportTransport.Control;
 
     public override void ResetToDefault()
     {
@@ -337,6 +340,7 @@ public class OutputReportSettings : DeviceSubSettings
         destiny.IsOutputReportDeduplicatorEnabled = source.IsOutputReportDeduplicatorEnabled;
         destiny.IsOutputReportRateControlEnabled = source.IsOutputReportRateControlEnabled;
         destiny.MaxOutputRate = source.MaxOutputRate;
+        destiny.BluetoothOutputReportTransport = source.BluetoothOutputReportTransport;
     }
 }
 

--- a/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfig.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfig.cs
@@ -17,6 +17,7 @@ public class DshmDeviceSettings
     public bool? PairOnHotReload { get; set; }
     public string? CustomPairingAddress { get; set; }
     public UsbOutputReportTransport? UsbOutputReportTransport { get; set; }
+    public BluetoothOutputReportTransport? BluetoothOutputReportTransport { get; set; }
     public bool? DisableWirelessIdleTimeout { get; set; }
     public bool? IsOutputRateControlEnabled { get; set; }
     public byte? OutputRateControlPeriodMs { get; set; }

--- a/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfigSerialization.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfigSerialization.cs
@@ -116,6 +116,8 @@ internal static class DshmConfigSerialization
         settings.PairOnHotReload = ReadBool(element, "PairOnHotReload");
         settings.CustomPairingAddress = ReadString(element, "CustomPairingAddress");
         settings.UsbOutputReportTransport = ReadEnum<UsbOutputReportTransport>(element, "UsbOutputReportTransport");
+        settings.BluetoothOutputReportTransport =
+            ReadEnum<BluetoothOutputReportTransport>(element, "BluetoothOutputReportTransport");
         settings.DisableWirelessIdleTimeout = ReadBool(element, "DisableWirelessIdleTimeout");
         settings.IsOutputRateControlEnabled = ReadBool(element, "IsOutputRateControlEnabled");
         settings.OutputRateControlPeriodMs = ReadByte(element, "OutputRateControlPeriodMs");

--- a/ControlApp/Models/DshmConfigManager/DshmConfig/Enums/DSHMDriverEnums.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfig/Enums/DSHMDriverEnums.cs
@@ -27,6 +27,16 @@ public enum UsbOutputReportTransport
     ControlEndpoint
 }
 
+/// <summary>
+///     Which Bluetooth HID channel is used to send output reports (LEDs/rumble).
+///     Control is the historical default; Interrupt is the PR 460 candidate.
+/// </summary>
+public enum BluetoothOutputReportTransport
+{
+    Control,
+    Interrupt
+}
+
 public enum PressureMode
 {
     Digital,

--- a/ControlApp/Models/DshmConfigManager/DshmTranslationUtils.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmTranslationUtils.cs
@@ -179,6 +179,7 @@ public class DshmManagerToDriverConversion
         OutputReportSettings x_OutRep = appFormat.OutputReport;
         driverFormat.IsOutputRateControlEnabled = x_OutRep.IsOutputReportRateControlEnabled;
         driverFormat.OutputRateControlPeriodMs = (byte)x_OutRep.MaxOutputRate;
+        driverFormat.BluetoothOutputReportTransport = x_OutRep.BluetoothOutputReportTransport;
 
         LeftMotorRescalingSettings x_LeftMRescale = appFormat.LeftMotorRescaling;
         DshmDeviceSettings.HeavyRescaleSettings dshmLeftRumbleRescaleSettings =
@@ -291,6 +292,11 @@ public class DshmManagerToDriverConversion
             appFormat.OutputReport.MaxOutputRate = rateMs;
         }
 
+        if (driverFormat.BluetoothOutputReportTransport is { } bluetoothTransport)
+        {
+            appFormat.OutputReport.BluetoothOutputReportTransport = bluetoothTransport;
+        }
+
         if (rumble.HeavyRescale.IsEnabled is { } heavyEnabled)
         {
             appFormat.LeftMotorRescaling.IsLeftMotorStrRescalingEnabled = heavyEnabled;
@@ -351,6 +357,8 @@ public class DshmManagerToDriverConversion
         merged.PairOnHotReload = overlay.PairOnHotReload ?? merged.PairOnHotReload;
         merged.CustomPairingAddress = overlay.CustomPairingAddress ?? merged.CustomPairingAddress;
         merged.UsbOutputReportTransport = overlay.UsbOutputReportTransport ?? merged.UsbOutputReportTransport;
+        merged.BluetoothOutputReportTransport =
+            overlay.BluetoothOutputReportTransport ?? merged.BluetoothOutputReportTransport;
         merged.DisableWirelessIdleTimeout = overlay.DisableWirelessIdleTimeout ?? merged.DisableWirelessIdleTimeout;
         merged.IsOutputRateControlEnabled = overlay.IsOutputRateControlEnabled ?? merged.IsOutputRateControlEnabled;
         merged.OutputRateControlPeriodMs = overlay.OutputRateControlPeriodMs ?? merged.OutputRateControlPeriodMs;
@@ -564,6 +572,7 @@ public class DshmManagerToDriverConversion
         clone.PairOnHotReload = source.PairOnHotReload;
         clone.CustomPairingAddress = source.CustomPairingAddress;
         clone.UsbOutputReportTransport = source.UsbOutputReportTransport;
+        clone.BluetoothOutputReportTransport = source.BluetoothOutputReportTransport;
         return clone;
     }
 

--- a/ControlApp/ViewModels/UserControls/DeviceSettings/OutputReportSettingsViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceSettings/OutputReportSettingsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
+using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.DshmConfig.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.Enums;
 
 namespace Nefarius.DsHidMini.ControlApp.ViewModels.UserControls.DeviceSettings;
@@ -38,6 +39,19 @@ public class OutputReportSettingsViewModel : DeviceSettingsViewModel
             OnPropertyChanged();
         }
     }
+
+    public BluetoothOutputReportTransport BluetoothOutputReportTransport
+    {
+        get => _tempBackingData.BluetoothOutputReportTransport;
+        set
+        {
+            _tempBackingData.BluetoothOutputReportTransport = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public static IReadOnlyList<BluetoothOutputReportTransport> BluetoothOutputReportTransports { get; } =
+        Enum.GetValues<BluetoothOutputReportTransport>();
 
     //public override void SaveSettingsToBackingDataContainer(BackingDataContainer dataContainerSource)
     //{

--- a/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
+++ b/ControlApp/Views/UserControls/DeviceSettingsEditor.xaml
@@ -642,6 +642,19 @@
                     Content="Enable output report deduplicator"
                     DockPanel.Dock="Top"
                     IsChecked="{Binding IsOutputReportDeduplicatorEnabled}" />
+                <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}">
+                    <ui:TextBlock
+                        Style="{StaticResource SettingsFieldLabel}"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        DockPanel.Dock="Left"
+                        Text="Bluetooth output channel:" />
+                    <ComboBox
+                        VerticalAlignment="Center"
+                        DockPanel.Dock="Right"
+                        ItemsSource="{Binding BluetoothOutputReportTransports}"
+                        SelectedItem="{Binding BluetoothOutputReportTransport}" />
+                </DockPanel>
             </DockPanel>
         </DataTemplate>
 

--- a/driver/Configuration.c
+++ b/driver/Configuration.c
@@ -80,6 +80,31 @@ static DS_USB_OUTPUT_REPORT_TRANSPORT DS_USB_OUTPUT_REPORT_TRANSPORT_FROM_NAME(_
 }
 
 //
+// Translates a friendly name string into the corresponding DS_BLUETOOTH_OUTPUT_REPORT_TRANSPORT value
+// 
+static DS_BLUETOOTH_OUTPUT_REPORT_TRANSPORT DS_BLUETOOTH_OUTPUT_REPORT_TRANSPORT_FROM_NAME(_In_ cJSON* pNode)
+{
+	if (!cJSON_IsString(pNode))
+	{
+		TraceWarning(
+			TRACE_CONFIG,
+			"BluetoothOutputReportTransport configuration value is not a string, ignoring and using Control"
+		);
+
+		return DsBluetoothOutputReportTransportControl;
+	}
+
+	const PSTR ModeName = cJSON_GetStringValue(pNode);
+
+	if (!_strcmpi(ModeName, G_BLUETOOTH_OUTPUT_REPORT_TRANSPORT_NAMES[1]))
+	{
+		return DsBluetoothOutputReportTransportInterrupt;
+	}
+
+	return DsBluetoothOutputReportTransportControl;
+}
+
+//
 // Translates a friendly name string into the corresponding DS_PRESSURE_EXPOSURE_MODE value
 // 
 static DS_PRESSURE_EXPOSURE_MODE DS_PRESSURE_EXPOSURE_MODE_FROM_NAME(_In_ const PSTR ModeName)
@@ -527,6 +552,12 @@ static void ConfigNodeParse(
 			pCfg->UsbOutputReportTransport = DS_USB_OUTPUT_REPORT_TRANSPORT_FROM_NAME(pNode);
 			EventWriteOverrideSettingUInt(ParentNode->string, "UsbOutputReportTransport", pCfg->UsbOutputReportTransport);
 		}
+	}
+
+	if ((pNode = cJSON_GetObjectItem(ParentNode, "BluetoothOutputReportTransport")))
+	{
+		pCfg->BluetoothOutputReportTransport = DS_BLUETOOTH_OUTPUT_REPORT_TRANSPORT_FROM_NAME(pNode);
+		EventWriteOverrideSettingUInt(ParentNode->string, "BluetoothOutputReportTransport", pCfg->BluetoothOutputReportTransport);
 	}
 
 	if ((pNode = cJSON_GetObjectItem(ParentNode, "DevicePairingMode")))
@@ -1037,6 +1068,7 @@ ConfigSetDefaults(
 	Config->PairOnHotReload = FALSE;
 	Config->AutoRestartOnHidModeMismatch = TRUE;
 	Config->UsbOutputReportTransport = DsUsbOutputReportTransportAuto;
+	Config->BluetoothOutputReportTransport = DsBluetoothOutputReportTransportControl;
 	for (int i = 0; i < 6; i++)
 	{
 		Config->CustomHostAddress[i] = 0x00;

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -31,7 +31,7 @@ const UCHAR G_Ds3UsbHidOutputReport[] = {
 // Default Output Report for LED & Rumble state changes (Bluetooth)
 // 
 const UCHAR G_Ds3BthHidOutputReport[] = {
-	0x52, /* HID BT Set_report (0x50) | Report Type (Output 0x02)*/
+	DS3_BTH_HID_OUTPUT_REPORT_CONTROL_PREFIX, /* HID BT Set_report (0x50) | Output (0x02); send path may override to 0xA2 */
 	0x01, /* Report ID */
 	0x00, 0xFF, 0x00, 0xFF, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00,

--- a/driver/Ds3.h
+++ b/driver/Ds3.h
@@ -11,6 +11,14 @@ extern const UCHAR G_Ds3BthHidOutputReport[];
 
 #define DS3_BTH_HID_OUTPUT_REPORT_SIZE		0x32
 
+//
+// Bluetooth HID transaction prefixes for the output-report template.
+// Control (SET_REPORT | Output) is the historical default; Interrupt
+// (DATA | Output) is applied at send time when configured (PR 460).
+// 
+#define DS3_BTH_HID_OUTPUT_REPORT_CONTROL_PREFIX	0x52
+#define DS3_BTH_HID_OUTPUT_REPORT_INTERRUPT_PREFIX	0xA2
+
 #define DS3_LED_1       0x02
 #define DS3_LED_2       0x04
 #define DS3_LED_3       0x08

--- a/driver/DsCommon.h
+++ b/driver/DsCommon.h
@@ -175,6 +175,33 @@ static CONST PSTR G_USB_OUTPUT_REPORT_TRANSPORT_NAMES[] =
 };
 
 //
+// Which Bluetooth HID channel is used to send output reports (LEDs/rumble).
+// Control is the historical default; Interrupt is the PR 460 candidate that
+// some pads need for wireless rumble. Selected at send time so it can change
+// on hot-reload without reinstalling.
+// 
+typedef enum
+{
+	//
+	// HID control channel, 0x52 (SET_REPORT | Output)
+	// 
+	DsBluetoothOutputReportTransportControl = 0,
+	//
+	// HID interrupt channel, 0xA2 (DATA | Output)
+	// 
+	DsBluetoothOutputReportTransportInterrupt
+} DS_BLUETOOTH_OUTPUT_REPORT_TRANSPORT, * PDS_BLUETOOTH_OUTPUT_REPORT_TRANSPORT;
+
+//
+// Friendly names for reading from JSON
+// 
+static CONST PSTR G_BLUETOOTH_OUTPUT_REPORT_TRANSPORT_NAMES[] =
+{
+	"Control",
+	"Interrupt"
+};
+
+//
 // Output report processing mode
 // 
 typedef enum
@@ -597,6 +624,12 @@ typedef struct _DS_DRIVER_CONFIGURATION
 	// altered at runtime; only evaluated once during PrepareHardware.
 	// 
 	DS_USB_OUTPUT_REPORT_TRANSPORT UsbOutputReportTransport;
+
+	//
+	// Which Bluetooth HID channel to use for output reports (LEDs/rumble).
+	// Applied at send time so a hot-reload can switch without reinstalling.
+	// 
+	DS_BLUETOOTH_OUTPUT_REPORT_TRANSPORT BluetoothOutputReportTransport;
 
 	//
 	// When set, the driver requests a self re-enumeration if the HID mode

--- a/driver/DsHidMini.json
+++ b/driver/DsHidMini.json
@@ -4,6 +4,7 @@
     "AutoRestartOnHidModeMismatch": true,
     "DevicePairingMode": "Auto",
     "PairOnHotReload": false,
+    "BluetoothOutputReportTransport": "Control",
     "IsOutputRateControlEnabled": true,
     "OutputRateControlPeriodMs": 150,
     "IsOutputDeduplicatorEnabled": false,

--- a/driver/OutputReport.c
+++ b/driver/OutputReport.c
@@ -3,6 +3,37 @@
 
 
 //
+// Selects the Bluetooth HID channel and matching report prefix immediately
+// before a send. Control (0x52 / CONTROL_WRITE) is the historical default;
+// Interrupt (0xA2 / INTERRUPT_WRITE) is the PR 460 rumble candidate.
+// The 0x53 Sixaxis init write stays on the control channel in Ds3.c.
+// 
+static
+VOID
+DSHM_BthPrepareOutputReport(
+	_In_ const PDEVICE_CONTEXT DeviceContext,
+	_Inout_updates_(BufferSize) PUCHAR Buffer,
+	_In_ size_t BufferSize,
+	_Out_ PULONG Ioctl
+)
+{
+	const BOOLEAN useInterrupt =
+		DeviceContext->Configuration.BluetoothOutputReportTransport ==
+		DsBluetoothOutputReportTransportInterrupt;
+
+	if (BufferSize > 0)
+	{
+		Buffer[0] = useInterrupt
+			? DS3_BTH_HID_OUTPUT_REPORT_INTERRUPT_PREFIX
+			: DS3_BTH_HID_OUTPUT_REPORT_CONTROL_PREFIX;
+	}
+
+	*Ioctl = useInterrupt
+		? IOCTL_BTHPS3_HID_INTERRUPT_WRITE
+		: IOCTL_BTHPS3_HID_CONTROL_WRITE;
+}
+
+//
 // Enqueues current output report buffer to get sent to device. Takes
 // Context->OutputReport.Lock; see DSHM_SendOutputReportUnlocked for callers
 // that already hold it.
@@ -301,17 +332,26 @@ DSHM_EvtExecuteOutputPacketReceived(
 			break;
 		}
 
-		status = DMF_DefaultTarget_SendSynchronously(
-			pDevCtx->Connection.Bth.HidControl.OutputWriterModule,
-			ClientWorkBuffer,
-			bufferSize,
-			NULL,
-			0,
-			ContinuousRequestTarget_RequestType_Ioctl,
-			IOCTL_BTHPS3_HID_CONTROL_WRITE,
-			0,
-			&bytesWritten
-		);
+			ULONG bthOutputIoctl = IOCTL_BTHPS3_HID_CONTROL_WRITE;
+
+			DSHM_BthPrepareOutputReport(
+				pDevCtx,
+				ClientWorkBuffer,
+				bufferSize,
+				&bthOutputIoctl
+			);
+
+			status = DMF_DefaultTarget_SendSynchronously(
+				pDevCtx->Connection.Bth.HidControl.OutputWriterModule,
+				ClientWorkBuffer,
+				bufferSize,
+				NULL,
+				0,
+				ContinuousRequestTarget_RequestType_Ioctl,
+				bthOutputIoctl,
+				0,
+				&bytesWritten
+			);
 
 		if (NT_SUCCESS(status))
 		{

--- a/research/bth-output-transport-matrix.md
+++ b/research/bth-output-transport-matrix.md
@@ -1,0 +1,69 @@
+# Bluetooth output transport hardware matrix
+
+Record control-transport baseline results, then repeat with interrupt transport.
+Keep `BluetoothOutputReportTransport` at `Control` as the shipped default until
+every exercised row is clean on both settings.
+
+## Automated verification (2026-09-08)
+
+- NUKE `Compile` succeeded on `fix/bth-output-transport` (DMF + driver + ControlApp).
+- `ControlApp.Tests`: 72 passed, including default `Control`, Interrupt round-trip,
+  legacy JSON without the key, and overlay/copy coverage.
+- GitHub x86/x64/ARM64 CI runs when this branch is pushed. Local NUKE does not
+  replace those platform legs.
+
+## Default decision
+
+Do **not** change the shipped default to Interrupt until this matrix is clean.
+Control remains the default so established pads keep today's Bluetooth behavior.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| DsHidMini build | |
+| BthPS3 version | |
+| Adapter | |
+| Windows | |
+| Date | |
+
+## Cases
+
+For each controller: set HID mode, connect, run the case on **Control**, then
+hot-reload to **Interrupt** and repeat. Switching back to Control must restore
+the baseline without reinstalling the driver.
+
+| Controller (model/rev) | Connection | HID mode | Transport | Rumble both motors | Finite / sustain / stop | LEDs / authority | Rate-limit / keep-alive | Reconnect / USB-BT / sleep | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| | USB | XInput | n/a | | | | | | |
+| | Bluetooth | XInput | Control | | | | | | |
+| | Bluetooth | XInput | Interrupt | | | | | | |
+| | Bluetooth | DS4Windows | Control | | | | | | |
+| | Bluetooth | DS4Windows | Interrupt | | | | | | |
+| | Bluetooth | SXS | Control | | | | | | |
+| | Bluetooth | SXS | Interrupt | | | | | | |
+| | Bluetooth | SDF | Control | | | | | | |
+| | Bluetooth | SDF | Interrupt | | | | | | |
+| | Bluetooth | GPJ | Control | | | | | | |
+| | Bluetooth | GPJ | Interrupt | | | | | | |
+
+Include at least: multiple genuine DS3/SIXAXIS revisions, a Navigation
+controller, and one third-party clone. Devices without rumble still need
+unchanged LEDs, input, and connection behavior.
+
+## Stress
+
+- Rapid rumble on/off and LED changes around the 150 ms rate limit
+- Deduplication / keep-alive while rumble is held
+- Disconnect while rumbling
+- Capture driver traces and, when available, Bluetooth traffic showing
+  `0x52` + `IOCTL_BTHPS3_HID_CONTROL_WRITE` or `0xA2` +
+  `IOCTL_BTHPS3_HID_INTERRUPT_WRITE`
+
+## Acceptance
+
+- Interrupt must fix the affected pad(s) and not regress the per-device
+  Control baseline.
+- Reverting to Control must restore established behavior without reinstalling.
+- Changing the default from Control to Interrupt is a separate review after
+  this matrix is clean.


### PR DESCRIPTION
… changing the default.

Control stays the shipped channel; Interrupt (PR 460) is selected at send time and can hot-reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Bluetooth output-report transport setting with **Control** and **Interrupt** options.
  - Added a selector in device output settings to choose the preferred transport.
  - Changes apply dynamically when configuration is reloaded, without reinstalling.

- **Bug Fixes**
  - Preserved the selected transport across saving, loading, copying, and overlay settings.
  - Existing configurations without this setting continue using **Control** by default.

- **Documentation**
  - Added a hardware validation matrix covering both transport options and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->