### PR TITLE
Add a once-per-day ControlApp update prompt so users can download new…

### DIFF
--- a/ControlApp.Tests/ApplicationConfigurationAndTrayPolicyTests.cs
+++ b/ControlApp.Tests/ApplicationConfigurationAndTrayPolicyTests.cs
@@ -27,6 +27,7 @@ public class ApplicationConfigurationAndTrayPolicyTests
         Assert.True(loaded.MinimizeToTray);
         Assert.True(loaded.IsLoggingEnabled);
         Assert.False(loaded.IsUpdateCheckEnabled);
+        Assert.Null(loaded.LastUpdateCheckDate);
     }
 
     [Fact]
@@ -35,6 +36,26 @@ public class ApplicationConfigurationAndTrayPolicyTests
         ApplicationConfiguration config = new();
 
         Assert.False(config.MinimizeToTray);
+        Assert.True(config.IsUpdateCheckEnabled);
+        Assert.Null(config.LastUpdateCheckDate);
+    }
+
+    [Fact]
+    public void ApplicationConfiguration_JsonRoundTrip_PreservesLastUpdateCheckDate()
+    {
+        DateOnly checkedOn = new(2026, 9, 8);
+        ApplicationConfiguration original = new()
+        {
+            IsUpdateCheckEnabled = true,
+            LastUpdateCheckDate = checkedOn
+        };
+
+        string json = JsonConvert.SerializeObject(original);
+        ApplicationConfiguration? loaded = JsonConvert.DeserializeObject<ApplicationConfiguration>(json);
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded.IsUpdateCheckEnabled);
+        Assert.Equal(checkedOn, loaded.LastUpdateCheckDate);
     }
 
     [Fact]

--- a/ControlApp.Tests/HttpRetryPolicyTests.cs
+++ b/ControlApp.Tests/HttpRetryPolicyTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http;
+
+using Nefarius.DsHidMini.ControlApp.Models;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class HttpRetryPolicyTests
+{
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public void ShouldRetry_TemporaryHttpStatusCodes(HttpStatusCode statusCode)
+    {
+        Assert.True(HttpRetryPolicy.ShouldRetry(statusCode, null));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.OK)]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public void ShouldRetry_IgnoresSuccessfulAndNonTransientClientErrors(HttpStatusCode statusCode)
+    {
+        Assert.False(HttpRetryPolicy.ShouldRetry(statusCode, null));
+    }
+
+    [Fact]
+    public void ShouldRetry_HttpRequestException()
+    {
+        Assert.True(HttpRetryPolicy.ShouldRetry(null, new HttpRequestException("temporary failure")));
+    }
+
+    [Fact]
+    public void ShouldRetry_NoErrorDoesNotRetry()
+    {
+        Assert.False(HttpRetryPolicy.ShouldRetry(null, null));
+    }
+}

--- a/ControlApp.Tests/UpdateCheckPolicyTests.cs
+++ b/ControlApp.Tests/UpdateCheckPolicyTests.cs
@@ -46,6 +46,23 @@ public class UpdateCheckPolicyTests
     }
 
     [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    public void ShouldReuseInFlightCheck_ManualDoesNotReuseGatedCheck(
+        bool requestIgnoresLastCheckDate,
+        bool inFlightIgnoresLastCheckDate,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            UpdateCheckPolicy.ShouldReuseInFlightCheck(
+                requestIgnoresLastCheckDate,
+                inFlightIgnoresLastCheckDate));
+    }
+
+    [Theory]
     [InlineData("3.4.2131.0", "3.0.0.0", true)]
     [InlineData("3.4.2131.0", "3.4.2131.0", false)]
     [InlineData("3.0.0.0", "3.4.2131.0", false)]

--- a/ControlApp.Tests/UpdateCheckPolicyTests.cs
+++ b/ControlApp.Tests/UpdateCheckPolicyTests.cs
@@ -28,6 +28,24 @@ public class UpdateCheckPolicyTests
     }
 
     [Theory]
