### PR TITLE
Stop ControlApp crashing when user-data replace is denied.

### DIFF
--- a/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
+++ b/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
 
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.DshmConfig;
@@ -159,6 +161,52 @@ public class ConfigMigrationAndLifecycleTests : IDisposable
     }
 
     [Fact]
+    public void UserDataSave_WhenDeleteIsDenied_OverwritesExistingFile()
+    {
+        DshmConfigLocations locations = new(UserDir, DriverDir);
+        DshmConfigManagerUserData userData = DshmConfigManagerUserData.Load(locations);
+        userData.SchemaVersion = DshmConfigManagerUserData.CurrentSchemaVersion;
+        userData.AutoRestartOnHidModeMismatch = true;
+        userData.Save(locations);
+
+        userData.AutoRestartOnHidModeMismatch = false;
+        using (DenyFileDelete(locations.UserDataFilePath))
+        {
+            userData.Save(locations);
+        }
+
+        DshmConfigManagerUserData reloaded = DshmConfigManagerUserData.Load(locations);
+        Assert.False(reloaded.AutoRestartOnHidModeMismatch);
+        Assert.False(File.Exists(locations.UserDataFilePath + ".tmp"));
+    }
+
+    [Fact]
+    public void SaveChangesAndUpdate_WhenUserDataWriteFails_RestoresMemoryAndReportsFailure()
+    {
+        DshmConfigLocations locations = new(UserDir, DriverDir);
+        DshmConfigManagerUserData userData = DshmConfigManagerUserData.Load(locations);
+        userData.SchemaVersion = DshmConfigManagerUserData.CurrentSchemaVersion;
+        userData.AutoRestartOnHidModeMismatch = true;
+        userData.Save(locations);
+        string original = File.ReadAllText(locations.UserDataFilePath);
+
+        DshmConfigManager manager = new(userData, locations);
+        manager.AutoRestartOnHidModeMismatch = false;
+
+        File.SetAttributes(locations.UserDataFilePath, FileAttributes.ReadOnly);
+        try
+        {
+            Assert.False(manager.SaveChangesAndUpdateDsHidMiniConfigFile());
+            Assert.True(manager.AutoRestartOnHidModeMismatch);
+            Assert.Equal(original, File.ReadAllText(locations.UserDataFilePath));
+        }
+        finally
+        {
+            File.SetAttributes(locations.UserDataFilePath, FileAttributes.Normal);
+        }
+    }
+
+    [Fact]
     public void UserData_CorruptFile_IsBackedUp()
     {
         string userFile = Path.Combine(UserDir, "DshmUserData.json");
@@ -173,6 +221,38 @@ public class ConfigMigrationAndLifecycleTests : IDisposable
 
     private DshmConfigManager CreateManager() =>
         new(new DshmConfigLocations(UserDir, DriverDir));
+
+    private static RestoreFileSecurity DenyFileDelete(string path)
+    {
+        FileInfo info = new(path);
+        FileSecurity original = info.GetAccessControl();
+        FileSecurity modified = info.GetAccessControl();
+        SecurityIdentifier user = WindowsIdentity.GetCurrent().User
+                                  ?? throw new InvalidOperationException("Current Windows user SID is unavailable.");
+        modified.AddAccessRule(new FileSystemAccessRule(
+            user,
+            FileSystemRights.Delete,
+            AccessControlType.Deny));
+        info.SetAccessControl(modified);
+        return new RestoreFileSecurity(info, original);
+    }
+
+    private sealed class RestoreFileSecurity : IDisposable
+    {
+        private readonly FileInfo _info;
+        private readonly FileSecurity _original;
+
+        public RestoreFileSecurity(FileInfo info, FileSecurity original)
+        {
+            _info = info;
+            _original = original;
+        }
+
+        public void Dispose()
+        {
+            _info.SetAccessControl(_original);
+        }
+    }
 }
 
 public class UserDataLocationMigrationTests : IDisposable

--- a/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
+++ b/ControlApp.Tests/ConfigMigrationAndLifecycleTests.cs
@@ -170,9 +170,13 @@ public class ConfigMigrationAndLifecycleTests : IDisposable
         userData.Save(locations);
 
         userData.AutoRestartOnHidModeMismatch = false;
