### PR TITLE
Store ControlApp settings under ProgramData\DsHidMini and migrate the…

### DIFF
--- a/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
+++ b/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
@@ -220,6 +220,25 @@ public class UserDataLocationMigrationTests : IDisposable
     }
 
     [Fact]
+    public void MigratesLegacyArtifacts_AndRemovesEmptyLegacyDirectory()
+    {
+        Directory.CreateDirectory(LegacyDir);
+        File.WriteAllText(LegacyFile, """{"SchemaVersion":1}""");
+        string corruptName = "DshmUserData.json.corrupt-20260101120000";
+        string tmpName = "DshmUserData.json.tmp";
+        File.WriteAllText(Path.Combine(LegacyDir, corruptName), "broken");
+        File.WriteAllText(Path.Combine(LegacyDir, tmpName), "tmp");
+
+        DshmConfigLocations locations = DshmConfigLocations.CreateDefault(ProgramData, DriverDir);
+
+        Assert.Equal(Path.GetFullPath(PreferredDir), locations.UserDataDirectory);
+        Assert.Equal("""{"SchemaVersion":1}""", File.ReadAllText(PreferredFile));
+        Assert.Equal("broken", File.ReadAllText(Path.Combine(PreferredDir, corruptName)));
+        Assert.Equal("tmp", File.ReadAllText(Path.Combine(PreferredDir, tmpName)));
+        Assert.False(Directory.Exists(LegacyDir));
+    }
+
+    [Fact]
     public void NoLegacyData_UsesPreferredDirectory()
     {
         DshmConfigLocations locations = DshmConfigLocations.CreateDefault(ProgramData, DriverDir);

--- a/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
+++ b/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
@@ -174,3 +174,89 @@ public class ConfigMigrationAndLifecycleTests : IDisposable
     private DshmConfigManager CreateManager() =>
         new(new DshmConfigLocations(UserDir, DriverDir));
 }
+
+public class UserDataLocationMigrationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "dshm-loc-" + Guid.NewGuid().ToString("N"));
+
+    public UserDataLocationMigrationTests()
+    {
+        Directory.CreateDirectory(ProgramData);
+        Directory.CreateDirectory(DriverDir);
+    }
+
+    private string ProgramData => _root;
+    private string DriverDir => Path.Combine(_root, "DsHidMini");
+    private string PreferredDir => Path.Combine(DriverDir, "ControlApp");
+    private string LegacyDir => Path.Combine(ProgramData, "ControlApp");
+    private string PreferredFile => Path.Combine(PreferredDir, "DshmUserData.json");
+    private string LegacyFile => Path.Combine(LegacyDir, "DshmUserData.json");
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void MigratesLegacyFile_AndRemovesEmptyLegacyDirectory()
+    {
+        Directory.CreateDirectory(LegacyDir);
+        File.WriteAllText(LegacyFile, """{"SchemaVersion":1}""");
+
+        DshmConfigLocations locations = DshmConfigLocations.CreateDefault(ProgramData, DriverDir);
+
+        Assert.Equal(Path.GetFullPath(PreferredDir), locations.UserDataDirectory);
+        Assert.True(File.Exists(PreferredFile));
+        Assert.Equal("""{"SchemaVersion":1}""", File.ReadAllText(PreferredFile));
+        Assert.False(File.Exists(LegacyFile));
+        Assert.False(Directory.Exists(LegacyDir));
+    }
+
+    [Fact]
+    public void NoLegacyData_UsesPreferredDirectory()
+    {
+        DshmConfigLocations locations = DshmConfigLocations.CreateDefault(ProgramData, DriverDir);
+
+        Assert.Equal(Path.GetFullPath(PreferredDir), locations.UserDataDirectory);
+        Assert.False(File.Exists(PreferredFile));
+        Assert.False(File.Exists(LegacyFile));
+    }
+
+    [Fact]
+    public void ExistingDestination_IsAuthoritative_AndIdempotent()
+    {
+        Directory.CreateDirectory(LegacyDir);
+        Directory.CreateDirectory(PreferredDir);
+        File.WriteAllText(LegacyFile, """{"SchemaVersion":1,"Source":"legacy"}""");
+        File.WriteAllText(PreferredFile, """{"SchemaVersion":1,"Source":"preferred"}""");
+
+        DshmConfigLocations first = DshmConfigLocations.CreateDefault(ProgramData, DriverDir);
+        DshmConfigLocations second = DshmConfigLocations.CreateDefault(ProgramData, DriverDir);
+
+        Assert.Equal(Path.GetFullPath(PreferredDir), first.UserDataDirectory);
+        Assert.Equal(first.UserDataDirectory, second.UserDataDirectory);
+        Assert.Equal("""{"SchemaVersion":1,"Source":"preferred"}""", File.ReadAllText(PreferredFile));
+        Assert.True(File.Exists(LegacyFile));
+    }
+
+    [Fact]
+    public void FailedMove_FallsBackToLegacyDirectory()
+    {
+        Directory.CreateDirectory(LegacyDir);
+        File.WriteAllText(LegacyFile, """{"SchemaVersion":1}""");
+        File.WriteAllText(PreferredDir, "blocked");
+
+        DshmConfigLocations locations = DshmConfigLocations.CreateDefault(ProgramData, DriverDir);
+
+        Assert.Equal(Path.GetFullPath(LegacyDir), locations.UserDataDirectory);
+        Assert.True(File.Exists(LegacyFile));
+        Assert.Equal("""{"SchemaVersion":1}""", File.ReadAllText(LegacyFile));
+    }
+}

