### PR TITLE
Add ControlApp Settings controls for the experimental driver IPC flag.

### DIFF
--- a/ControlApp.Tests/DshmIpcStatusServiceTests.cs
+++ b/ControlApp.Tests/DshmIpcStatusServiceTests.cs
@@ -1,0 +1,175 @@
+using Nefarius.DsHidMini.ControlApp.Models.Drivers;
+using Nefarius.DsHidMini.ControlApp.Services;
+
+using Wpf.Ui.Controls;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class DshmIpcStatusServiceTests
+{
+    [Fact]
+    public void Refresh_MissingValue_IsDisabledAndKnown()
+    {
+        FakeStore store = new() { Value = null };
+        DshmIpcStatusService service = new(store, static () => true);
+
+        service.Refresh();
+
+        Assert.True(service.IsStateKnown);
+        Assert.False(service.IsEnabled);
+        Assert.Equal("Disabled", service.StateDisplay);
+        Assert.True(service.CanEnable);
+        Assert.False(service.CanDisable);
+        Assert.Equal(InfoBarSeverity.Informational, service.Severity);
+    }
+
+    [Fact]
+    public void Refresh_ZeroValue_IsDisabled()
+    {
+        FakeStore store = new() { Value = 0 };
+        DshmIpcStatusService service = new(store, static () => false);
+
+        service.Refresh();
+
+        Assert.True(service.IsStateKnown);
+        Assert.False(service.IsEnabled);
+        Assert.Equal("Disabled", service.StateDisplay);
+        Assert.False(service.CanEnable);
+        Assert.False(service.CanDisable);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Refresh_NonzeroValue_IsEnabled(int stored)
+    {
+        FakeStore store = new() { Value = stored };
+        DshmIpcStatusService service = new(store, static () => true);
+
+        service.Refresh();
+
+        Assert.True(service.IsStateKnown);
+        Assert.True(service.IsEnabled);
+        Assert.Equal("Enabled", service.StateDisplay);
+        Assert.False(service.CanEnable);
+        Assert.True(service.CanDisable);
+        Assert.Equal(InfoBarSeverity.Warning, service.Severity);
+    }
+
+    [Fact]
+    public void Refresh_ReadFailure_IsUnknownAndCommandsDisabled()
+    {
+        FakeStore store = new() { ReadSucceeds = false };
+        DshmIpcStatusService service = new(store, static () => true);
+
+        service.Refresh();
+
+        Assert.False(service.IsStateKnown);
+        Assert.False(service.IsEnabled);
+        Assert.Equal("Unknown", service.StateDisplay);
+        Assert.False(service.CanEnable);
+        Assert.False(service.CanDisable);
+        Assert.Equal(InfoBarSeverity.Warning, service.Severity);
+    }
+
+    [Fact]
+    public void TrySetEnabled_NonElevated_DoesNotWrite()
+    {
+        FakeStore store = new() { Value = 0 };
+        DshmIpcStatusService service = new(store, static () => false);
+
+        bool changed = service.TrySetEnabled(true);
+
+        Assert.False(changed);
+        Assert.False(store.WriteCalled);
+        Assert.Equal(0, store.Value);
+        Assert.False(service.CanEnable);
+        Assert.False(service.CanDisable);
+    }
+
+    [Fact]
+    public void TrySetEnabled_ElevatedEnable_WritesDwordOneAndRefreshesCommands()
+    {
+        FakeStore store = new() { Value = 0 };
+        DshmIpcStatusService service = new(store, static () => true);
+
+        bool changed = service.TrySetEnabled(true);
+
+        Assert.True(changed);
+        Assert.True(store.WriteCalled);
+        Assert.Equal(1, store.LastWritten);
+        Assert.Equal(1, store.Value);
+        Assert.True(service.IsEnabled);
+        Assert.False(service.CanEnable);
+        Assert.True(service.CanDisable);
+    }
+
+    [Fact]
+    public void TrySetEnabled_ElevatedDisable_WritesDwordZeroAndRefreshesCommands()
+    {
+        FakeStore store = new() { Value = 1 };
+        DshmIpcStatusService service = new(store, static () => true);
+
+        bool changed = service.TrySetEnabled(false);
+
+        Assert.True(changed);
+        Assert.True(store.WriteCalled);
+        Assert.Equal(0, store.LastWritten);
+        Assert.Equal(0, store.Value);
+        Assert.False(service.IsEnabled);
+        Assert.True(service.CanEnable);
+        Assert.False(service.CanDisable);
+    }
+
+    [Fact]
+    public void TrySetEnabled_WriteFailure_ReturnsFalseAndRefreshes()
+    {
+        FakeStore store = new()
+        {
+            Value = 0,
+            WriteException = new UnauthorizedAccessException("denied")
+        };
+        DshmIpcStatusService service = new(store, static () => true);
+
+        bool changed = service.TrySetEnabled(true);
+
+        Assert.False(changed);
+        Assert.True(store.WriteCalled);
+        Assert.False(service.IsEnabled);
+        Assert.True(service.CanEnable);
+        Assert.False(service.CanDisable);
+    }
+
+    private sealed class FakeStore : IDshmDriverParametersStore
+    {
+        public int? LastWritten { get; private set; }
+
+        public bool ReadSucceeds { get; init; } = true;
+
+        public int? Value { get; set; }
+
+        public Exception? WriteException { get; init; }
+
+        public bool WriteCalled { get; private set; }
+
+        public bool TryReadIpcEnabled(out int? value)
+        {
+            value = Value;
+            return ReadSucceeds;
+        }
+
+        public void WriteIpcEnabled(int value)
+        {
+            WriteCalled = true;
+            LastWritten = value;
+            if (WriteException is not null)
+            {
+                throw WriteException;
+            }
+
+            Value = value;
+        }
+    }
+}

--- a/ControlApp.Tests/DshmIpcStatusServiceTests.cs
+++ b/ControlApp.Tests/DshmIpcStatusServiceTests.cs
@@ -43,6 +43,7 @@ public class DshmIpcStatusServiceTests
     [Theory]
     [InlineData(1)]
     [InlineData(2)]
+    [InlineData(-1)]
     public void Refresh_NonzeroValue_IsEnabled(int stored)
     {
         FakeStore store = new() { Value = stored };

--- a/ControlApp/App.xaml.cs
+++ b/ControlApp/App.xaml.cs
@@ -85,6 +85,7 @@ public partial class App
             services.AddSingleton<DshmDevMan>();
             services.AddSingleton<DshmConfigManager>();
             services.AddSingleton<BthPS3StatusService>();
+            services.AddSingleton<DshmIpcStatusService>();
             services.AddSingleton<DefenderBtStatusService>();
 
             services.AddSingleton<DevicesPage>();

--- a/ControlApp/Models/Drivers/DshmDriverParametersStore.cs
+++ b/ControlApp/Models/Drivers/DshmDriverParametersStore.cs
@@ -1,0 +1,96 @@
+using Microsoft.Win32;
+
+namespace Nefarius.DsHidMini.ControlApp.Models.Drivers;
+
+/// <summary>
+///     Reads and writes DsHidMini WUDF service parameters under HKLM.
+/// </summary>
+internal interface IDshmDriverParametersStore
+{
+    /// <summary>
+    ///     Reads the <c>IPCEnabled</c> DWORD. A missing key or value is reported as success with
+    ///     <paramref name="value" /> set to <see langword="null" />.
+    /// </summary>
+    /// <returns><see langword="false" /> if the registry could not be queried or the value is not a DWORD.</returns>
+    bool TryReadIpcEnabled(out int? value);
+
+    /// <summary>
+    ///     Writes <c>IPCEnabled</c> as a DWORD. Requires administrator rights.
+    /// </summary>
+    void WriteIpcEnabled(int value);
+}
+
+/// <summary>
+///     Registry-backed <see cref="IDshmDriverParametersStore" /> for the installed DsHidMini driver.
+/// </summary>
+internal sealed class DshmDriverParametersStore : IDshmDriverParametersStore
+{
+    internal const string ParametersKeyPath =
+        @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\WUDF\Services\dshidmini\Parameters";
+
+    internal const string IpcEnabledValueName = "IPCEnabled";
+
+    public bool TryReadIpcEnabled(out int? value)
+    {
+        value = null;
+
+        try
+        {
+            using RegistryKey? key = RegistryHelpers.GetRegistryKey(ParametersKeyPath);
+            if (key is null)
+            {
+                return true;
+            }
+
+            object? raw = key.GetValue(IpcEnabledValueName);
+            if (raw is null)
+            {
+                return true;
+            }
+
+            if (!TryCoerceDword(raw, out int coerced))
+            {
+                Log.Logger.Warning(
+                    "DsHidMini {ValueName} has an unexpected type {ValueType}.",
+                    IpcEnabledValueName,
+                    raw.GetType().FullName);
+                return false;
+            }
+
+            value = coerced;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "Failed to read {ValueName} from DsHidMini parameters.", IpcEnabledValueName);
+            return false;
+        }
+    }
+
+    public void WriteIpcEnabled(int value)
+    {
+        using RegistryKey? key = RegistryHelpers.GetRegistryKey(ParametersKeyPath, writable: true);
+        if (key is null)
+        {
+            throw new InvalidOperationException("DsHidMini parameters registry key was not found.");
+        }
+
+        key.SetValue(IpcEnabledValueName, value, RegistryValueKind.DWord);
+    }
+
+    private static bool TryCoerceDword(object raw, out int value)
+    {
+        switch (raw)
+        {
+            case int i:
+                value = i;
+                return true;
+            case uint u:
+                value = unchecked((int)u);
+                return true;
+            default:
+                value = 0;
+                return false;
+        }
+    }
+}

--- a/ControlApp/README.md
+++ b/ControlApp/README.md
@@ -112,6 +112,7 @@ This compiles the solution (if needed) and publishes the ControlApp to the solut
 - **App version** — Displayed in the title bar / settings.
 - **Automatically restart devices on HID mode mismatch** — Driver self-restart when the loaded HID mode does not match the mode Windows already probed.
 - **Minimize to tray** — When enabled, Minimize and Close hide ControlApp to the notification area; use the tray icon to reopen or Exit to quit.
+- **Experimental driver IPC** — Check, enable, or disable the driver’s `IPCEnabled` registry flag. Changing it requires Administrator rights and a reboot or driver reload.
 - **Application configuration** — Stored in %AppData%; see [Configuration](#configuration).
 
 ---
@@ -135,7 +136,7 @@ DsHidMini driver configuration (profiles, global profile, per-device profile ass
 ## Elevation and permissions
 
 - The app runs **as invoker** (no mandatory elevation). Normal users can open the app, view devices and profiles, and change application settings.
-- **“Restart as Administrator”** — Shown in the title bar when not elevated; use it to get full device-editing and pairing support (e.g. handle duplication for raw input and pairing).
+- **“Restart as Administrator”** — Shown in the title bar when not elevated; use it to get full device-editing and pairing support (e.g. handle duplication for raw input and pairing) and to change experimental driver IPC.
 - **Device editing** — Some device operations (e.g. pairing to host, or reliable application of certain settings) require the process to have sufficient privileges; restarting as administrator is the supported way to obtain them.
 
 ---

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -134,6 +134,39 @@ public class AppSnackbarMessagesService
         );
     }
 
+    public void ShowDriverIpcEnabledMessage()
+    {
+        _snackbarService.Show(
+            "Driver IPC enabled",
+            "A reboot or driver reload is required before this takes effect.",
+            ControlAppearance.Success,
+            new SymbolIcon(SymbolRegular.CheckmarkCircle24),
+            TimeSpan.FromSeconds(6)
+        );
+    }
+
+    public void ShowDriverIpcDisabledMessage()
+    {
+        _snackbarService.Show(
+            "Driver IPC disabled",
+            "A reboot or driver reload is required before this takes effect.",
+            ControlAppearance.Success,
+            new SymbolIcon(SymbolRegular.CheckmarkCircle24),
+            TimeSpan.FromSeconds(6)
+        );
+    }
+
+    public void ShowDriverIpcChangeFailedMessage()
+    {
+        _snackbarService.Show(
+            "Failed to update driver IPC",
+            "Run as Administrator and confirm DsHidMini is installed.",
+            ControlAppearance.Danger,
+            new SymbolIcon(SymbolRegular.DismissCircle24),
+            TimeSpan.FromSeconds(6)
+        );
+    }
+
     public void ShowDefenderBtSwitchedToPs3ModeMessage()
     {
         _snackbarService.Show(

--- a/ControlApp/Services/DshmIpcStatusService.cs
+++ b/ControlApp/Services/DshmIpcStatusService.cs
@@ -1,0 +1,143 @@
+using Nefarius.DsHidMini.ControlApp.Models.Drivers;
+
+using Wpf.Ui.Controls;
+
+namespace Nefarius.DsHidMini.ControlApp.Services;
+
+/// <summary>
+///     Reports and updates the experimental driver IPCEnabled registry flag.
+/// </summary>
+public partial class DshmIpcStatusService : ObservableObject
+{
+    private readonly Func<bool> _isElevatedProbe;
+    private readonly IDshmDriverParametersStore _store;
+
+    public DshmIpcStatusService()
+        : this(new DshmDriverParametersStore(), static () => SecurityUtil.IsElevated)
+    {
+    }
+
+    internal DshmIpcStatusService(IDshmDriverParametersStore store, Func<bool> isElevated)
+    {
+        _store = store;
+        _isElevatedProbe = isElevated;
+    }
+
+    [ObservableProperty]
+    private bool _canDisable;
+
+    [ObservableProperty]
+    private bool _canEnable;
+
+    [ObservableProperty]
+    private bool _isElevated;
+
+    [ObservableProperty]
+    private bool _isEnabled;
+
+    [ObservableProperty]
+    private bool _isStateKnown;
+
+    [ObservableProperty]
+    private InfoBarSeverity _severity = InfoBarSeverity.Informational;
+
+    [ObservableProperty]
+    private string _stateDisplay = "Unknown";
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private string _statusTitle = string.Empty;
+
+    /// <summary>
+    ///     Re-reads elevation and the stored IPCEnabled value.
+    /// </summary>
+    public void Refresh()
+    {
+        IsElevated = _isElevatedProbe();
+
+        if (!_store.TryReadIpcEnabled(out int? value))
+        {
+            IsStateKnown = false;
+            IsEnabled = false;
+        }
+        else
+        {
+            IsStateKnown = true;
+            IsEnabled = value is > 0;
+        }
+
+        CanEnable = IsElevated && IsStateKnown && !IsEnabled;
+        CanDisable = IsElevated && IsStateKnown && IsEnabled;
+        StateDisplay = !IsStateKnown
+            ? "Unknown"
+            : IsEnabled
+                ? "Enabled"
+                : "Disabled";
+
+        ApplyStatus();
+    }
+
+    /// <summary>
+    ///     Writes IPCEnabled as a DWORD and refreshes the displayed state.
+    /// </summary>
+    public bool TrySetEnabled(bool enabled)
+    {
+        if (!_isElevatedProbe())
+        {
+            Refresh();
+            return false;
+        }
+
+        try
+        {
+            _store.WriteIpcEnabled(enabled ? 1 : 0);
+            Refresh();
+            return IsStateKnown && IsEnabled == enabled;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Error(ex, "Failed to update DsHidMini IPCEnabled.");
+            Refresh();
+            return false;
+        }
+    }
+
+    private void ApplyStatus()
+    {
+        if (!IsStateKnown)
+        {
+            SetStatus(
+                InfoBarSeverity.Warning,
+                "Driver IPC state could not be read",
+                "Could not read IPCEnabled from the DsHidMini driver parameters.");
+            return;
+        }
+
+        if (IsEnabled)
+        {
+            SetStatus(
+                InfoBarSeverity.Warning,
+                "Experimental driver IPC is enabled",
+                IsElevated
+                    ? "IPC is still experimental. A reboot or driver reload is required after changing this setting."
+                    : "IPC is still experimental. Restart as Administrator to change this setting. A reboot or driver reload is required after a change.");
+            return;
+        }
+
+        SetStatus(
+            InfoBarSeverity.Informational,
+            "Experimental driver IPC is disabled",
+            IsElevated
+                ? "The driver keeps IPC off unless IPCEnabled is set to 1. A reboot or driver reload is required after changing this setting."
+                : "The driver keeps IPC off unless IPCEnabled is set to 1. Restart as Administrator to change this setting.");
+    }
+
+    private void SetStatus(InfoBarSeverity severity, string title, string message)
+    {
+        Severity = severity;
+        StatusTitle = title;
+        StatusMessage = message;
+    }
+}

--- a/ControlApp/Services/DshmIpcStatusService.cs
+++ b/ControlApp/Services/DshmIpcStatusService.cs
@@ -65,7 +65,7 @@ public partial class DshmIpcStatusService : ObservableObject
         else
         {
             IsStateKnown = true;
-            IsEnabled = value is > 0;
+            IsEnabled = value.GetValueOrDefault() != 0;
         }
 
         CanEnable = IsElevated && IsStateKnown && !IsEnabled;

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -20,14 +20,18 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     public SettingsViewModel(
         DshmConfigManager dshmConfigManager,
         BthPS3StatusService bthPs3,
+        DshmIpcStatusService driverIpc,
         AppSnackbarMessagesService appSnackbarMessagesService)
     {
         _dshmConfigManager = dshmConfigManager;
         BthPs3 = bthPs3;
+        DriverIpc = driverIpc;
         _appSnackbarMessagesService = appSnackbarMessagesService;
     }
 
     public BthPS3StatusService BthPs3 { get; }
+
+    public DshmIpcStatusService DriverIpc { get; }
 
     /// <summary>
     ///     When enabled (default), the driver requests a self restart on a HID mode mismatch instead of requiring a
@@ -118,6 +122,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         }
 
         BthPs3.Refresh();
+        DriverIpc.Refresh();
 
         return Task.CompletedTask;
     }
@@ -179,6 +184,38 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         else
         {
             _appSnackbarMessagesService.ShowBthPS3SettingsRectifyFailedMessage();
+        }
+    }
+
+    [RelayCommand]
+    private void RefreshDriverIpc()
+    {
+        DriverIpc.Refresh();
+    }
+
+    [RelayCommand]
+    private void EnableDriverIpc()
+    {
+        if (DriverIpc.TrySetEnabled(true))
+        {
+            _appSnackbarMessagesService.ShowDriverIpcEnabledMessage();
+        }
+        else
+        {
+            _appSnackbarMessagesService.ShowDriverIpcChangeFailedMessage();
+        }
+    }
+
+    [RelayCommand]
+    private void DisableDriverIpc()
+    {
+        if (DriverIpc.TrySetEnabled(false))
+        {
+            _appSnackbarMessagesService.ShowDriverIpcDisabledMessage();
+        }
+        else
+        {
+            _appSnackbarMessagesService.ShowDriverIpcChangeFailedMessage();
         }
     }
 }

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -51,6 +51,34 @@
             <ui:TextBlock
                 Margin="0,28,0,8"
                 FontTypography="Subtitle"