+    [InlineData(false, "2026-09-08", "2026-09-08")]
+    [InlineData(true, "2026-09-08", "2026-09-08")]
+    public void ShouldPerformNetworkCheck_ManualIgnoresEnablementAndLastCheckDate(
+        bool isEnabled,
+        string todayText,
+        string lastCheckText)
+    {
+        DateOnly today = DateOnly.Parse(todayText);
+        DateOnly lastCheck = DateOnly.Parse(lastCheckText);
+
+        Assert.True(UpdateCheckPolicy.ShouldPerformNetworkCheck(
+            isEnabled,
+            today,
+            lastCheck,
+            ignoreLastCheckDate: true));
+    }
+
+    [Theory]
     [InlineData("3.4.2131.0", "3.0.0.0", true)]
     [InlineData("3.4.2131.0", "3.4.2131.0", false)]
     [InlineData("3.0.0.0", "3.4.2131.0", false)]

--- a/ControlApp.Tests/UpdateCheckPolicyTests.cs
+++ b/ControlApp.Tests/UpdateCheckPolicyTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+
+using Nefarius.DsHidMini.ControlApp.Models;
+using Nefarius.DsHidMini.ControlApp.Models.Util.Web;
+using Nefarius.DsHidMini.ControlApp.Services;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class UpdateCheckPolicyTests
+{
+    [Theory]
+    [InlineData(false, "2026-09-08", null, false)]
+    [InlineData(true, "2026-09-08", null, true)]
+    [InlineData(true, "2026-09-08", "2026-09-08", false)]
+    [InlineData(true, "2026-09-09", "2026-09-08", true)]
+    public void ShouldPerformNetworkCheck_RespectsEnablementAndLocalCalendarDay(
+        bool isEnabled,
+        string todayText,
+        string? lastCheckText,
+        bool expected)
+    {
+        DateOnly today = DateOnly.Parse(todayText);
+        DateOnly? lastCheck = lastCheckText is null ? null : DateOnly.Parse(lastCheckText);
+
+        Assert.Equal(expected, UpdateCheckPolicy.ShouldPerformNetworkCheck(isEnabled, today, lastCheck));
+    }
+
+    [Theory]
+    [InlineData("3.4.2131.0", "3.0.0.0", true)]
+    [InlineData("3.4.2131.0", "3.4.2131.0", false)]
+    [InlineData("3.0.0.0", "3.4.2131.0", false)]
+    public void IsRemoteNewer_ComparesParsedFileVersions(string remoteText, string localText, bool expected)
+    {
+        Assert.True(UpdateCheckPolicy.TryParseFileVersion(remoteText, out Version? remote));
+        Assert.True(UpdateCheckPolicy.TryParseFileVersion(localText, out Version? local));
+        Assert.NotNull(remote);
+        Assert.NotNull(local);
+
+        Assert.Equal(expected, UpdateCheckPolicy.IsRemoteNewer(remote, local));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("v3.4.2131.0")]
+    [InlineData("3.4.2131.0+f4a6a3ca02d16f45d861ffa808ae23919f14592b")]
+    public void TryParseFileVersion_RejectsMissingAndMalformedValues(string? value)
+    {
+        Assert.False(UpdateCheckPolicy.TryParseFileVersion(value, out Version? version));
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public void ArtifactMetaData_DeserializesBuildbotFileVersionPayload()
+    {
+        const string json =
+            """{"FileVersion":"3.4.2131.0","ProductVersion":"3.4.2131.0\u002Bf4a6a3ca02d16f45d861ffa808ae23919f14592b"}""";
+
+        ArtifactMetaData? metadata = JsonSerializer.Deserialize<ArtifactMetaData>(json);
+
+        Assert.NotNull(metadata);
+        Assert.Equal("3.4.2131.0", metadata.FileVersion);
+        Assert.Equal("3.4.2131.0+f4a6a3ca02d16f45d861ffa808ae23919f14592b", metadata.ProductVersion);
+        Assert.True(UpdateCheckPolicy.TryParseFileVersion(metadata.FileVersion, out Version? version));
+        Assert.Equal(new Version(3, 4, 2131, 0), version);
+    }
+
+    [Fact]
+    public void TryGetLocalFileVersion_RejectsMissingProcessPath()
+    {
+        Assert.False(ControlAppUpdateService.TryGetLocalFileVersion(null, out Version? version));
+        Assert.Null(version);
+    }
+}

--- a/ControlApp/App.xaml.cs
+++ b/ControlApp/App.xaml.cs
@@ -113,13 +113,13 @@ public partial class App
             {
                 client.BaseAddress = new Uri("https://buildbot.nefarius.at/");
                 client.DefaultRequestHeaders.UserAgent.ParseAdd(context.HostingEnvironment.ApplicationName);
-            });
+            }).AddCommonRetryPolicy();
 
             services.AddHttpClient("Docs", client =>
             {
                 client.BaseAddress = new Uri("https://docs.nefarius.at/");
                 client.DefaultRequestHeaders.UserAgent.ParseAdd(context.HostingEnvironment.ApplicationName);
-            });
+            }).AddCommonRetryPolicy();
         }).Build();
 
     /// <summary>