-        using (DenyFileDelete(locations.UserDataFilePath))
+        using (DenyFileReplacement(locations.UserDataFilePath))
         {
+            string accessSddl = GetAccessSddl(locations.UserDataFilePath);
+            Assert.True(HasExplicitDeleteDenial(locations.UserDataFilePath));
             userData.Save(locations);
+            Assert.Equal(accessSddl, GetAccessSddl(locations.UserDataFilePath));
+            Assert.True(HasExplicitDeleteDenial(locations.UserDataFilePath));
         }
 
         DshmConfigManagerUserData reloaded = DshmConfigManagerUserData.Load(locations);
@@ -222,35 +226,78 @@ public class ConfigMigrationAndLifecycleTests : IDisposable
     private DshmConfigManager CreateManager() =>
         new(new DshmConfigLocations(UserDir, DriverDir));
 
-    private static RestoreFileSecurity DenyFileDelete(string path)
+    private static string GetAccessSddl(string path) =>
+        new FileInfo(path).GetAccessControl().GetSecurityDescriptorSddlForm(AccessControlSections.Access);
+
+    private static bool HasExplicitDeleteDenial(string path)
     {
-        FileInfo info = new(path);
-        FileSecurity original = info.GetAccessControl();
-        FileSecurity modified = info.GetAccessControl();
-        SecurityIdentifier user = WindowsIdentity.GetCurrent().User
-                                  ?? throw new InvalidOperationException("Current Windows user SID is unavailable.");
-        modified.AddAccessRule(new FileSystemAccessRule(
+        SecurityIdentifier user = CurrentUserSid();
+        AuthorizationRuleCollection rules = new FileInfo(path)
+            .GetAccessControl()
+            .GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier));
+
+        return rules
+            .OfType<FileSystemAccessRule>()
+            .Any(rule =>
+                rule.IdentityReference.Equals(user)
+                && rule.AccessControlType == AccessControlType.Deny
+                && rule.FileSystemRights.HasFlag(FileSystemRights.Delete));
+    }
+
+    private static RestoreReplacementDenial DenyFileReplacement(string path)
+    {
+        FileInfo file = new(path);
+        DirectoryInfo directory = file.Directory
+                                  ?? throw new InvalidOperationException("User data file has no parent directory.");
+        FileSecurity originalFile = file.GetAccessControl();
+        DirectorySecurity originalDirectory = directory.GetAccessControl();
+        SecurityIdentifier user = CurrentUserSid();
+
+        FileSecurity fileSecurity = file.GetAccessControl();
+        fileSecurity.AddAccessRule(new FileSystemAccessRule(
             user,
             FileSystemRights.Delete,
             AccessControlType.Deny));
-        info.SetAccessControl(modified);
-        return new RestoreFileSecurity(info, original);
+        file.SetAccessControl(fileSecurity);
+
+        // File.Move can still replace a file through DELETE_CHILD on the parent directory.
+        DirectorySecurity directorySecurity = directory.GetAccessControl();
+        directorySecurity.AddAccessRule(new FileSystemAccessRule(
+            user,
+            FileSystemRights.DeleteSubdirectoriesAndFiles,
+            AccessControlType.Deny));
+        directory.SetAccessControl(directorySecurity);
+
+        return new RestoreReplacementDenial(file, originalFile, directory, originalDirectory);
     }
 
-    private sealed class RestoreFileSecurity : IDisposable
-    {
-        private readonly FileInfo _info;
-        private readonly FileSecurity _original;
+    private static SecurityIdentifier CurrentUserSid() =>
+        WindowsIdentity.GetCurrent().User
+        ?? throw new InvalidOperationException("Current Windows user SID is unavailable.");
 
-        public RestoreFileSecurity(FileInfo info, FileSecurity original)
+    private sealed class RestoreReplacementDenial : IDisposable
+    {
+        private readonly FileInfo _file;
+        private readonly FileSecurity _originalFile;
+        private readonly DirectoryInfo _directory;
+        private readonly DirectorySecurity _originalDirectory;
+
+        public RestoreReplacementDenial(
+            FileInfo file,
+            FileSecurity originalFile,
+            DirectoryInfo directory,
+            DirectorySecurity originalDirectory)
         {
-            _info = info;
-            _original = original;
+            _file = file;
+            _originalFile = originalFile;
+            _directory = directory;
+            _originalDirectory = originalDirectory;
         }
 
         public void Dispose()
         {
-            _info.SetAccessControl(_original);
+            _file.SetAccessControl(_originalFile);
+            _directory.SetAccessControl(_originalDirectory);
         }
     }
 }

