### PR TITLE
Add a ControlApp About page for license, repo, and update-check.

### DIFF
--- a/ControlApp/App.xaml.cs
+++ b/ControlApp/App.xaml.cs
@@ -93,6 +93,8 @@ public partial class App
             services.AddSingleton<ProfilesViewModel>();
             services.AddSingleton<SettingsPage>();
             services.AddSingleton<SettingsViewModel>();
+            services.AddSingleton<AboutPage>();
+            services.AddSingleton<AboutViewModel>();
             services.AddSingleton<Main>();
 
             services.AddSingleton<AddressValidator>();

--- a/ControlApp/ViewModels/Pages/AboutViewModel.cs
+++ b/ControlApp/ViewModels/Pages/AboutViewModel.cs
@@ -1,0 +1,80 @@
+using Nefarius.DsHidMini.ControlApp.Services;
+using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
+
+using Wpf.Ui.Abstractions.Controls;
+
+namespace Nefarius.DsHidMini.ControlApp.ViewModels.Pages;
+
+public partial class AboutViewModel : ObservableObject, INavigationAware
+{
+    private readonly AppSnackbarMessagesService _appSnackbarMessagesService;
+    private readonly ControlAppUpdateService _updateService;
+
+    [ObservableProperty]
+    private string _appVersion = string.Empty;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CheckForUpdatesCommand))]
+    private bool _isCheckingForUpdates;
+
+    private bool _isInitialized;
+
+    public AboutViewModel(
+        AppSnackbarMessagesService appSnackbarMessagesService,
+        ControlAppUpdateService updateService)
+    {
+        _appSnackbarMessagesService = appSnackbarMessagesService;
+        _updateService = updateService;
+    }
+
+    public string CopyrightNotice { get; } = "Copyright (c) 2020–2026, Benjamin Höglinger-Stelzer";
+
+    public Task OnNavigatedToAsync()
+    {
+        if (!_isInitialized)
+        {
+            AppVersion = $"DsHidMini ControlApp {MainWindowViewModel.GetDisplayVersion()}";
+            _isInitialized = true;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnNavigatedFromAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCheckForUpdates))]
+    private async Task CheckForUpdates()
+    {
+        IsCheckingForUpdates = true;
+        try
+        {
+            UpdateCheckOutcome outcome = await _updateService.CheckNowAsync();
+            switch (outcome)
+            {
+                case UpdateCheckOutcome.UpToDate:
+                    _appSnackbarMessagesService.ShowControlAppUpToDateMessage();
+                    break;
+                case UpdateCheckOutcome.Failed:
+                    _appSnackbarMessagesService.ShowControlAppUpdateCheckFailedMessage();
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Manual ControlApp update check failed.");
+            _appSnackbarMessagesService.ShowControlAppUpdateCheckFailedMessage();
+        }
+        finally
+        {
+            IsCheckingForUpdates = false;
+        }
+    }
+
+    private bool CanCheckForUpdates()
+    {
+        return !IsCheckingForUpdates;
+    }
+}

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Services;
-using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
 
 using Wpf.Ui.Abstractions.Controls;
 using Wpf.Ui.Appearance;
@@ -12,30 +11,20 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 {
     private readonly AppSnackbarMessagesService _appSnackbarMessagesService;
     private readonly DshmConfigManager _dshmConfigManager;
-    private readonly ControlAppUpdateService _updateService;
-
-    [ObservableProperty]
-    private string _appVersion = string.Empty;
 
     [ObservableProperty]
     private ApplicationTheme _currentTheme = ApplicationTheme.Unknown;
 
     private bool _isInitialized;
 
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(CheckForUpdatesCommand))]
-    private bool _isCheckingForUpdates;
-
     public SettingsViewModel(
         DshmConfigManager dshmConfigManager,
         BthPS3StatusService bthPs3,
-        AppSnackbarMessagesService appSnackbarMessagesService,
-        ControlAppUpdateService updateService)
+        AppSnackbarMessagesService appSnackbarMessagesService)
     {
         _dshmConfigManager = dshmConfigManager;
         BthPs3 = bthPs3;
         _appSnackbarMessagesService = appSnackbarMessagesService;
-        _updateService = updateService;
     }
 
     public BthPS3StatusService BthPs3 { get; }