--- a/ControlApp/App.xaml.cs
+++ b/ControlApp/App.xaml.cs
@@ -96,6 +96,7 @@ public partial class App
             services.AddSingleton<Main>();
 
             services.AddSingleton<AddressValidator>();
+            services.AddSingleton<ControlAppUpdateService>();
 
             Log.Logger = new LoggerConfiguration()
 #if DEBUG

--- a/ControlApp/ControlApp.csproj
+++ b/ControlApp/ControlApp.csproj
@@ -29,6 +29,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.272">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ControlApp/Models/ApplicationConfiguration.cs
+++ b/ControlApp/Models/ApplicationConfiguration.cs
@@ -30,6 +30,12 @@ public class ApplicationConfiguration
     public bool IsUpdateCheckEnabled { get; set; } = true;
 
     /// <summary>
+    ///     Local calendar date of the last startup update check attempt (success or failure).
+    ///     Used so Download and Skip both suppress another check until the next local day.
+    /// </summary>
+    public DateOnly? LastUpdateCheckDate { get; set; }
+
+    /// <summary>
     ///     If true, downloads genuine OUI list and compares controller MAC against.
     /// </summary>
     public bool IsGenuineCheckEnabled { get; set; } = true;

--- a/ControlApp/Models/HttpRetryPolicy.cs
+++ b/ControlApp/Models/HttpRetryPolicy.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Net.Http;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+
+using Polly;
+
+namespace Nefarius.DsHidMini.ControlApp.Models;
+
+/// <summary>
+///     Shared retry rules for ControlApp HTTP clients. Covers typical transient
+///     failures and 404, which Buildbot can return briefly for the latest JSON.
+/// </summary>
+internal static class HttpRetryPolicy
+{
+    public static IHttpClientBuilder AddCommonRetryPolicy(this IHttpClientBuilder builder)
+    {
+        builder.AddResilienceHandler("common-retry", pipeline =>
+        {
+            pipeline.AddRetry(CreateOptions());
+        });
+
+        return builder;
+    }
+
+    public static HttpRetryStrategyOptions CreateOptions()
+    {
+        return new HttpRetryStrategyOptions
+        {
+            ShouldHandle = args => ValueTask.FromResult(
+                ShouldRetry(args.Outcome.Result?.StatusCode, args.Outcome.Exception))
+        };
+    }
+
+    public static bool ShouldRetry(HttpStatusCode? statusCode, Exception? exception)
+    {
+        if (exception is HttpRequestException)
+        {
+            return true;
+        }
+
+        return statusCode is HttpStatusCode.NotFound
+            or HttpStatusCode.RequestTimeout
+            or HttpStatusCode.TooManyRequests
+            or >= HttpStatusCode.InternalServerError;
+    }
+}

--- a/ControlApp/Models/UpdateCheckPolicy.cs
+++ b/ControlApp/Models/UpdateCheckPolicy.cs
@@ -20,6 +20,13 @@ internal static class UpdateCheckPolicy
         return isUpdateCheckEnabled && lastUpdateCheckDate != today;
     }
 
+    public static bool ShouldReuseInFlightCheck(
+        bool requestIgnoresLastCheckDate,
+        bool inFlightIgnoresLastCheckDate)
+    {
+        return !requestIgnoresLastCheckDate || inFlightIgnoresLastCheckDate;
+    }
+
     public static bool TryParseFileVersion(string? value, out Version? version)
     {
         if (!string.IsNullOrWhiteSpace(value) && Version.TryParse(value.Trim(), out Version parsed))

--- a/ControlApp/Models/UpdateCheckPolicy.cs
+++ b/ControlApp/Models/UpdateCheckPolicy.cs
@@ -9,8 +9,14 @@ internal static class UpdateCheckPolicy
     public static bool ShouldPerformNetworkCheck(
         bool isUpdateCheckEnabled,
         DateOnly today,
-        DateOnly? lastUpdateCheckDate)
+        DateOnly? lastUpdateCheckDate,
+        bool ignoreLastCheckDate = false)
     {
+        if (ignoreLastCheckDate)
+        {
+            return true;
+        }
+
         return isUpdateCheckEnabled && lastUpdateCheckDate != today;
     }
 