--- a/ControlApp.Tests/ControlApp.Tests.csproj
+++ b/ControlApp.Tests/ControlApp.Tests.csproj
@@ -19,6 +19,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ControlApp/Models/DshmConfigManager/DshmConfigManager.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfigManager.cs
@@ -137,9 +137,21 @@ public class DshmConfigManager
     public bool SaveChangesAndUpdateDsHidMiniConfigFile()
     {
         string userDataPath = _locations.UserDataFilePath;
-        string? previousUserJson = File.Exists(userDataPath) ? File.ReadAllText(userDataPath) : null;
+        string? previousUserJson = null;
+        try
+        {
+            previousUserJson = File.Exists(userDataPath) ? File.ReadAllText(userDataPath) : null;
+            _userData.Save(_locations);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Log.Logger.Error(ex,
+                "Failed to persist ControlApp user data to {UserDataPath}.",
+                userDataPath);
+            RestoreUserDataMemory(previousUserJson);
+            return false;
+        }
 
-        _userData.Save(_locations);
         bool updated = ApplySettings();
         if (!updated)
         {

--- a/ControlApp/Models/DshmConfigManager/JsonDshmUserData.cs
+++ b/ControlApp/Models/DshmConfigManager/JsonDshmUserData.cs
@@ -84,7 +84,7 @@ public static class JsonDshmUserData
                 Log.Logger.Warning(ex,
                     "Atomic replace of User Data file {ConfigPath} failed. Falling back to in-place overwrite.",
                     configPath);
-                File.Copy(tempPath, configPath, overwrite: true);
+                OverwriteExistingFile(tempPath, configPath);
             }
         }
         finally
@@ -139,6 +139,14 @@ public static class JsonDshmUserData
         T config = new();
         Save(fileNameWithoutExtension, config, userDataDir);
         return config;
+    }
+
+    private static void OverwriteExistingFile(string sourcePath, string destinationPath)
+    {
+        using FileStream source = File.OpenRead(sourcePath);
+        using FileStream destination = new(destinationPath, FileMode.Open, FileAccess.Write, FileShare.Read);
+        destination.SetLength(0);
+        source.CopyTo(destination);
     }
 
     private static void TryDeleteTemporaryFile(string path)

--- a/ControlApp/Models/DshmConfigManager/JsonDshmUserData.cs
+++ b/ControlApp/Models/DshmConfigManager/JsonDshmUserData.cs
@@ -73,23 +73,23 @@ public static class JsonDshmUserData
         {
             File.WriteAllText(tempPath, JsonConvert.SerializeObject(configuration, Formatting.Indented, settings),
                 Encoding.UTF8);
-            File.Move(tempPath, configPath, overwrite: true);
-        }
-        catch
-        {
             try
             {
-                if (File.Exists(tempPath))
-                {
-                    File.Delete(tempPath);
-                }
+                File.Move(tempPath, configPath, overwrite: true);
             }
-            catch (Exception cleanupEx) when (cleanupEx is IOException or UnauthorizedAccessException)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                Log.Logger.Debug(cleanupEx, "Failed to delete temporary User Data file {TempPath}.", tempPath);
+                // ProgramData ACLs and in-use destinations can deny delete/replace while still
+                // allowing an in-place overwrite of the existing file.
+                Log.Logger.Warning(ex,
+                    "Atomic replace of User Data file {ConfigPath} failed. Falling back to in-place overwrite.",
+                    configPath);
+                File.Copy(tempPath, configPath, overwrite: true);
             }
-
-            throw;
+        }
+        finally
+        {
+            TryDeleteTemporaryFile(tempPath);
         }
     }
 
@@ -139,5 +139,20 @@ public static class JsonDshmUserData
         T config = new();
         Save(fileNameWithoutExtension, config, userDataDir);
         return config;
+    }
+
+    private static void TryDeleteTemporaryFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception cleanupEx) when (cleanupEx is IOException or UnauthorizedAccessException)
+        {
+            Log.Logger.Debug(cleanupEx, "Failed to delete temporary User Data file {TempPath}.", path);
+        }
     }
 }


### PR DESCRIPTION
Fall back to an in-place overwrite and report save failures instead of letting pairing hot-reload throw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving user settings, including when files or parent folders are protected from deletion.
  * Preserved existing configuration data when saving fails, preventing partial or inconsistent updates.
  * Prevented driver settings from being applied when user data cannot be saved successfully.
  * Improved fallback handling when overwriting existing configuration files while retaining their access protections.
  * Maintained temporary-file cleanup behavior during save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->