@@ -141,7 +130,6 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private void InitializeViewModel()
     {
         CurrentTheme = ApplicationThemeManager.GetAppTheme();
-        AppVersion = $"DsHidMini ControlApp {MainWindowViewModel.GetDisplayVersion()}";
 
         _isInitialized = true;
     }
@@ -173,39 +161,6 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
                 break;
         }
-    }
-
-    [RelayCommand(CanExecute = nameof(CanCheckForUpdates))]
-    private async Task CheckForUpdates()
-    {
-        IsCheckingForUpdates = true;
-        try
-        {
-            UpdateCheckOutcome outcome = await _updateService.CheckNowAsync();
-            switch (outcome)
-            {
-                case UpdateCheckOutcome.UpToDate:
-                    _appSnackbarMessagesService.ShowControlAppUpToDateMessage();
-                    break;
-                case UpdateCheckOutcome.Failed:
-                    _appSnackbarMessagesService.ShowControlAppUpdateCheckFailedMessage();
-                    break;
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.Logger.Warning(ex, "Manual ControlApp update check failed.");
-            _appSnackbarMessagesService.ShowControlAppUpdateCheckFailedMessage();
-        }
-        finally
-        {
-            IsCheckingForUpdates = false;
-        }
-    }
-
-    private bool CanCheckForUpdates()
-    {
-        return !IsCheckingForUpdates;
     }
 
     [RelayCommand]

--- a/ControlApp/ViewModels/Windows/MainWindowViewModel.cs
+++ b/ControlApp/ViewModels/Windows/MainWindowViewModel.cs
@@ -24,6 +24,12 @@ public partial class MainWindowViewModel : ObservableObject
             Content = "Settings",
             Icon = new SymbolIcon { Symbol = SymbolRegular.Settings24 },
             TargetPageType = typeof(SettingsPage)
+        },
+        new NavigationViewItem
+        {
+            Content = "About",
+            Icon = new SymbolIcon { Symbol = SymbolRegular.Info24 },
+            TargetPageType = typeof(AboutPage)
         }
     };
 

