### PR TITLE
Stop restarting the Navigation charging LED flash.

### DIFF
--- a/driver/DsHidMiniDrv.c
+++ b/driver/DsHidMiniDrv.c
@@ -870,8 +870,14 @@ VOID DsUsb_EvtUsbInterruptPipeReadComplete(
 	// not actively drawing charge current (issue #365), so any change away
 	// from Charging needs the same LED refresh as a Charged transition
 	// gets.
+	//
+	// Navigation has one LED and uses a self-sustaining slow flash. The
+	// one-second chase tick would re-send the same report and restart the
+	// pad's flash cycle into a permanent on-phase. Let it fall through to
+	// the on-change refresh instead.
 	// 
-	if (battery == DsBatteryStatusCharging)
+	if (battery == DsBatteryStatusCharging &&
+		pDevCtx->DeviceType != DsDeviceTypeNavigation)
 	{
 		if (pDevCtx->Connection.Usb.ChargingCycleTimestamp.QuadPart == 0)
 		{

--- a/driver/DsLed.c
+++ b/driver/DsLed.c
@@ -413,13 +413,13 @@ DsLed_AdvanceChargingAnimation(
 		}
 
 		//
-		// Navigation has one LED; charging is a slow flash, not the
-		// four-LED USB chase used on DualShock 3 (issue #48).
+		// Navigation charging is a self-sustaining slow flash applied once
+		// on status change. Re-sending here would restart the pad's flash
+		// cycle. USB input no longer ticks this function for Navigation;
+		// keep the branch as a defensive no-send.
 		// 
 		if (Context->DeviceType == DsDeviceTypeNavigation)
 		{
-			DsLedApplyBatteryIndicatorLocked(Context, FALSE);
-			(void)DSHM_SendOutputReportUnlocked(Context, Ds3OutputReportSourceDriverLowPriority);
 			break;
 		}
 


### PR DESCRIPTION
The USB chase tick re-sent the same slow-flash report every second and kept the pad on its on-phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved charging LED behavior for Navigation controllers by preventing repeated refreshes from interrupting their slow-flash cycle.
  * Preserved existing charging animation behavior for DualShock 3 controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->