+                Text="Experimental driver IPC" />
+            <ui:InfoBar
+                Title="{Binding ViewModel.DriverIpc.StatusTitle}"
+                IsClosable="False"
+                IsOpen="True"
+                Message="{Binding ViewModel.DriverIpc.StatusMessage}"
+                Severity="{Binding ViewModel.DriverIpc.Severity}" />
+            <TextBlock
+                Margin="0,12,0,12"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="{Binding ViewModel.DriverIpc.StateDisplay, StringFormat=Registry state: {0}}" />
+            <StackPanel Margin="0,0,0,8" Orientation="Horizontal">
+                <ui:Button
+                    Margin="0,0,8,0"
+                    Command="{Binding ViewModel.EnableDriverIpcCommand}"
+                    Content="Enable"
+                    IsEnabled="{Binding ViewModel.DriverIpc.CanEnable}" />
+                <ui:Button
+                    Margin="0,0,8,0"
+                    Command="{Binding ViewModel.DisableDriverIpcCommand}"
+                    Content="Disable"
+                    IsEnabled="{Binding ViewModel.DriverIpc.CanDisable}" />
+                <ui:Button Command="{Binding ViewModel.RefreshDriverIpcCommand}" Content="Refresh" />
+            </StackPanel>
+
+            <ui:TextBlock
+                Margin="0,28,0,8"
+                FontTypography="Subtitle"
                 Text="Bluetooth (BthPS3)" />
             <ui:InfoBar
                 Title="{Binding ViewModel.BthPs3.StatusTitle}"


### PR DESCRIPTION
Users can check, enable, or disable IPCEnabled without a manual HKLM registry edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental driver IPC controls to Settings, including status visibility and Enable, Disable, and Refresh actions.
  * Added status handling for enabled, disabled, unknown, and failed driver IPC states.
  * Added notifications explaining successful changes, required restarts, and failure conditions.
  * Prevented IPC changes when administrator privileges are unavailable.

* **Documentation**
  * Updated Settings and administrator-restart guidance for driver IPC configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->