### PR TITLE
Fix navigation controller status reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
         id: version
         shell: pwsh
         run: |
-          $buildVersion = "3.4.$([int]$env:BUILD_VERSION_OFFSET + ${{ github.run_number }}).0"
+          $buildVersion = "3.5.$([int]$env:BUILD_VERSION_OFFSET + ${{ github.run_number }}).0"
           echo "BUILD_VERSION=$buildVersion" >> $env:GITHUB_ENV
           echo "build-version=$buildVersion" >> $env:GITHUB_OUTPUT
           Write-Output "Building version $buildVersion"

--- a/ControlApp.Tests/NavigationStatusRegressionTests.cs
+++ b/ControlApp.Tests/NavigationStatusRegressionTests.cs
@@ -1,0 +1,40 @@
+using Nefarius.DsHidMini.ControlApp.Models;
+using Nefarius.DsHidMini.IPC.Models.Drivers;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class NavigationStatusRegressionTests
+{
+    [Theory]
+    [InlineData(@"USB\VID_054C&PID_042F\6&4B29C3C&0&2")]
+    [InlineData(@"BTHPS3BUS\{206F84FC-1615-4D9F-954D-21F5A5D388C5}&Dev&VID_054C&PID_042F")]
+    public void FromInstanceId_NavigationIds_AreRecognized(string instanceId)
+    {
+        Assert.Equal(DsDeviceType.Navigation, DsDeviceCapabilities.FromInstanceId(instanceId));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(@"USB\VID_054C&PID_ZZZZ")]
+    [InlineData(@"USB\VID_1234&PID_042F")]
+    public void FromInstanceId_InvalidOrUnsupportedIds_AreUnknown(string? instanceId)
+    {
+        Assert.Equal(DsDeviceType.Unknown, DsDeviceCapabilities.FromInstanceId(instanceId));
+    }
+
+    [Theory]
+    [InlineData(0x00, DsBatteryStatus.Unknown)]
+    [InlineData(0x05, DsBatteryStatus.Full)]
+    [InlineData(0x06, DsBatteryStatus.Unknown)]
+    [InlineData(0xEE, DsBatteryStatus.Charging)]
+    [InlineData(0xEF, DsBatteryStatus.Charged)]
+    [InlineData(0xF0, DsBatteryStatus.Charging)]
+    [InlineData(0xF1, DsBatteryStatus.Charged)]
+    public void NormalizeBatteryStatus_UsesSonyChargingBit(byte rawStatus, DsBatteryStatus expected)
+    {
+        Assert.Equal(expected, DsDeviceCapabilities.NormalizeBatteryStatus(rawStatus));
+    }
+}

--- a/ControlApp/Models/DsDeviceCapabilities.cs
+++ b/ControlApp/Models/DsDeviceCapabilities.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 using Nefarius.DsHidMini.IPC.Models.Drivers;
 
 namespace Nefarius.DsHidMini.ControlApp.Models;
@@ -25,6 +27,46 @@ public static class DsDeviceCapabilities
             SixaxisProductId => DsDeviceType.Sixaxis,
             _ => DsDeviceType.Unknown
         };
+    }
+
+    public static DsDeviceType FromInstanceId(string? instanceId)
+    {
+        return TryReadHexId(instanceId, "VID_", out ushort vendorId) &&
+               TryReadHexId(instanceId, "PID_", out ushort productId)
+            ? FromHardwareIds(vendorId, productId)
+            : DsDeviceType.Unknown;
+    }
+
+    private static bool TryReadHexId(string? instanceId, string marker, out ushort value)
+    {
+        value = 0;
+        if (string.IsNullOrEmpty(instanceId))
+        {
+            return false;
+        }
+
+        int markerIndex = instanceId.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        int valueIndex = markerIndex + marker.Length;
+        return markerIndex >= 0 &&
+               instanceId.Length >= valueIndex + 4 &&
+               ushort.TryParse(instanceId.AsSpan(valueIndex, 4), NumberStyles.AllowHexSpecifier,
+                   CultureInfo.InvariantCulture, out value);
+    }
+
+    public static DsBatteryStatus NormalizeBatteryStatus(byte rawStatus)
+    {
+        // Linux hid-sony applies the same rule: Sony controllers can use values
+        // above 0xEF, where the low bit still distinguishes charged from charging.
+        if (rawStatus >= (byte)DsBatteryStatus.Charging)
+        {
+            return (rawStatus & 0x01) == 0
+                ? DsBatteryStatus.Charging
+                : DsBatteryStatus.Charged;
+        }
+
+        return rawStatus <= (byte)DsBatteryStatus.Full
+            ? (DsBatteryStatus)rawStatus
+            : DsBatteryStatus.Unknown;
     }
 
     public static bool HasRumble(DsDeviceType type) => type != DsDeviceType.Navigation;

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.NetworkInformation;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Windows;
 