--- a/ControlApp/Models/DshmConfigManager/DshmConfigLocations.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfigLocations.cs
@@ -22,8 +22,29 @@ internal sealed class DshmConfigLocations
     public string DriverConfigFilePath =>
         DshmConfigSerialization.GetDriverConfigFilePath(DriverConfigDirectory);
 
-    public static DshmConfigLocations Default { get; } = new(
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            DshmConfigManagerUserData.GlobalUserDataFolderName),
-        DshmConfigSerialization.GetDriverConfigDirectory());
+    private static readonly Lazy<DshmConfigLocations> DefaultLazy = new(() => CreateDefault());
+
+    public static DshmConfigLocations Default => DefaultLazy.Value;
+
+    internal static DshmConfigLocations CreateDefault(
+        string? programDataDirectory = null,
+        string? driverConfigDirectory = null)
+    {
+        string programData = programDataDirectory
+                             ?? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        string driverDirectory = driverConfigDirectory
+                                 ?? DshmConfigSerialization.GetDriverConfigDirectory();
+        string preferredUserDataDirectory = Path.Combine(
+            driverDirectory,
+            DshmConfigManagerUserData.GlobalUserDataFolderName);
+        string legacyUserDataDirectory = Path.Combine(
+            programData,
+            DshmConfigManagerUserData.GlobalUserDataFolderName);
+
+        return new DshmConfigLocations(
+            DshmUserDataLocationMigration.ResolveUserDataDirectory(
+                preferredUserDataDirectory,
+                legacyUserDataDirectory),
+            driverDirectory);
+    }
 }