--- a/ControlApp/Models/UpdateCheckPolicy.cs
+++ b/ControlApp/Models/UpdateCheckPolicy.cs
@@ -1,0 +1,33 @@
+namespace Nefarius.DsHidMini.ControlApp.Models;
+
+/// <summary>
+///     Pure rules for the ControlApp startup update check. Kept separate so daily
+///     gating and version comparison can be unit-tested without HTTP or WPF.
+/// </summary>
+internal static class UpdateCheckPolicy
+{
+    public static bool ShouldPerformNetworkCheck(
+        bool isUpdateCheckEnabled,
+        DateOnly today,
+        DateOnly? lastUpdateCheckDate)
+    {
+        return isUpdateCheckEnabled && lastUpdateCheckDate != today;
+    }
+
+    public static bool TryParseFileVersion(string? value, out Version? version)
+    {
+        if (!string.IsNullOrWhiteSpace(value) && Version.TryParse(value.Trim(), out Version parsed))
+        {
+            version = parsed;
+            return true;
+        }
+
+        version = null;
+        return false;
+    }
+
+    public static bool IsRemoteNewer(Version remote, Version local)
+    {
+        return remote.CompareTo(local) > 0;
+    }
+}

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -101,6 +101,28 @@ public class AppSnackbarMessagesService
         );
     }
 