--- a/ControlApp/Views/Pages/AboutPage.xaml
+++ b/ControlApp/Views/Pages/AboutPage.xaml
@@ -1,0 +1,104 @@
+<Page
+    x:Class="Nefarius.DsHidMini.ControlApp.Views.Pages.AboutPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Nefarius.DsHidMini.ControlApp.Views.Pages"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="AboutPage"
+    d:DataContext="{d:DesignInstance local:AboutPage,
+                                     IsDesignTimeCreatable=False}"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    ScrollViewer.CanContentScroll="False"
+    mc:Ignorable="d">
+    <ScrollViewer
+        HorizontalScrollBarVisibility="Disabled"
+        VerticalScrollBarVisibility="Auto">
+        <StackPanel MaxWidth="720" Margin="20" HorizontalAlignment="Left">
+            <StackPanel Margin="0,0,0,16" Orientation="Horizontal">
+                <Image
+                    Width="64"
+                    Height="64"
+                    Margin="0,0,16,0"
+                    Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
+                <StackPanel VerticalAlignment="Center">
+                    <ui:TextBlock FontTypography="Title" Text="DsHidMini ControlApp" />
+                    <ui:TextBlock
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="{Binding ViewModel.AppVersion}" />
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,16" Orientation="Horizontal">
+                <ui:HyperlinkButton
+                    Margin="0,0,8,0"
+                    Content="Open repository"
+                    Icon="{ui:SymbolIcon Open24}"
+                    NavigateUri="https://github.com/nefarius/DsHidMini" />
+                <ui:HyperlinkButton
+                    Content="View license"
+                    Icon="{ui:SymbolIcon DocumentText24}"
+                    NavigateUri="https://github.com/nefarius/DsHidMini/blob/master/LICENSE" />
+            </StackPanel>
+
+            <ui:Button
+                Margin="0,0,0,8"
+                HorizontalAlignment="Left"
+                Command="{Binding ViewModel.CheckForUpdatesCommand}"
+                Content="Check for updates" />
+            <TextBlock
+                Margin="0,0,0,24"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="Looks for a newer ControlApp on Buildbot, even if you already skipped an update today."
+                TextWrapping="Wrap" />
+
+            <TextBlock
+                Margin="0,0,0,16"
+                Text="{Binding ViewModel.CopyrightNotice}"
+                TextWrapping="Wrap" />
+            <TextBlock
+                Margin="0,0,0,16"
+                Text="This is a community project and not affiliated with Sony Interactive Entertainment Inc. in any way."
+                TextWrapping="Wrap" />
+            <TextBlock
+                Margin="0,0,0,16"
+                Text="&quot;PlayStation&quot;, &quot;PSP&quot;, &quot;PS2&quot;, &quot;PS one&quot;, &quot;DUALSHOCK&quot; and &quot;SIXAXIS&quot; are registered trademarks of Sony Interactive Entertainment Inc."
+                TextWrapping="Wrap" />
+            <TextBlock
+                Margin="0,0,0,16"
+                Text="DsHidMini is released under the BSD 3-Clause License. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the conditions of that license are met."
+                TextWrapping="Wrap" />
+            <TextBlock
+                Margin="0,0,0,16"
+                Text="Should you wish to redistribute this program, or any part of it, you should read the full terms and conditions set out in the license agreement before doing so. A copy of the license is available in the project repository."
+                TextWrapping="Wrap" />
+            <TextBlock
+                Margin="0,0,0,16"
+                Text="If you simply wish to install and use this software, you need only be aware of the disclaimer conditions in the license, which are set out below."
+                TextWrapping="Wrap" />
+            <TextBlock
+                Margin="0,0,0,16"
+                FontWeight="Bold"
+                Text="NO WARRANTY" />
+            <TextBlock
+                TextAlignment="Justify"
+                TextWrapping="Wrap">
+                THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
+                AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+                IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+                FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+                DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+                SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+                CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+                OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+                OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            </TextBlock>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/ControlApp/Views/Pages/AboutPage.xaml.cs
+++ b/ControlApp/Views/Pages/AboutPage.xaml.cs
@@ -1,0 +1,18 @@
+using Nefarius.DsHidMini.ControlApp.ViewModels.Pages;
+
+using Wpf.Ui.Abstractions.Controls;
+
+namespace Nefarius.DsHidMini.ControlApp.Views.Pages;
+
+public partial class AboutPage : INavigableView<AboutViewModel>
+{
+    public AboutPage(AboutViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        DataContext = this;
+
+        InitializeComponent();
+    }
+
+    public AboutViewModel ViewModel { get; }
+}

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -93,24 +93,6 @@
                     Icon="{ui:SymbolIcon QuestionCircle24}"
                     NavigateUri="https://docs.nefarius.at/projects/BthPS3/" />
             </StackPanel>
-            <ui:TextBlock
-                Margin="0,28,0,8"
-                FontTypography="Subtitle"
-                Text="About" />
-            <ui:TextBlock
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Text="{Binding ViewModel.AppVersion}" />
-            <ui:Button
-                Margin="0,12,0,0"
-                HorizontalAlignment="Left"
-                Command="{Binding ViewModel.CheckForUpdatesCommand}"
-                Content="Check for updates" />
-            <TextBlock
-                MaxWidth="600"
-                Margin="0,8,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Text="Looks for a newer ControlApp on Buildbot, even if you already skipped an update today."
-                TextWrapping="Wrap" />
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020-2025, Benjamin Höglinger-Stelzer
+Copyright (c) 2020-2026, Benjamin Höglinger-Stelzer
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated About page accessible from the main navigation.
  - Displays the application version, copyright and trademark notices, license information, and repository links.
  - Added a manual update-check action with progress feedback and result notifications.

- **Improvements**
  - Moved application information and update checking from Settings to the new About page.
  - Updated the BSD 3-Clause License copyright year through 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->