--- a/ControlApp/Models/DshmConfigManager/DshmUserDataLocationMigration.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmUserDataLocationMigration.cs
@@ -1,0 +1,75 @@
+using System.IO;
+
+namespace Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
+
+/// <summary>
+///     One-time move of ControlApp user data from the legacy ProgramData folder into
+///     <c>%ProgramData%\DsHidMini\ControlApp</c>.
+/// </summary>
+internal static class DshmUserDataLocationMigration
+{
+    public static string ResolveUserDataDirectory(string preferredDirectory, string legacyDirectory)
+    {
+        string preferredFull = Path.GetFullPath(preferredDirectory);
+        string legacyFull = Path.GetFullPath(legacyDirectory);
+        if (string.Equals(preferredFull, legacyFull, StringComparison.OrdinalIgnoreCase))
+        {
+            return preferredFull;
+        }
+
+        string preferredFile = UserDataFilePath(preferredFull);
+        string legacyFile = UserDataFilePath(legacyFull);
+
+        if (File.Exists(preferredFile))
+        {
+            TryDeleteEmptyDirectory(legacyFull);
+            return preferredFull;
+        }
+
+        if (!File.Exists(legacyFile))
+        {
+            TryDeleteEmptyDirectory(legacyFull);
+            return preferredFull;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(preferredFull);
+            File.Move(legacyFile, preferredFile);
+            Log.Logger.Information(
+                "Migrated ControlApp user data from {LegacyPath} to {PreferredPath}.",
+                legacyFile, preferredFile);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Log.Logger.Error(ex,
+                "Failed to migrate ControlApp user data from {LegacyPath} to {PreferredPath}. Using the legacy location for this run.",
+                legacyFile, preferredFile);
+            return legacyFull;
+        }
+
+        TryDeleteEmptyDirectory(legacyFull);
+        return preferredFull;
+    }
+
+    private static string UserDataFilePath(string directory) =>
+        Path.Combine(directory, DshmConfigManagerUserData.GlobalUserDataFileName + ".json");
+
+    private static void TryDeleteEmptyDirectory(string directory)
+    {
+        try
+        {
+            if (!Directory.Exists(directory) || Directory.EnumerateFileSystemEntries(directory).Any())
+            {
+                return;
+            }
+
+            Directory.Delete(directory);
+            Log.Logger.Debug("Removed empty leftover ControlApp directory {Directory}.", directory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Log.Logger.Warning(ex, "Failed to remove leftover ControlApp directory {Directory}.", directory);
+        }
+    }
+}

--- a/ControlApp/Models/DshmConfigManager/DshmUserDataLocationMigration.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmUserDataLocationMigration.cs
@@ -8,6 +8,9 @@ namespace Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 /// </summary>
 internal static class DshmUserDataLocationMigration
 {
+    private static readonly string UserDataFileName =
+        DshmConfigManagerUserData.GlobalUserDataFileName + ".json";
+
     public static string ResolveUserDataDirectory(string preferredDirectory, string legacyDirectory)
     {
         string preferredFull = Path.GetFullPath(preferredDirectory);
@@ -22,12 +25,14 @@ internal static class DshmUserDataLocationMigration
 
         if (File.Exists(preferredFile))
         {
+            TryMigrateSidecarArtifacts(legacyFull, preferredFull);
             TryDeleteEmptyDirectory(legacyFull);
             return preferredFull;
         }
 
         if (!File.Exists(legacyFile))
         {
+            TryMigrateSidecarArtifacts(legacyFull, preferredFull);
             TryDeleteEmptyDirectory(legacyFull);
             return preferredFull;
         }
@@ -48,12 +53,56 @@ internal static class DshmUserDataLocationMigration
             return legacyFull;
         }
 
+        TryMigrateSidecarArtifacts(legacyFull, preferredFull);
         TryDeleteEmptyDirectory(legacyFull);
         return preferredFull;
     }
 
     private static string UserDataFilePath(string directory) =>
-        Path.Combine(directory, DshmConfigManagerUserData.GlobalUserDataFileName + ".json");
+        Path.Combine(directory, UserDataFileName);
+
+    private static void TryMigrateSidecarArtifacts(string legacyDirectory, string preferredDirectory)
+    {
+        foreach (string sourcePath in EnumerateUserDataArtifacts(legacyDirectory))
+        {
+            string fileName = Path.GetFileName(sourcePath);
+            if (string.Equals(fileName, UserDataFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string destinationPath = Path.Combine(preferredDirectory, fileName);
+            if (File.Exists(destinationPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(preferredDirectory);
+                File.Move(sourcePath, destinationPath);
+                Log.Logger.Information(
+                    "Migrated ControlApp user-data artifact from {LegacyPath} to {PreferredPath}.",
+                    sourcePath, destinationPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Log.Logger.Warning(ex,
+                    "Failed to migrate ControlApp user-data artifact from {LegacyPath} to {PreferredPath}.",
+                    sourcePath, destinationPath);
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateUserDataArtifacts(string directory)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return [];
+        }
+
+        return Directory.EnumerateFiles(directory, UserDataFileName + "*");
+    }
 
     private static void TryDeleteEmptyDirectory(string directory)
     {


### PR DESCRIPTION
… legacy folder once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User data now uses the preferred application directory when available.
  * Existing legacy user data, including backup and temporary artifacts, is automatically migrated.
  * Existing data in the preferred location takes precedence.
  * Empty legacy directories are cleaned up after migration.
  * If migration cannot be completed, the application continues using the legacy location.

* **Bug Fixes**
  * Improved startup handling for user-data location selection and migration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->