+    public void ShowControlAppUpToDateMessage()
+    {
+        _snackbarService.Show(
+            "ControlApp is up to date",
+            "No newer version is available on Buildbot.",
+            ControlAppearance.Success,
+            new SymbolIcon(SymbolRegular.CheckmarkCircle24),
+            TimeSpan.FromSeconds(3)
+        );
+    }
+
+    public void ShowControlAppUpdateCheckFailedMessage()
+    {
+        _snackbarService.Show(
+            "Update check failed",
+            "Could not reach Buildbot or read the latest version. Try again later.",
+            ControlAppearance.Caution,
+            new SymbolIcon(SymbolRegular.ErrorCircle24),
+            TimeSpan.FromSeconds(5)
+        );
+    }
+
     public void ShowBthPS3SettingsRectifyFailedMessage()
     {
         _snackbarService.Show(

--- a/ControlApp/Services/ControlAppUpdateService.cs
+++ b/ControlApp/Services/ControlAppUpdateService.cs
@@ -14,6 +14,14 @@ using Wpf.Ui.Extensions;
 
 namespace Nefarius.DsHidMini.ControlApp.Services;
 
+internal enum UpdateCheckOutcome
+{
+    Skipped,
+    UpToDate,
+    UpdateAvailable,
+    Failed
+}
+
 /// <summary>
 ///     Checks Buildbot for a newer ControlApp once per local calendar day and offers a download.
 /// </summary>
@@ -25,7 +33,17 @@ public sealed class ControlAppUpdateService(
     public const string MetadataRelativePath = "builds/DsHidMini/latest/bin/.ControlApp.exe.json";
     public const string DownloadUrl = "https://buildbot.nefarius.at/builds/DsHidMini/latest/bin/ControlApp.exe";
 
-    public async Task CheckOnStartupAsync(CancellationToken cancellationToken = default)
+    public Task CheckOnStartupAsync(CancellationToken cancellationToken = default)
+    {
+        return CheckAsync(ignoreLastCheckDate: false, cancellationToken);
+    }
+
+    internal Task<UpdateCheckOutcome> CheckNowAsync(CancellationToken cancellationToken = default)
+    {
+        return CheckAsync(ignoreLastCheckDate: true, cancellationToken);
+    }
+
+    private async Task<UpdateCheckOutcome> CheckAsync(bool ignoreLastCheckDate, CancellationToken cancellationToken)
     {
         DateOnly today = DateOnly.FromDateTime(DateTime.Now);
         ApplicationConfiguration config = ApplicationConfiguration.Instance;
@@ -33,9 +51,10 @@ public sealed class ControlAppUpdateService(
         if (!UpdateCheckPolicy.ShouldPerformNetworkCheck(
                 config.IsUpdateCheckEnabled,
                 today,
-                config.LastUpdateCheckDate))
+                config.LastUpdateCheckDate,
+                ignoreLastCheckDate))
         {
-            return;
+            return UpdateCheckOutcome.Skipped;
         }
 
         TryRecordCheckDate(config, today);
@@ -51,32 +70,33 @@ public sealed class ControlAppUpdateService(
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
         {
             logger?.LogWarning(ex, "ControlApp update check failed.");
-            return;
+            return UpdateCheckOutcome.Failed;
         }
         catch (Exception ex)
         {
             logger?.LogWarning(ex, "ControlApp update check failed unexpectedly.");
-            return;
+            return UpdateCheckOutcome.Failed;
         }
 
         if (metadata is null ||
             !UpdateCheckPolicy.TryParseFileVersion(metadata.FileVersion, out Version? remote) ||
             remote is null)
         {
-            return;
+            return UpdateCheckOutcome.Failed;
         }
 
         if (!TryGetLocalFileVersion(out Version? local) || local is null)
         {
-            return;
+            return UpdateCheckOutcome.Failed;
         }
 
         if (!UpdateCheckPolicy.IsRemoteNewer(remote, local))
         {
-            return;
+            return UpdateCheckOutcome.UpToDate;
         }
 
         await ShowUpdateDialogAsync(remote, local).ConfigureAwait(false);
+        return UpdateCheckOutcome.UpdateAvailable;
     }
 
     private static void TryRecordCheckDate(ApplicationConfiguration config, DateOnly today)

--- a/ControlApp/Services/ControlAppUpdateService.cs
+++ b/ControlApp/Services/ControlAppUpdateService.cs
@@ -33,14 +33,57 @@ public sealed class ControlAppUpdateService(
     public const string MetadataRelativePath = "builds/DsHidMini/latest/bin/.ControlApp.exe.json";
     public const string DownloadUrl = "https://buildbot.nefarius.at/builds/DsHidMini/latest/bin/ControlApp.exe";
 
+    private Task<UpdateCheckOutcome>? _inFlightCheck;
+
     public Task CheckOnStartupAsync(CancellationToken cancellationToken = default)
     {
-        return CheckAsync(ignoreLastCheckDate: false, cancellationToken);
+        return RunExclusiveAsync(ignoreLastCheckDate: false, cancellationToken);
     }
 
     internal Task<UpdateCheckOutcome> CheckNowAsync(CancellationToken cancellationToken = default)
     {
-        return CheckAsync(ignoreLastCheckDate: true, cancellationToken);
+        return RunExclusiveAsync(ignoreLastCheckDate: true, cancellationToken);
+    }
+
+    private async Task<UpdateCheckOutcome> RunExclusiveAsync(
+        bool ignoreLastCheckDate,
+        CancellationToken cancellationToken)
+    {
+        Task<UpdateCheckOutcome>? existing = Volatile.Read(ref _inFlightCheck);
+        if (existing is not null)
+        {
+            return await existing.ConfigureAwait(false);
+        }
+
+        TaskCompletionSource<UpdateCheckOutcome> completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<UpdateCheckOutcome>? raced =
+            Interlocked.CompareExchange(ref _inFlightCheck, completion.Task, null);
+        if (raced is not null)
+        {
+            return await raced.ConfigureAwait(false);
+        }
+
+        try
+        {
+            UpdateCheckOutcome outcome = await CheckAsync(ignoreLastCheckDate, cancellationToken)
+                .ConfigureAwait(false);
+            completion.SetResult(outcome);
+            return outcome;
+        }
+        catch (Exception ex)
+        {
+            completion.SetException(ex);
+            throw;
+        }
+        finally
+        {
+            Task<UpdateCheckOutcome>? completed = Interlocked.CompareExchange(
+                ref _inFlightCheck,
+                null,
+                completion.Task);
+            _ = completed;
+        }
     }
 
     private async Task<UpdateCheckOutcome> CheckAsync(bool ignoreLastCheckDate, CancellationToken cancellationToken)
@@ -56,8 +99,6 @@ public sealed class ControlAppUpdateService(
         {
             return UpdateCheckOutcome.Skipped;
         }
-
-        TryRecordCheckDate(config, today);
 
         ArtifactMetaData? metadata;
         try
@@ -89,6 +130,8 @@ public sealed class ControlAppUpdateService(
         {
             return UpdateCheckOutcome.Failed;
         }
+
+        TryRecordCheckDate(config, today);
 
         if (!UpdateCheckPolicy.IsRemoteNewer(remote, local))
         {

--- a/ControlApp/Services/ControlAppUpdateService.cs
+++ b/ControlApp/Services/ControlAppUpdateService.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using Microsoft.Extensions.Logging;
+
+using Nefarius.DsHidMini.ControlApp.Models;
+using Nefarius.DsHidMini.ControlApp.Models.Util.Web;
+
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+using Wpf.Ui.Extensions;
+
+namespace Nefarius.DsHidMini.ControlApp.Services;
+
+/// <summary>
+///     Checks Buildbot for a newer ControlApp once per local calendar day and offers a download.
+/// </summary>
+public sealed class ControlAppUpdateService(
+    IHttpClientFactory httpClientFactory,
+    IContentDialogService contentDialogService,
+    ILogger<ControlAppUpdateService>? logger = null)
+{
+    public const string MetadataRelativePath = "builds/DsHidMini/latest/bin/.ControlApp.exe.json";
+    public const string DownloadUrl = "https://buildbot.nefarius.at/builds/DsHidMini/latest/bin/ControlApp.exe";
+
+    public async Task CheckOnStartupAsync(CancellationToken cancellationToken = default)
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.Now);
+        ApplicationConfiguration config = ApplicationConfiguration.Instance;
+
+        if (!UpdateCheckPolicy.ShouldPerformNetworkCheck(
+                config.IsUpdateCheckEnabled,
+                today,
+                config.LastUpdateCheckDate))
+        {
+            return;
+        }
+
+        TryRecordCheckDate(config, today);
+
+        ArtifactMetaData? metadata;
+        try
+        {
+            HttpClient client = httpClientFactory.CreateClient("Buildbot");
+            metadata = await client.GetFromJsonAsync<ArtifactMetaData>(
+                MetadataRelativePath,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            logger?.LogWarning(ex, "ControlApp update check failed.");
+            return;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "ControlApp update check failed unexpectedly.");
+            return;
+        }
+
+        if (metadata is null ||
+            !UpdateCheckPolicy.TryParseFileVersion(metadata.FileVersion, out Version? remote) ||
+            remote is null)
+        {
+            return;
+        }
+
+        if (!TryGetLocalFileVersion(out Version? local) || local is null)
+        {
+            return;
+        }
+
+        if (!UpdateCheckPolicy.IsRemoteNewer(remote, local))
+        {
+            return;
+        }
+
+        await ShowUpdateDialogAsync(remote, local).ConfigureAwait(false);
+    }
+
+    private static void TryRecordCheckDate(ApplicationConfiguration config, DateOnly today)
+    {
+        try
+        {
+            config.LastUpdateCheckDate = today;
+            config.Save();
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to persist LastUpdateCheckDate.");
+        }
+    }
+
+    internal static bool TryGetLocalFileVersion(string? processPath, out Version? version)
+    {
+        version = null;
+
+        if (string.IsNullOrWhiteSpace(processPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            FileVersionInfo info = FileVersionInfo.GetVersionInfo(processPath);
+            return UpdateCheckPolicy.TryParseFileVersion(info.FileVersion, out version);
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to read local ControlApp file version from {Path}.", processPath);
+            return false;
+        }
+    }
+
+    private bool TryGetLocalFileVersion(out Version? version)
+    {
+        return TryGetLocalFileVersion(Environment.ProcessPath, out version);
+    }
+
+    private async Task ShowUpdateDialogAsync(Version remote, Version local)
+    {
+        Application? application = Application.Current;
+        if (application is null)
+        {
+            return;
+        }
+
+        if (!application.Dispatcher.CheckAccess())
+        {
+            await application.Dispatcher.InvokeAsync(() => ShowUpdateDialogAsync(remote, local)).Task.Unwrap();
+            return;
+        }
+
+        ContentDialogResult result = await contentDialogService.ShowSimpleDialogAsync(
+            new SimpleContentDialogCreateOptions
+            {
+                Title = "Update available",
+                Content = $"A newer ControlApp ({remote}) is available. You are running {local}.",
+                PrimaryButtonText = "Download",
+                CloseButtonText = "Skip"
+            });
+
+        if (result == ContentDialogResult.Primary)
+        {
+            OpenDownload();
+        }
+    }
+
+    internal static void OpenDownload()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(DownloadUrl) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to open ControlApp download URL.");
+        }
+    }
+}

--- a/ControlApp/Services/ControlAppUpdateService.cs
+++ b/ControlApp/Services/ControlAppUpdateService.cs
@@ -33,7 +33,7 @@ public sealed class ControlAppUpdateService(
     public const string MetadataRelativePath = "builds/DsHidMini/latest/bin/.ControlApp.exe.json";
     public const string DownloadUrl = "https://buildbot.nefarius.at/builds/DsHidMini/latest/bin/ControlApp.exe";
 
-    private Task<UpdateCheckOutcome>? _inFlightCheck;
+    private InFlightUpdateCheck? _inFlightCheck;
 
     public Task CheckOnStartupAsync(CancellationToken cancellationToken = default)
     {
@@ -49,40 +49,58 @@ public sealed class ControlAppUpdateService(
         bool ignoreLastCheckDate,
         CancellationToken cancellationToken)
     {
-        Task<UpdateCheckOutcome>? existing = Volatile.Read(ref _inFlightCheck);
-        if (existing is not null)
+        while (true)
         {
-            return await existing.ConfigureAwait(false);
-        }
+            InFlightUpdateCheck? existing = Volatile.Read(ref _inFlightCheck);
+            if (existing is not null)
+            {
+                UpdateCheckOutcome existingOutcome = await existing.Task.ConfigureAwait(false);
+                if (UpdateCheckPolicy.ShouldReuseInFlightCheck(
+                        ignoreLastCheckDate,
+                        existing.IgnoreLastCheckDate))
+                {
+                    return existingOutcome;
+                }
 
-        TaskCompletionSource<UpdateCheckOutcome> completion =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-        Task<UpdateCheckOutcome>? raced =
-            Interlocked.CompareExchange(ref _inFlightCheck, completion.Task, null);
-        if (raced is not null)
-        {
-            return await raced.ConfigureAwait(false);
-        }
+                continue;
+            }
 
-        try
-        {
-            UpdateCheckOutcome outcome = await CheckAsync(ignoreLastCheckDate, cancellationToken)
-                .ConfigureAwait(false);
-            completion.SetResult(outcome);
-            return outcome;
-        }
-        catch (Exception ex)
-        {
-            completion.SetException(ex);
-            throw;
-        }
-        finally
-        {
-            Task<UpdateCheckOutcome>? completed = Interlocked.CompareExchange(
-                ref _inFlightCheck,
-                null,
-                completion.Task);
-            _ = completed;
+            TaskCompletionSource<UpdateCheckOutcome> completion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            InFlightUpdateCheck candidate = new(completion.Task, ignoreLastCheckDate);
+            InFlightUpdateCheck? raced =
+                Interlocked.CompareExchange(ref _inFlightCheck, candidate, null);
+            if (raced is not null)
+            {
+                UpdateCheckOutcome racedOutcome = await raced.Task.ConfigureAwait(false);
+                if (UpdateCheckPolicy.ShouldReuseInFlightCheck(
+                        ignoreLastCheckDate,
+                        raced.IgnoreLastCheckDate))
+                {
+                    return racedOutcome;
+                }
+
+                continue;
+            }
+
+            try
+            {
+                UpdateCheckOutcome outcome = await CheckAsync(ignoreLastCheckDate, cancellationToken)
+                    .ConfigureAwait(false);
+                completion.SetResult(outcome);
+                return outcome;
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+                throw;
+            }
+            finally
+            {
+                InFlightUpdateCheck? completed =
+                    Interlocked.CompareExchange(ref _inFlightCheck, null, candidate);
+                _ = completed;
+            }
         }
     }
 
@@ -221,4 +239,8 @@ public sealed class ControlAppUpdateService(
             Log.Logger.Warning(ex, "Failed to open ControlApp download URL.");
         }
     }
+
+    private sealed record InFlightUpdateCheck(
+        Task<UpdateCheckOutcome> Task,
+        bool IgnoreLastCheckDate);
 }

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -12,6 +12,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 {
     private readonly AppSnackbarMessagesService _appSnackbarMessagesService;
     private readonly DshmConfigManager _dshmConfigManager;
+    private readonly ControlAppUpdateService _updateService;
 
     [ObservableProperty]
     private string _appVersion = string.Empty;
@@ -21,14 +22,20 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     private bool _isInitialized;
 
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CheckForUpdatesCommand))]
+    private bool _isCheckingForUpdates;
+
     public SettingsViewModel(
         DshmConfigManager dshmConfigManager,
         BthPS3StatusService bthPs3,
-        AppSnackbarMessagesService appSnackbarMessagesService)
+        AppSnackbarMessagesService appSnackbarMessagesService,
+        ControlAppUpdateService updateService)
     {
         _dshmConfigManager = dshmConfigManager;
         BthPs3 = bthPs3;
         _appSnackbarMessagesService = appSnackbarMessagesService;
+        _updateService = updateService;
     }
 
     public BthPS3StatusService BthPs3 { get; }
@@ -166,6 +173,39 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
                 break;
         }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCheckForUpdates))]