@@ -207,12 +207,19 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         {
             try
             {
-                return (DsDeviceType)Device.GetProperty<byte>(DsHidMiniDriver.DeviceTypeProperty);
+                DsDeviceType publishedType =
+                    (DsDeviceType)Device.GetProperty<byte>(DsHidMiniDriver.DeviceTypeProperty);
+                if (publishedType != DsDeviceType.Unknown)
+                {
+                    return publishedType;
+                }
             }
             catch (Exception)
             {
-                return DsDeviceType.Unknown;
+                // Older driver builds do not publish DeviceTypeProperty.
             }
+
+            return DsDeviceCapabilities.FromInstanceId(Device.InstanceId);
         }
     }
 
@@ -338,14 +345,13 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     /// <summary>
     ///     Current battery status.
     /// </summary>
-    public DsBatteryStatus BatteryStatus =>
-        (DsBatteryStatus)Device.GetProperty<byte>(DsHidMiniDriver.BatteryStatusProperty);
+    public DsBatteryStatus BatteryStatus => DsDeviceCapabilities.NormalizeBatteryStatus(
+        Device.GetProperty<byte>(DsHidMiniDriver.BatteryStatusProperty));
 
     /// <summary>
     ///     String representation of current battery status
     /// </summary>
-    public string BatteryStatusInText =>
-        ((DsBatteryStatus)Device.GetProperty<byte>(DsHidMiniDriver.BatteryStatusProperty)).ToString();
+    public string BatteryStatusInText => BatteryStatus.ToString();
 
     /// <summary>
     ///     Return a battery icon depending on the charge.

--- a/driver/DsHidMiniDrv.c
+++ b/driver/DsHidMiniDrv.c
@@ -12,6 +12,29 @@ PWSTR G_DsHidMini_Strings[] =
 #define DSHIDMINI_XBOX_PRODUCT_STRING    L"Controller (Xbox One For Windows)"
 #define DSHIDMINI_SERIAL_NUMBER_STRING   L"" // TODO: use device address?
 
+static
+DS_BATTERY_STATUS
+DSHM_NormalizeBatteryStatus(
+	UCHAR RawStatus
+)
+{
+	//
+	// Sony's hid-sony driver applies the same rule. Navigation Controllers
+	// can report values such as 0xF1: values from 0xEE upwards use the low
+	// bit to distinguish charging (even) from charged (odd).
+	//
+	if (RawStatus >= DsBatteryStatusCharging)
+	{
+		return (RawStatus & 0x01) != 0
+			? DsBatteryStatusCharged
+			: DsBatteryStatusCharging;
+	}
+
+	return RawStatus <= DsBatteryStatusFull
+		? (DS_BATTERY_STATUS)RawStatus
+		: DsBatteryStatusNone;
+}
+
 
 // This macro declares the following function:
 // DMF_CONTEXT_GET()
@@ -801,7 +824,7 @@ VOID DsUsb_EvtUsbInterruptPipeReadComplete(
 	// under the reference that function already takes.
 	// 
 
-	battery = (DS_BATTERY_STATUS)pInReport->BatteryStatus;
+	battery = DSHM_NormalizeBatteryStatus(pInReport->BatteryStatus);
 
 	//
 	// Capture the previous value before it gets overwritten below, so both
@@ -963,7 +986,7 @@ DsBth_HidInterruptReadContinuousRequestCompleted(
 	//
 	// Grab battery info
 	// 
-	battery = (DS_BATTERY_STATUS)pInReport->BatteryStatus;
+	battery = DSHM_NormalizeBatteryStatus(pInReport->BatteryStatus);
 
 	//
 	// React if last known state differs from current state


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device recognition when driver-reported device information is unavailable or unknown.
  * Devices can now be identified from supported instance IDs, while invalid or unsupported identifiers remain unknown.
  * Corrected Sony controller battery status reporting to distinguish charging and fully charged states more reliably over USB and Bluetooth.
  * Invalid battery values are now reported as unavailable rather than producing misleading statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->