### PR TITLE
Show the configured Bluetooth output channel on the device Info tab.

### DIFF
--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows;
 
 using Nefarius.DsHidMini.ControlApp.Models;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
+using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.DshmConfig.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.Util;
@@ -158,6 +159,13 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     ///     The Hid Mode the device is expected to be based on the device's user data
     /// </summary>
     public SettingsContext ExpectedHidMode => _dshmConfigManager.GetDeviceExpectedHidMode(_deviceUserData);
+
+    /// <summary>
+    ///     Configured Bluetooth HID channel used to send output reports (LEDs/rumble).
+    ///     Resolved from custom, profile, or global settings, or the Control default.
+    /// </summary>
+    public BluetoothOutputReportTransport BluetoothOutputReportTransport =>
+        _dshmConfigManager.ResolveEffectiveSettings(_deviceUserData).OutputReport.BluetoothOutputReportTransport;
 
 
     /// <summary>
@@ -641,6 +649,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         AdjustSettingsTabState();
         OnPropertyChanged(nameof(DeviceSettingsStatus));
         OnPropertyChanged(nameof(IsHidModeMismatched));
+        OnPropertyChanged(nameof(BluetoothOutputReportTransport));
         await RefreshXInputSlotLabelAsync();
     }
 

--- a/ControlApp/Views/UserControls/DeviceUserControl.xaml
+++ b/ControlApp/Views/UserControls/DeviceUserControl.xaml
@@ -207,6 +207,18 @@
                                 DockPanel.Dock="Right"
                                 Text="{Binding HidEmulationMode, Mode=OneWay}" />
                         </DockPanel>
+                        <!--  Configured Bluetooth output channel (USB and Bluetooth)  -->
+                        <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
+                            <ui:TextBlock
+                                DockPanel.Dock="Left"
+                                Style="{StaticResource MyKey_InfoDescriptionTextbox}"
+                                Text="Bluetooth output channel:" />
+                            <ui:TextBlock
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                DockPanel.Dock="Right"
+                                Text="{Binding BluetoothOutputReportTransport, Mode=OneWay}" />
+                        </DockPanel>
                         <!--  XInput player slot (XInput HID mode only)  -->
                         <DockPanel
                             Margin="{StaticResource MyKey_NextLineSpacement}"


### PR DESCRIPTION
Resolve the effective per-device setting so USB and Bluetooth connections both display Control or Interrupt without requiring the Configure editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Device Info display showing the configured Bluetooth output channel for USB and Bluetooth devices.
  * The displayed value now updates when device settings are refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->