+    private async Task CheckForUpdates()
+    {
+        IsCheckingForUpdates = true;
+        try
+        {
+            UpdateCheckOutcome outcome = await _updateService.CheckNowAsync();
+            switch (outcome)
+            {
+                case UpdateCheckOutcome.UpToDate:
+                    _appSnackbarMessagesService.ShowControlAppUpToDateMessage();
+                    break;
+                case UpdateCheckOutcome.Failed:
+                    _appSnackbarMessagesService.ShowControlAppUpdateCheckFailedMessage();
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Manual ControlApp update check failed.");
+            _appSnackbarMessagesService.ShowControlAppUpdateCheckFailedMessage();
+        }
+        finally
+        {
+            IsCheckingForUpdates = false;
+        }
+    }
+
+    private bool CanCheckForUpdates()
+    {
+        return !IsCheckingForUpdates;
     }
 
     [RelayCommand]

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -100,6 +100,17 @@
             <ui:TextBlock
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                 Text="{Binding ViewModel.AppVersion}" />
+            <ui:Button
+                Margin="0,12,0,0"
+                HorizontalAlignment="Left"
+                Command="{Binding ViewModel.CheckForUpdatesCommand}"
+                Content="Check for updates" />
+            <TextBlock
+                MaxWidth="600"
+                Margin="0,8,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="Looks for a newer ControlApp on Buildbot, even if you already skipped an update today."
+                TextWrapping="Wrap" />
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/ControlApp/Views/Windows/MainWindow.xaml.cs
+++ b/ControlApp/Views/Windows/MainWindow.xaml.cs
@@ -16,6 +16,8 @@ public partial class MainWindow : INavigationWindow
 {
     private readonly DshmDevMan _dshmDevMan;
     private readonly DefenderBtStatusService _defenderBtStatusService;
+    private readonly ControlAppUpdateService _updateService;
+    private bool _updateCheckStarted;
 
     public MainWindow(
         MainWindowViewModel viewModel,
@@ -24,7 +26,8 @@ public partial class MainWindow : INavigationWindow
         INavigationService navigationService,
         IServiceProvider serviceProvider,
         ISnackbarService snackbarService,
-        IContentDialogService contentDialogService
+        IContentDialogService contentDialogService,
+        ControlAppUpdateService updateService
     )
     {
         ViewModel = viewModel;
@@ -32,6 +35,7 @@ public partial class MainWindow : INavigationWindow
 
         _dshmDevMan = dshmDevMan;
         _defenderBtStatusService = defenderBtStatusService;
+        _updateService = updateService;
 
         SystemThemeWatcher.Watch(this);
 
@@ -74,6 +78,31 @@ public partial class MainWindow : INavigationWindow
         _dshmDevMan.StartListeningForDshmDevices();
         _defenderBtStatusService.StartListening();
         ApplyMinimizeToTraySetting();
+    }
+
+    protected override void OnContentRendered(EventArgs e)
+    {
+        base.OnContentRendered(e);
+
+        if (_updateCheckStarted)
+        {
+            return;
+        }
+
+        _updateCheckStarted = true;
+        _ = CheckForUpdatesAsync();
+    }
+
+    private async Task CheckForUpdatesAsync()
+    {
+        try
+        {
+            await _updateService.CheckOnStartupAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Startup update check failed.");
+        }
     }
 
     protected override void OnStateChanged(EventArgs e)


### PR DESCRIPTION
…er builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic startup update checks, limited to once per calendar day when enabled.
  - Added a “Check for updates” button in Settings for manual checks at any time.
  - Notifies users when a newer version is available, with an option to download it.
  - Shows confirmation when the app is up to date or when an update check fails.
  - Persists the date of the last update check.
  - Validates update information and handles unavailable or invalid data gracefully.
  - Improves reliability when communicating with update services.

- **Tests**
  - Added coverage for scheduling, version comparison, metadata parsing, persistence, retries, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->