### PR TITLE
Add a wired USB power-off action so ControlApp can send the console s…

### DIFF
--- a/ControlApp.Tests/UsbPowerOffResultTests.cs
+++ b/ControlApp.Tests/UsbPowerOffResultTests.cs
@@ -1,0 +1,58 @@
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class UsbPowerOffResultTests
+{
+    private const uint StatusSuccess = 0x00000000;
+    private const uint StatusNotSupported = 0xC00000BB;
+    private const uint StatusUnsuccessful = 0xC0000001;
+    private const uint StatusInformational = 0x40000000;
+
+    [Theory]
+    [InlineData(StatusSuccess, true)]
+    [InlineData(StatusInformational, true)]
+    [InlineData(StatusNotSupported, false)]
+    [InlineData(StatusUnsuccessful, false)]
+    public void IsNtSuccess_MatchesDriverNtSuccess(uint status, bool expected)
+    {
+        Assert.Equal(expected, PowerOffUsbResult.IsNtSuccess(status));
+    }
+
+    [Fact]
+    public void Succeeded_RequiresBothTransfersToSucceed()
+    {
+        Assert.True(new PowerOffUsbResult
+        {
+            IndicatorsOffStatus = StatusSuccess,
+            ShutdownStatus = StatusSuccess
+        }.Succeeded);
+
+        Assert.False(new PowerOffUsbResult
+        {
+            IndicatorsOffStatus = StatusSuccess,
+            ShutdownStatus = StatusNotSupported
+        }.Succeeded);
+
+        Assert.False(new PowerOffUsbResult
+        {
+            IndicatorsOffStatus = StatusUnsuccessful,
+            ShutdownStatus = StatusSuccess
+        }.Succeeded);
+    }
+
+    [Fact]
+    public void ToString_IncludesBothStatuses()
+    {
+        string text = new PowerOffUsbResult
+        {
+            IndicatorsOffStatus = StatusSuccess,
+            ShutdownStatus = StatusNotSupported
+        }.ToString();
+
+        Assert.Contains("0x0", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("0xC00000BB", text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -156,6 +156,28 @@ public class AppSnackbarMessagesService
         );
     }
 
+    public void ShowUsbPowerOffSucceededMessage()
+    {
+        _snackbarService.Show(
+            "Controller turned off",
+            "USB stays connected. Use Restart on the device card to wake it.",
+            ControlAppearance.Success,
+            new SymbolIcon(SymbolRegular.CheckmarkCircle24),
+            TimeSpan.FromSeconds(5)
+        );
+    }
+
+    public void ShowUsbPowerOffFailedMessage(string detail)
+    {
+        _snackbarService.Show(
+            "Failed to turn off controller",
+            detail,
+            ControlAppearance.Danger,
+            new SymbolIcon(SymbolRegular.DismissCircle24),
+            TimeSpan.FromSeconds(8)
+        );
+    }
+
     public void ShowPowerCyclingDeviceMessage(bool isWireless, bool isAppElevated, bool reconnectionResult)
     {
         if (!isWireless && !isAppElevated)

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -771,8 +771,11 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
 
         try
         {
-            using DsHidMiniInterop interop = new();
-            PowerOffUsbResult result = interop.PowerOffUsbDevice(deviceIndex);
+            PowerOffUsbResult result = await Task.Run(() =>
+            {
+                using DsHidMiniInterop interop = new();
+                return interop.PowerOffUsbDevice(deviceIndex);
+            });
 
             Log.Logger.Information(
                 "USB power-off for '{DeviceAddress}' slot {Slot}: {Result}",

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -9,7 +9,9 @@ using Nefarius.DsHidMini.ControlApp.Models.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.Util;
 using Nefarius.DsHidMini.ControlApp.Models.Util.Web;
 using Nefarius.DsHidMini.ControlApp.Services;
+using Nefarius.DsHidMini.IPC;
 using Nefarius.DsHidMini.IPC.Models.Drivers;
+using Nefarius.DsHidMini.IPC.Models.Public;
 using Nefarius.Utilities.DeviceManagement.PnP;
 
 using Wpf.Ui;
@@ -378,6 +380,17 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             : "Restart this USB controller. Requires running as Administrator.";
 
     /// <summary>
+    ///     Wired controllers can receive the console USB power-off sequence.
+    /// </summary>
+    public bool CanPowerOffUsb => !IsWireless;
+
+    /// <summary>
+    ///     Tooltip for the wired-only USB power-off button.
+    /// </summary>
+    public string PowerOffUsbDeviceToolTip =>
+        "Turn off this USB controller. It stays plugged in; use Restart to wake it.";
+
+    /// <summary>
     ///     Last time this device has been seen connected (applies to Bluetooth connected devices only).
     /// </summary>
     public DateTimeOffset LastConnected =>
@@ -709,6 +722,99 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             IsWireless ? "wireless" : "wired", DeviceAddress);
         _appSnackbarMessagesService.ShowPowerCyclingDeviceMessage(IsWireless, SecurityUtil.IsElevated,
             reconnectionResult && propertyApplyResult);
+    }
+
+    [RelayCommand]
+    private async Task PowerOffUsbDevice()
+    {
+        if (!CanPowerOffUsb)
+        {
+            return;
+        }
+
+        ContentDialogResult confirmation = await _contentDialogService.ShowSimpleDialogAsync(
+            new SimpleContentDialogCreateOptions
+            {
+                Title = "Turn off controller?",
+                Content = """
+                          This sends the PlayStation 3 USB power-off sequence. The controller stays plugged in and can keep charging, but LEDs and input stop.
+
+                          Use Restart on this card to wake it again.
+                          """,
+                PrimaryButtonText = "Turn off",
+                CloseButtonText = "Cancel"
+            }
+        );
+
+        if (confirmation != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        int? slot = TryGetIpcSlotIndex();
+        if (slot is not int deviceIndex)
+        {
+            Log.Logger.Warning(
+                "USB power-off skipped for '{DeviceAddress}': no readable IPC slot.",
+                DeviceAddress);
+            _appSnackbarMessagesService.ShowUsbPowerOffFailedMessage(
+                "The driver did not report an IPC slot for this device.");
+            return;
+        }
+
+        if (!DsHidMiniInterop.IsAvailable)
+        {
+            _appSnackbarMessagesService.ShowUsbPowerOffFailedMessage(
+                "Driver IPC is not available. Confirm the controller is still connected.");
+            return;
+        }
+
+        try
+        {
+            using DsHidMiniInterop interop = new();
+            PowerOffUsbResult result = interop.PowerOffUsbDevice(deviceIndex);
+
+            Log.Logger.Information(
+                "USB power-off for '{DeviceAddress}' slot {Slot}: {Result}",
+                DeviceAddress,
+                deviceIndex,
+                result);
+
+            if (result.Succeeded)
+            {
+                _appSnackbarMessagesService.ShowUsbPowerOffSucceededMessage();
+            }
+            else
+            {
+                _appSnackbarMessagesService.ShowUsbPowerOffFailedMessage(
+                    $"{result}. Restart the controller if it stopped responding.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Error(ex, "USB power-off failed for '{DeviceAddress}'", DeviceAddress);
+            _appSnackbarMessagesService.ShowUsbPowerOffFailedMessage(ex.Message);
+        }
+    }
+
+    private int? TryGetIpcSlotIndex()
+    {
+        uint slot;
+        try
+        {
+            slot = Device.GetProperty<uint>(DsHidMiniDriver.IpcSlotIndexProperty);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        if (slot is < 1 or > byte.MaxValue)
+        {
+            return null;
+        }
+
+        return (int)slot;
     }
 
     [RelayCommand]

--- a/ControlApp/Views/Pages/DevicesPage.xaml
+++ b/ControlApp/Views/Pages/DevicesPage.xaml
@@ -141,6 +141,35 @@
                                             </Viewbox>
 
 
+                                            <!--  Wired USB power-off (issue #366)  -->
+                                            <Viewbox
+                                                Margin="0"
+                                                DockPanel.Dock="Left"
+                                                Visibility="{Binding CanPowerOffUsb, Converter={StaticResource BoolToVis_TV_FC}}">
+                                                <ui:Button
+                                                    Width="50"
+                                                    Height="50"
+                                                    Padding="5"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Stretch"
+                                                    HorizontalContentAlignment="Stretch"
+                                                    Command="{Binding PowerOffUsbDeviceCommand}"
+                                                    FontStyle="Normal"
+                                                    ToolTip="{Binding PowerOffUsbDeviceToolTip}"
+                                                    ToolTipService.InitialShowDelay="200">
+                                                    <ui:Button.Content>
+                                                        <Viewbox>
+                                                            <ui:SymbolIcon
+                                                                Margin="0"
+                                                                HorizontalAlignment="Center"
+                                                                FontSize="28"
+                                                                Foreground="White"
+                                                                Symbol="Sleep24" />
+                                                        </Viewbox>
+                                                    </ui:Button.Content>
+                                                </ui:Button>
+                                            </Viewbox>
+
                                             <!--  Power cycle/Reconnect button  -->
                                             <Viewbox Margin="0" DockPanel.Dock="Left">
                                                 <ui:Button

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
@@ -393,4 +393,74 @@ public partial class DsHidMiniInterop
             _commandMutex.ReleaseMutex();
         }
     }
+
+    /// <summary>
+    ///     Sends the PlayStation 3 USB power-off sequence to a wired device: a 48-byte zero
+    ///     output report, then Feature 0xF4 disable. The controller stays enumerated.
+    /// </summary>
+    /// <param name="deviceIndex">The one-based device index.</param>
+    /// <exception cref="DsHidMiniInteropUnavailableException">
+    ///     Driver IPC unavailable, make sure that at least one compatible
+    ///     controller is connected and operational.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropInvalidDeviceIndexException">
+    ///     The <paramref name="deviceIndex" /> was outside the valid range 1..255.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropConcurrencyException">A different thread is currently performing a data exchange.</exception>
+    /// <exception cref="DsHidMiniInteropReplyTimeoutException">The driver didn't respond within an expected period.</exception>
+    /// <exception cref="DsHidMiniInteropUnexpectedReplyException">The driver returned unexpected or malformed data.</exception>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public unsafe PowerOffUsbResult PowerOffUsbDevice(int deviceIndex)
+    {
+        if (_commandMutex is null || _cmdView is null)
+        {
+            throw new DsHidMiniInteropUnavailableException();
+        }
+
+        ValidateDeviceIndex(deviceIndex);
+
+        AcquireCommandLock();
+
+        try
+        {
+            ref DSHM_IPC_MSG_USB_POWER_OFF_REQUEST request =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_USB_POWER_OFF_REQUEST>(_cmdView);
+
+            request.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_RESPONSE;
+            request.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_DEVICE;
+            request.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF;
+            request.Header.TargetIndex = (uint)deviceIndex;
+            request.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_USB_POWER_OFF_REQUEST>();
+
+            if (!SendAndWait())
+            {
+                throw new DsHidMiniInteropReplyTimeoutException();
+            }
+
+            ref DSHM_IPC_MSG_USB_POWER_OFF_REPLY reply =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_USB_POWER_OFF_REPLY>(_cmdView);
+
+            if (reply.Header is
+                {
+                    Type: DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY,
+                    Target: DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT,
+                    Command.Device: DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF
+                }
+                && reply.Header.TargetIndex == deviceIndex
+                && reply.Header.Size == Marshal.SizeOf<DSHM_IPC_MSG_USB_POWER_OFF_REPLY>())
+            {
+                return new PowerOffUsbResult
+                {
+                    IndicatorsOffStatus = reply.IndicatorsOffStatus,
+                    ShutdownStatus = reply.ShutdownStatus
+                };
+            }
+
+            throw new DsHidMiniInteropUnexpectedReplyException(ref reply.Header);
+        }
+        finally
+        {
+            _commandMutex.ReleaseMutex();
+        }
+    }
 }

--- a/SDK/Nefarius.DsHidMini.IPC/Models/CmdStructs.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/CmdStructs.cs
@@ -124,3 +124,35 @@ internal struct DSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY
 
     public UInt32 NtStatus;
 }
+
+/// <summary>
+///     Requests the console-style USB power-off sequence (issue #366).
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_USB_POWER_OFF_REQUEST
+{
+    public DSHM_IPC_MSG_HEADER Header;
+}
+
+/// <summary>
+///     Reply to <see cref="DSHM_IPC_MSG_USB_POWER_OFF_REQUEST" />.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_USB_POWER_OFF_REPLY
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    /// <summary>
+    ///     NTSTATUS of the 48-byte zero output report (LEDs/rumble off)
+    /// </summary>
+    public UInt32 IndicatorsOffStatus;
+
+    /// <summary>
+    ///     NTSTATUS of the Feature 0xF4 disable transfer
+    /// </summary>
+    public UInt32 ShutdownStatus;
+}

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Enums.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Enums.cs
@@ -99,5 +99,10 @@ internal enum DSHM_IPC_MSG_CMD_DEVICE : UInt32
     /// <summary>
     ///     Requests a player index update (switch player LED etc.)
     /// </summary>
-    DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX
+    DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX,
+
+    /// <summary>
+    ///     Sends the console USB power-off sequence (zero output report + disable)
+    /// </summary>
+    DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF
 }

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/PowerOffUsbResult.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/PowerOffUsbResult.cs
@@ -1,0 +1,35 @@
+namespace Nefarius.DsHidMini.IPC.Models.Public;
+
+/// <summary>
+///     Result of the console-style USB power-off sequence (issue #366).
+/// </summary>
+public readonly struct PowerOffUsbResult
+{
+    /// <summary>
+    ///     NTSTATUS of the 48-byte zero output report that turns LEDs and rumble off.
+    /// </summary>
+    public UInt32 IndicatorsOffStatus { get; init; }
+
+    /// <summary>
+    ///     NTSTATUS of the Feature 0xF4 disable transfer that stops input reports.
+    /// </summary>
+    public UInt32 ShutdownStatus { get; init; }
+
+    /// <summary>
+    ///     <see langword="true" /> when both transfers completed successfully.
+    /// </summary>
+    public bool Succeeded => IsNtSuccess(IndicatorsOffStatus) && IsNtSuccess(ShutdownStatus);
+
+    /// <summary>
+    ///     Interprets a raw NTSTATUS value the same way the driver does (<c>NT_SUCCESS</c>).
+    /// </summary>
+    public static bool IsNtSuccess(UInt32 status)
+    {
+        return unchecked((Int32)status) >= 0;
+    }
+
+    public override string ToString()
+    {
+        return $"Indicators-off: 0x{IndicatorsOffStatus:X}, shutdown: 0x{ShutdownStatus:X}";
+    }
+}

--- a/SDK/Nefarius.DsHidMini.IPC/Nefarius.DsHidMini.IPC.csproj
+++ b/SDK/Nefarius.DsHidMini.IPC/Nefarius.DsHidMini.IPC.csproj
@@ -16,6 +16,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <MinVerTagPrefix>sdk-v</MinVerTagPrefix>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'True'">true</ContinuousIntegrationBuild>
+    <!-- CsWin32 already emits some C# 13 polyfills; only generate init support. -->
+    <PolySharpIncludeGeneratedTypes>System.Runtime.CompilerServices.IsExternalInit</PolySharpIncludeGeneratedTypes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +35,10 @@
     </PackageReference>
     <PackageReference Include="MinVer" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="PolySharp" Version="1.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="6.1.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />

--- a/SDK/Nefarius.DsHidMini.IPC/README.md
+++ b/SDK/Nefarius.DsHidMini.IPC/README.md
@@ -39,6 +39,7 @@ Use it from a .NET Standard 2.0 consumer or a .NET 10 Windows application (deskt
 | **Read raw input** | Poll or wait for `DS3_RAW_INPUT_REPORT` (buttons, sticks, pressure, motion) |
 | **Pair to host** | Set the Bluetooth host address the controller pairs to (`SetHostAddress`) |
 | **Player index** | Set the player LED slot (1–7) with `SetPlayerIndex` |
+| **USB power-off** | Send the console USB power-off sequence with `PowerOffUsbDevice` |
 | **Liveness check** | Verify driver is responsive with `SendPing` |
 
 The SDK handles reconnection when the last device disconnects and the next one arrives, and exposes device arrival/removal via internal device notification handling.
@@ -121,6 +122,7 @@ if (gotReport)
 | **`void SendPing()`** | Sends a ping to the driver and waits for a reply (liveness check). |
 | **`SetHostResult SetHostAddress(int deviceIndex, PhysicalAddress hostAddress)`** | Writes the new Bluetooth host address (pairing). Returns write/read NTSTATUS in `SetHostResult`. |
 | **`uint SetPlayerIndex(int deviceIndex, byte playerIndex)`** | Sets the player LED index (1–7). Returns NTSTATUS. |
+| **`PowerOffUsbResult PowerOffUsbDevice(int deviceIndex)`** | Sends the PlayStation 3 USB power-off sequence (zero output report, then Feature 0xF4 disable). Wired devices only; the controller stays enumerated. |
 
 All device-indexed APIs use a **one-based** device index (see [Device index](#device-index)).
 
@@ -150,6 +152,12 @@ All device-indexed APIs use a **one-based** device index (see [Device index](#de
 
 - **`WriteStatus`** — NTSTATUS of the “pair to host” write.  
 - **`ReadStatus`** — NTSTATUS of the subsequent read-back of the address.
+
+### `PowerOffUsbResult` (USB power-off)
+
+- **`IndicatorsOffStatus`** — NTSTATUS of the 48-byte zero output report.  
+- **`ShutdownStatus`** — NTSTATUS of the Feature 0xF4 disable transfer.  
+- **`Succeeded`** — `true` when both transfers completed successfully.
 
 ### Driver / model enums (see API docs)
 

--- a/driver/IPC.Device.c
+++ b/driver/IPC.Device.c
@@ -69,6 +69,63 @@ DSHM_EvtDispatchDeviceMessage(
 
 		status = STATUS_SUCCESS;
 	}
+	else if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF)
+	{
+		NTSTATUS indicatorsOffStatus = STATUS_NOT_SUPPORTED;
+		NTSTATUS shutdownStatus = STATUS_NOT_SUPPORTED;
+
+		if (DeviceContext->ConnectionType != DsDeviceConnectionTypeUsb)
+		{
+			TraceWarning(
+				TRACE_IPC,
+				"USB power-off requested for a non-USB device"
+			);
+		}
+		else
+		{
+			//
+			// PS3 sequence from issue #366: zero the 48-byte output report on
+			// EP0, then send Feature 0xF4 disable. Always attempt shutdown even
+			// if the first transfer fails.
+			// 
+			UCHAR zeroOutputReport[48] = { 0 };
+
+			indicatorsOffStatus = DsUsb_Ds3SendOutputReportControl(
+				DeviceContext,
+				zeroOutputReport,
+				ARRAYSIZE(zeroOutputReport)
+			);
+
+			if (!NT_SUCCESS(indicatorsOffStatus))
+			{
+				TraceWarning(
+					TRACE_IPC,
+					"USB power-off indicators-off report failed with %!STATUS!",
+					indicatorsOffStatus
+				);
+			}
+
+			shutdownStatus = DsUsb_Ds3Shutdown(DeviceContext);
+
+			if (!NT_SUCCESS(shutdownStatus))
+			{
+				TraceError(
+					TRACE_IPC,
+					"DsUsb_Ds3Shutdown failed with %!STATUS!",
+					shutdownStatus
+				);
+			}
+		}
+
+		DSHM_IPC_MSG_USB_POWER_OFF_RESPONSE_INIT(
+			(PDSHM_IPC_MSG_USB_POWER_OFF_REPLY)MessageHeader,
+			MessageHeader->TargetIndex,
+			indicatorsOffStatus,
+			shutdownStatus
+		);
+
+		status = STATUS_SUCCESS;
+	}
 
 	FuncExit(TRACE_IPC, "status=%!STATUS!", status);
 

--- a/driver/IPC.h
+++ b/driver/IPC.h
@@ -94,6 +94,10 @@ typedef enum
 	// Requests a player index update (switch player LED etc.)
 	// 
 	DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX,
+	//
+	// Sends the console USB power-off sequence (zero output report + disable)
+	// 
+	DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF,
 } DSHM_IPC_MSG_CMD_DEVICE;
 
 //
@@ -190,6 +194,34 @@ typedef struct _DSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY
 	
 } DSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY, *PDSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY;
 
+//
+// Requests the console-style USB power-off sequence (issue #366)
+// 
+typedef struct _DSHM_IPC_MSG_USB_POWER_OFF_REQUEST
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+} DSHM_IPC_MSG_USB_POWER_OFF_REQUEST, *PDSHM_IPC_MSG_USB_POWER_OFF_REQUEST;
+
+//
+// Reply to struct _DSHM_IPC_MSG_USB_POWER_OFF_REQUEST
+// 
+typedef struct _DSHM_IPC_MSG_USB_POWER_OFF_REPLY
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	//
+	// NTSTATUS of the 48-byte zero output report (LEDs/rumble off)
+	// 
+	NTSTATUS IndicatorsOffStatus;
+
+	//
+	// NTSTATUS of the Feature 0xF4 disable transfer
+	// 
+	NTSTATUS ShutdownStatus;
+
+} DSHM_IPC_MSG_USB_POWER_OFF_REPLY, *PDSHM_IPC_MSG_USB_POWER_OFF_REPLY;
+
 typedef
 _Function_class_(EVT_DSHM_IPC_DispatchDeviceMessage)
 _IRQL_requires_same_
@@ -279,6 +311,28 @@ DSHM_IPC_MSG_SET_PLAYER_INDEX_RESPONSE_INIT(
 	Message->Header.Size = size;
 
 	Message->NtStatus = Status;
+}
+
+VOID
+FORCEINLINE
+DSHM_IPC_MSG_USB_POWER_OFF_RESPONSE_INIT(
+	_Inout_ PDSHM_IPC_MSG_USB_POWER_OFF_REPLY Message,
+	_In_ UINT32 DeviceIndex,
+	_In_ NTSTATUS IndicatorsOffStatus,
+	_In_ NTSTATUS ShutdownStatus
+)
+{
+	const UINT32 size = sizeof(DSHM_IPC_MSG_USB_POWER_OFF_REPLY);
+	RtlZeroMemory(Message, size);
+
+	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
+	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF;
+	Message->Header.TargetIndex = DeviceIndex;
+	Message->Header.Size = size;
+
+	Message->IndicatorsOffStatus = IndicatorsOffStatus;
+	Message->ShutdownStatus = ShutdownStatus;
 }
 
 


### PR DESCRIPTION
…hutdown sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added USB power-off support for compatible wired controllers.
  * Device cards now provide a power-off action with confirmation and contextual guidance.
  * Added success and failure notifications, including diagnostic details when an operation fails.
  * Power-off results now distinguish between indicator shutdown and controller shutdown status.

* **Documentation**
  * Documented the USB power-off API and result fields.

* **Tests**
  * Added coverage for power-off success evaluation and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->