### PR TITLE
Implement remaining issue 379 IPC output commands.

### DIFF
--- a/ControlApp.Tests/IpcRuntimeOutputTests.cs
+++ b/ControlApp.Tests/IpcRuntimeOutputTests.cs
@@ -1,0 +1,93 @@
+using System.Runtime.InteropServices;
+
+using Nefarius.DsHidMini.IPC.Models;
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class IpcRuntimeOutputTests
+{
+    private const uint StatusSuccess = 0x00000000;
+    private const uint StatusAccessDenied = 0xC0000022;
+    private const uint StatusInvalidParameter = 0xC000000D;
+    private const uint StatusInvalidUserBuffer = 0xC00000E8;
+
+    [Theory]
+    [InlineData(1, Ds3PlayerLeds.Led1)]
+    [InlineData(2, Ds3PlayerLeds.Led2)]
+    [InlineData(3, Ds3PlayerLeds.Led3)]
+    [InlineData(4, Ds3PlayerLeds.Led4)]
+    [InlineData(5, Ds3PlayerLeds.Led1 | Ds3PlayerLeds.Led4)]
+    [InlineData(6, Ds3PlayerLeds.Led2 | Ds3PlayerLeds.Led4)]
+    [InlineData(7, Ds3PlayerLeds.Led3 | Ds3PlayerLeds.Led4)]
+    public void PlayerIndex_MapsToConsoleLedFlags(byte playerIndex, int expectedFlags)
+    {
+        Assert.True(Ds3PlayerLeds.TryGetFlags(playerIndex, out byte flags));
+        Assert.Equal((byte)expectedFlags, flags);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    [InlineData(255)]
+    public void PlayerIndex_RejectsOutOfRange(byte playerIndex)
+    {
+        Assert.False(Ds3PlayerLeds.TryGetFlags(playerIndex, out byte flags));
+        Assert.Equal(0, flags);
+    }
+
+    [Fact]
+    public void DeviceCommandOrdinals_PreserveExistingAbiAndAppendNewCommands()
+    {
+        Assert.Equal(0u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_INVALID);
+        Assert.Equal(1u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO);
+        Assert.Equal(2u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX);
+        Assert.Equal(3u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF);
+        Assert.Equal(4u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE);
+        Assert.Equal(5u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE);
+    }
+
+    [Fact]
+    public void PlayerIndexReply_UsesSetPlayerIndexCommandTag()
+    {
+        DSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY reply = default;
+        reply.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+        reply.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT;
+        reply.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX;
+        reply.Header.TargetIndex = 1;
+        reply.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY>();
+        reply.NtStatus = StatusSuccess;
+
+        Assert.Equal(
+            DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX,
+            reply.Header.Command.Device);
+        Assert.NotEqual(
+            DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO,
+            reply.Header.Command.Device);
+        Assert.Equal((uint)Marshal.SizeOf<DSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY>(), reply.Header.Size);
+    }
+
+    [Fact]
+    public void RuntimeOutputMessageLayouts_MatchPackedRequestReplySizes()
+    {
+        Assert.Equal(20, Marshal.SizeOf<DSHM_IPC_MSG_HEADER>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_PLAYER_INDEX_REQUEST>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_RUMBLE_REQUEST>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_RUMBLE_REPLY>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY>());
+    }
+
+    [Theory]
+    [InlineData(StatusSuccess, true)]
+    [InlineData(StatusAccessDenied, false)]
+    [InlineData(StatusInvalidParameter, false)]
+    [InlineData(StatusInvalidUserBuffer, false)]
+    public void PlayerIndexAndRumbleNtStatus_UsesDriverNtSuccess(uint status, bool expected)
+    {
+        Assert.Equal(expected, PowerOffUsbResult.IsNtSuccess(status));
+    }
+}

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
@@ -315,6 +315,9 @@ public partial class DsHidMiniInterop
 
     /// <summary>
     ///     Overwrites the player slot indicator (player LEDs) of the given device.
+    ///     The change is volatile: Automatic LED authority is handed to the application
+    ///     for the rest of the session so driver battery refreshes do not overwrite it.
+    ///     Returns <c>STATUS_ACCESS_DENIED</c> when LED authority is configured as Driver.
     /// </summary>
     /// <param name="deviceIndex">The one-based device index.</param>
     /// <param name="playerIndex">The player index to set to. Valid values include 1 to 7.</param>
@@ -454,6 +457,150 @@ public partial class DsHidMiniInterop
                     IndicatorsOffStatus = reply.IndicatorsOffStatus,
                     ShutdownStatus = reply.ShutdownStatus
                 };
+            }
+
+            throw new DsHidMiniInteropUnexpectedReplyException(ref reply.Header);
+        }
+        finally
+        {
+            _commandMutex.ReleaseMutex();
+        }
+    }
+
+    /// <summary>
+    ///     Sets rumble motor strengths on a device. Values are processed through the driver's
+    ///     existing rescale, alternative-mode, keep-alive, and Navigation-controller rules.
+    ///     The change is volatile and is not written to the JSON configuration.
+    /// </summary>
+    /// <param name="deviceIndex">The one-based device index.</param>
+    /// <param name="largeMotor">Heavy / left motor strength (0-255).</param>
+    /// <param name="smallMotor">Light / right motor strength (0-255).</param>
+    /// <returns>The NTSTATUS returned by the driver.</returns>
+    /// <exception cref="DsHidMiniInteropUnavailableException">
+    ///     Driver IPC unavailable, make sure that at least one compatible
+    ///     controller is connected and operational.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropInvalidDeviceIndexException">
+    ///     The <paramref name="deviceIndex" /> was outside the valid range 1..255.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropConcurrencyException">A different thread is currently performing a data exchange.</exception>
+    /// <exception cref="DsHidMiniInteropReplyTimeoutException">The driver didn't respond within an expected period.</exception>
+    /// <exception cref="DsHidMiniInteropUnexpectedReplyException">The driver returned unexpected or malformed data.</exception>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public unsafe UInt32 SetRumble(int deviceIndex, byte largeMotor, byte smallMotor)
+    {
+        if (_commandMutex is null || _cmdView is null)
+        {
+            throw new DsHidMiniInteropUnavailableException();
+        }
+
+        ValidateDeviceIndex(deviceIndex);
+
+        AcquireCommandLock();
+
+        try
+        {
+            ref DSHM_IPC_MSG_SET_RUMBLE_REQUEST request =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_SET_RUMBLE_REQUEST>(_cmdView);
+
+            request.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_RESPONSE;
+            request.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_DEVICE;
+            request.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE;
+            request.Header.TargetIndex = (uint)deviceIndex;
+            request.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_SET_RUMBLE_REQUEST>();
+
+            request.LargeMotor = largeMotor;
+            request.SmallMotor = smallMotor;
+
+            if (!SendAndWait())
+            {
+                throw new DsHidMiniInteropReplyTimeoutException();
+            }
+
+            ref DSHM_IPC_MSG_SET_RUMBLE_REPLY reply =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_SET_RUMBLE_REPLY>(_cmdView);
+
+            if (reply.Header is
+                {
+                    Type: DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY,
+                    Target: DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT,
+                    Command.Device: DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE
+                }
+                && reply.Header.TargetIndex == deviceIndex
+                && reply.Header.Size == Marshal.SizeOf<DSHM_IPC_MSG_SET_RUMBLE_REPLY>())
+            {
+                return reply.NtStatus;
+            }
+
+            throw new DsHidMiniInteropUnexpectedReplyException(ref reply.Header);
+        }
+        finally
+        {
+            _commandMutex.ReleaseMutex();
+        }
+    }
+
+    /// <summary>
+    ///     Enables or disables alternative rumble mode for the current session only.
+    ///     The persisted JSON configuration is not updated; a driver config reload
+    ///     restores the file value.
+    /// </summary>
+    /// <param name="deviceIndex">The one-based device index.</param>
+    /// <param name="enabled"><see langword="true" /> to enable alternative rumble mode.</param>
+    /// <returns>The NTSTATUS returned by the driver.</returns>
+    /// <exception cref="DsHidMiniInteropUnavailableException">
+    ///     Driver IPC unavailable, make sure that at least one compatible
+    ///     controller is connected and operational.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropInvalidDeviceIndexException">
+    ///     The <paramref name="deviceIndex" /> was outside the valid range 1..255.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropConcurrencyException">A different thread is currently performing a data exchange.</exception>
+    /// <exception cref="DsHidMiniInteropReplyTimeoutException">The driver didn't respond within an expected period.</exception>
+    /// <exception cref="DsHidMiniInteropUnexpectedReplyException">The driver returned unexpected or malformed data.</exception>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public unsafe UInt32 SetAlternateRumbleMode(int deviceIndex, bool enabled)
+    {
+        if (_commandMutex is null || _cmdView is null)
+        {
+            throw new DsHidMiniInteropUnavailableException();
+        }
+
+        ValidateDeviceIndex(deviceIndex);
+
+        AcquireCommandLock();
+
+        try
+        {
+            ref DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST request =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST>(_cmdView);
+
+            request.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_RESPONSE;
+            request.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_DEVICE;
+            request.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE;
+            request.Header.TargetIndex = (uint)deviceIndex;
+            request.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST>();
+
+            request.IsEnabled = enabled ? (byte)1 : (byte)0;
+
+            if (!SendAndWait())
+            {
+                throw new DsHidMiniInteropReplyTimeoutException();
+            }
+
+            ref DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY reply =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY>(_cmdView);
+
+            if (reply.Header is
+                {
+                    Type: DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY,
+                    Target: DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT,
+                    Command.Device: DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE
+                }
+                && reply.Header.TargetIndex == deviceIndex
+                && reply.Header.Size == Marshal.SizeOf<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY>())
+            {
+                return reply.NtStatus;
             }
 
             throw new DsHidMiniInteropUnexpectedReplyException(ref reply.Header);

--- a/SDK/Nefarius.DsHidMini.IPC/Models/CmdStructs.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/CmdStructs.cs
@@ -156,3 +156,66 @@ internal struct DSHM_IPC_MSG_USB_POWER_OFF_REPLY
     /// </summary>
     public UInt32 ShutdownStatus;
 }
+
+/// <summary>
+///     Updates rumble motor strengths on a given device.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_SET_RUMBLE_REQUEST
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    /// <summary>
+    ///     Heavy / left motor strength (0-255).
+    /// </summary>
+    public byte LargeMotor;
+
+    /// <summary>
+    ///     Light / right motor strength (0-255).
+    /// </summary>
+    public byte SmallMotor;
+}
+
+/// <summary>
+///     Reply to <see cref="DSHM_IPC_MSG_SET_RUMBLE_REQUEST" />.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_SET_RUMBLE_REPLY
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    public UInt32 NtStatus;
+}
+
+/// <summary>
+///     Toggles alternative rumble mode for a given device (volatile).
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    /// <summary>
+    ///     Non-zero enables alternative rumble mode.
+    /// </summary>
+    public byte IsEnabled;
+}
+
+/// <summary>
+///     Reply to <see cref="DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST" />.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    public UInt32 NtStatus;
+}

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Enums.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Enums.cs
@@ -104,5 +104,15 @@ internal enum DSHM_IPC_MSG_CMD_DEVICE : UInt32
     /// <summary>
     ///     Sends the console USB power-off sequence (zero output report + disable)
     /// </summary>
-    DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF
+    DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF,
+
+    /// <summary>
+    ///     Updates rumble motor strengths (volatile, not persisted)
+    /// </summary>
+    DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE,
+
+    /// <summary>
+    ///     Enables or disables alternative rumble mode at runtime
+    /// </summary>
+    DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE
 }

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3PlayerLeds.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3PlayerLeds.cs
@@ -1,0 +1,59 @@
+namespace Nefarius.DsHidMini.IPC.Models.Public;
+
+/// <summary>
+///     DualShock 3 player-index to LED flags mapping used by
+///     <see cref="DsHidMiniInterop.SetPlayerIndex" /> (issue #379).
+/// </summary>
+public static class Ds3PlayerLeds
+{
+    /// <summary>Physical LED 1 bit.</summary>
+    public const byte Led1 = 0x02;
+
+    /// <summary>Physical LED 2 bit.</summary>
+    public const byte Led2 = 0x04;
+
+    /// <summary>Physical LED 3 bit.</summary>
+    public const byte Led3 = 0x08;
+
+    /// <summary>Physical LED 4 bit.</summary>
+    public const byte Led4 = 0x10;
+
+    /// <summary>
+    ///     Maps a player index (1-7) to the DS3 LED flags byte. Indices 5-7 use the
+    ///     extra combinations the hardware uses once four physical LEDs are exhausted.
+    /// </summary>
+    /// <returns>
+    ///     <see langword="true" /> when <paramref name="playerIndex" /> is 1-7;
+    ///     <paramref name="flags" /> is then the matching LED mask.
+    /// </returns>
+    public static bool TryGetFlags(byte playerIndex, out byte flags)
+    {
+        switch (playerIndex)
+        {
+            case 1:
+                flags = Led1;
+                return true;
+            case 2:
+                flags = Led2;
+                return true;
+            case 3:
+                flags = Led3;
+                return true;
+            case 4:
+                flags = Led4;
+                return true;
+            case 5:
+                flags = (byte)(Led1 | Led4);
+                return true;
+            case 6:
+                flags = (byte)(Led2 | Led4);
+                return true;
+            case 7:
+                flags = (byte)(Led3 | Led4);
+                return true;
+            default:
+                flags = 0;
+                return false;
+        }
+    }
+}

--- a/SDK/Nefarius.DsHidMini.IPC/Nefarius.DsHidMini.IPC.csproj
+++ b/SDK/Nefarius.DsHidMini.IPC/Nefarius.DsHidMini.IPC.csproj
@@ -45,4 +45,8 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ControlApp.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/SDK/Nefarius.DsHidMini.IPC/README.md
+++ b/SDK/Nefarius.DsHidMini.IPC/README.md
@@ -38,7 +38,9 @@ Use it from a .NET Standard 2.0 consumer or a .NET 10 Windows application (deskt
 |------------|-------------|
 | **Read raw input** | Poll or wait for `DS3_RAW_INPUT_REPORT` (buttons, sticks, pressure, motion) |
 | **Pair to host** | Set the Bluetooth host address the controller pairs to (`SetHostAddress`) |
-| **Player index** | Set the player LED slot (1–7) with `SetPlayerIndex` |
+| **Player index** | Set the player LED slot (1–7) with `SetPlayerIndex` (volatile) |
+| **Rumble** | Send motor strengths with `SetRumble` (volatile; uses driver rescale / keep-alive) |
+| **Alternate rumble** | Toggle alternative rumble mode with `SetAlternateRumbleMode` (volatile; not written to JSON) |
 | **USB power-off** | Send the console USB power-off sequence with `PowerOffUsbDevice` |
 | **Liveness check** | Verify driver is responsive with `SendPing` |
 
@@ -121,7 +123,9 @@ if (gotReport)
 | **`bool GetRawInputReport(int deviceIndex, ref DS3_RAW_INPUT_REPORT report, TimeSpan? timeout)`** | Fills `report` with the last or next raw HID report. Use `timeout: null` for immediate read; use e.g. `TimeSpan.FromMilliseconds(20)` for event-based waiting on the driver’s named per-slot manual-reset event (`Global\DsHidMiniHidReportEvent` + index). Multiple clients can wait on the same slot. Returns `false` if the slot is empty, or if a timeout was requested and no wait object exists for that slot (nothing connected there). |
 | **`void SendPing()`** | Sends a ping to the driver and waits for a reply (liveness check). |
 | **`SetHostResult SetHostAddress(int deviceIndex, PhysicalAddress hostAddress)`** | Writes the new Bluetooth host address (pairing). Returns write/read NTSTATUS in `SetHostResult`. |
-| **`uint SetPlayerIndex(int deviceIndex, byte playerIndex)`** | Sets the player LED index (1–7). Returns NTSTATUS. |
+| **`uint SetPlayerIndex(int deviceIndex, byte playerIndex)`** | Sets the player LED index (1–7). Volatile: Automatic LED authority is handed to the application so driver battery refreshes do not overwrite the slot. Returns NTSTATUS (`STATUS_ACCESS_DENIED` when LED authority is Driver). |
+| **`uint SetRumble(int deviceIndex, byte largeMotor, byte smallMotor)`** | Sets heavy/left and light/right motor strengths (0–255). Volatile; processed through rescale, alternative mode, keep-alive, and Navigation suppression. Returns NTSTATUS. |
+| **`uint SetAlternateRumbleMode(int deviceIndex, bool enabled)`** | Enables or disables alternative rumble mode for the current session only. A config reload restores the JSON value. Returns NTSTATUS. |
 | **`PowerOffUsbResult PowerOffUsbDevice(int deviceIndex)`** | Sends the PlayStation 3 USB power-off sequence (zero output report, then Feature 0xF4 disable). Wired devices only; the controller stays enumerated. |
 
 All device-indexed APIs use a **one-based** device index (see [Device index](#device-index)).
@@ -152,6 +156,10 @@ All device-indexed APIs use a **one-based** device index (see [Device index](#de
 
 - **`WriteStatus`** — NTSTATUS of the “pair to host” write.  
 - **`ReadStatus`** — NTSTATUS of the subsequent read-back of the address.
+
+### `Ds3PlayerLeds` (player LED mapping)
+
+- **`TryGetFlags(byte playerIndex, out byte flags)`** — maps 1–7 to the DS3 LED mask (`0x02`, `0x04`, `0x08`, `0x10`, plus 5=`1+4`, 6=`2+4`, 7=`3+4`).
 
 ### `PowerOffUsbResult` (USB power-off)
 

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -1177,6 +1177,26 @@ VOID DS3_SET_BOTH_RUMBLE_STRENGTH(
 	DS3_PROCESS_RUMBLE_STRENGTH(Context);
 }
 
+_Use_decl_annotations_
+NTSTATUS
+DSHM_SetIpcRumble(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ UCHAR LargeValue,
+	_In_ UCHAR SmallValue
+)
+{
+	NTSTATUS status;
+
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	DS3_SET_BOTH_RUMBLE_STRENGTH(Context, LargeValue, SmallValue);
+	status = DSHM_SendOutputReportUnlocked(Context, Ds3OutputReportSourceIpc);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	return status;
+}
+
 VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	PDEVICE_CONTEXT Context
 )

--- a/driver/Ds3.h
+++ b/driver/Ds3.h
@@ -145,6 +145,19 @@ VOID DS3_PROCESS_RUMBLE_STRENGTH(
 	PDEVICE_CONTEXT Context
 );
 
+//
+// Writes rumble caches through DS3_PROCESS_RUMBLE_STRENGTH and enqueues the
+// output report under one hold of Context->OutputReport.Lock (issue #379).
+// 
+_Must_inspect_result_
+_Success_(return == STATUS_SUCCESS)
+NTSTATUS
+DSHM_SetIpcRumble(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ UCHAR LargeValue,
+	_In_ UCHAR SmallValue
+);
+
 typedef enum
 {
 	// Class-Specific Requests

--- a/driver/DsCommon.h
+++ b/driver/DsCommon.h
@@ -254,7 +254,12 @@ typedef enum
 	//
 	// Request came from XINPUTHID.SYS
 	// 
-	Ds3OutputReportSourceXInputHID
+	Ds3OutputReportSourceXInputHID,
+
+	//
+	// Request came from a non-HID IPC client (issue #379)
+	// 
+	Ds3OutputReportSourceIpc
 } DS_OUTPUT_REPORT_SOURCE, * PDS_OUTPUT_REPORT_SOURCE;
 
 //

--- a/driver/DsLed.c
+++ b/driver/DsLed.c
@@ -464,3 +464,81 @@ DsLed_AdvanceChargingAnimation(
 
 	FuncExitNoReturn(TRACE_LED);
 }
+
+//
+// Console / XInput-style player-index to LED flags. Indices 5-7 light the
+// extra combinations the hardware uses once four physical LEDs are exhausted.
+// 
+_Use_decl_annotations_
+BOOLEAN
+DsLed_PlayerIndexToFlags(
+	_In_ BYTE PlayerIndex,
+	_Out_ PUCHAR Flags
+)
+{
+	static const UCHAR map[] =
+	{
+		0x00,
+		DS3_LED_1,
+		DS3_LED_2,
+		DS3_LED_3,
+		DS3_LED_4,
+		DS3_LED_1 | DS3_LED_4,
+		DS3_LED_2 | DS3_LED_4,
+		DS3_LED_3 | DS3_LED_4
+	};
+
+	if (PlayerIndex < 1 || PlayerIndex > 7)
+	{
+		*Flags = 0x00;
+		return FALSE;
+	}
+
+	*Flags = map[PlayerIndex];
+	return TRUE;
+}
+
+//
+// IPC player-index write: hand Automatic authority to the application so
+// DsLed_Refresh cannot immediately overwrite the requested slot, then
+// mutate and enqueue under one hold of OutputReport.Lock.
+// 
+_Use_decl_annotations_
+NTSTATUS
+DsLed_ApplyIpcPlayerIndex(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ BYTE PlayerIndex
+)
+{
+	FuncEntry(TRACE_LED);
+
+	UCHAR flags;
+	NTSTATUS status = STATUS_INVALID_PARAMETER;
+
+	if (!DsLed_PlayerIndexToFlags(PlayerIndex, &flags))
+	{
+		FuncExit(TRACE_LED, "status=%!STATUS!", status);
+		return status;
+	}
+
+	if (Context->Configuration.LEDSettings.Authority == DsLEDAuthorityDriver)
+	{
+		status = STATUS_ACCESS_DENIED;
+		FuncExit(TRACE_LED, "status=%!STATUS!", status);
+		return status;
+	}
+
+	static const DS_LED staticEffect = DS3_LED_EFFECT_STATIC;
+
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	Context->OutputReport.Mode = Ds3OutputReportModeWriteReportPassThrough;
+	DsLedSetFlagsAndEffectsLocked(Context, flags, &staticEffect);
+	status = DSHM_SendOutputReportUnlocked(Context, Ds3OutputReportSourceIpc);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	FuncExit(TRACE_LED, "status=%!STATUS!", status);
+
+	return status;
+}

--- a/driver/DsLed.h
+++ b/driver/DsLed.h
@@ -132,3 +132,27 @@ VOID
 DsLed_ApplyCustomPatternLocked(
 	_In_ PDEVICE_CONTEXT Context
 );
+
+//
+// Maps a player index (1-7) to the DS3 LED flags byte used by the console
+// and by XInput-style extra-player encodings (5 = 1+4, 6 = 2+4, 7 = 3+4).
+// Returns FALSE when PlayerIndex is outside 1-7; Flags is then set to 0.
+// 
+BOOLEAN
+DsLed_PlayerIndexToFlags(
+	_In_ BYTE PlayerIndex,
+	_Out_ PUCHAR Flags
+);
+
+//
+// Applies an IPC player-index override: marks LEDs application-owned for
+// Automatic authority, writes the matching static LED pattern, and sends
+// the report under one hold of Context->OutputReport.Lock. Returns
+// STATUS_INVALID_PARAMETER for an out-of-range index and STATUS_ACCESS_DENIED
+// when LED authority is Driver (configuration owns the indicators).
+// 
+NTSTATUS
+DsLed_ApplyIpcPlayerIndex(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ BYTE PlayerIndex
+);

--- a/driver/IPC.Device.c
+++ b/driver/IPC.Device.c
@@ -18,6 +18,20 @@ DSHM_EvtDispatchDeviceMessage(
 
 	if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO)
 	{
+		if (MessageHeader->Size < sizeof(DSHM_IPC_MSG_PAIR_TO_REQUEST))
+		{
+			DSHM_IPC_MSG_PAIR_TO_RESPONSE_INIT(
+				(PDSHM_IPC_MSG_PAIR_TO_REPLY)MessageHeader,
+				MessageHeader->TargetIndex,
+				STATUS_INVALID_USER_BUFFER,
+				STATUS_INVALID_USER_BUFFER
+			);
+
+			status = STATUS_SUCCESS;
+			FuncExit(TRACE_IPC, "status=%!STATUS!", status);
+			return status;
+		}
+
 		const PDSHM_IPC_MSG_PAIR_TO_REQUEST request = (PDSHM_IPC_MSG_PAIR_TO_REQUEST)MessageHeader;
 
 		TraceVerbose(
@@ -59,12 +73,26 @@ DSHM_EvtDispatchDeviceMessage(
 	}
 	else if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX)
 	{
-		// TODO: implement me!
+		NTSTATUS applyStatus = STATUS_INVALID_USER_BUFFER;
+
+		if (MessageHeader->Size >= sizeof(DSHM_IPC_MSG_SET_PLAYER_INDEX_REQUEST))
+		{
+			const PDSHM_IPC_MSG_SET_PLAYER_INDEX_REQUEST request =
+				(PDSHM_IPC_MSG_SET_PLAYER_INDEX_REQUEST)MessageHeader;
+
+			TraceVerbose(
+				TRACE_IPC,
+				"Received player-index request: %d",
+				request->PlayerIndex
+			);
+
+			applyStatus = DsLed_ApplyIpcPlayerIndex(DeviceContext, request->PlayerIndex);
+		}
 
 		DSHM_IPC_MSG_SET_PLAYER_INDEX_RESPONSE_INIT(
 			(PDSHM_IPC_MSG_SET_PLAYER_INDEX_REPLY)MessageHeader,
 			MessageHeader->TargetIndex,
-			STATUS_NOT_IMPLEMENTED
+			applyStatus
 		);
 
 		status = STATUS_SUCCESS;
@@ -74,7 +102,12 @@ DSHM_EvtDispatchDeviceMessage(
 		NTSTATUS indicatorsOffStatus = STATUS_NOT_SUPPORTED;
 		NTSTATUS shutdownStatus = STATUS_NOT_SUPPORTED;
 
-		if (DeviceContext->ConnectionType != DsDeviceConnectionTypeUsb)
+		if (MessageHeader->Size < sizeof(DSHM_IPC_MSG_USB_POWER_OFF_REQUEST))
+		{
+			indicatorsOffStatus = STATUS_INVALID_USER_BUFFER;
+			shutdownStatus = STATUS_INVALID_USER_BUFFER;
+		}
+		else if (DeviceContext->ConnectionType != DsDeviceConnectionTypeUsb)
 		{
 			TraceWarning(
 				TRACE_IPC,
@@ -122,6 +155,68 @@ DSHM_EvtDispatchDeviceMessage(
 			MessageHeader->TargetIndex,
 			indicatorsOffStatus,
 			shutdownStatus
+		);
+
+		status = STATUS_SUCCESS;
+	}
+	else if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE)
+	{
+		NTSTATUS applyStatus = STATUS_INVALID_USER_BUFFER;
+
+		if (MessageHeader->Size >= sizeof(DSHM_IPC_MSG_SET_RUMBLE_REQUEST))
+		{
+			const PDSHM_IPC_MSG_SET_RUMBLE_REQUEST request =
+				(PDSHM_IPC_MSG_SET_RUMBLE_REQUEST)MessageHeader;
+
+			TraceVerbose(
+				TRACE_IPC,
+				"Received rumble request: large=%d small=%d",
+				request->LargeMotor,
+				request->SmallMotor
+			);
+
+			applyStatus = DSHM_SetIpcRumble(
+				DeviceContext,
+				request->LargeMotor,
+				request->SmallMotor
+			);
+		}
+
+		DSHM_IPC_MSG_SET_RUMBLE_RESPONSE_INIT(
+			(PDSHM_IPC_MSG_SET_RUMBLE_REPLY)MessageHeader,
+			MessageHeader->TargetIndex,
+			applyStatus
+		);
+
+		status = STATUS_SUCCESS;
+	}
+	else if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE)
+	{
+		NTSTATUS applyStatus = STATUS_INVALID_USER_BUFFER;
+
+		if (MessageHeader->Size >= sizeof(DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST))
+		{
+			const PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST request =
+				(PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST)MessageHeader;
+
+			//
+			// Volatile only: do not persist to JSON. A config hot-reload
+			// restores AlternativeMode.IsEnabled from disk.
+			// 
+			DeviceContext->RumbleControlState.AltMode.IsEnabled = request->IsEnabled ? TRUE : FALSE;
+			applyStatus = STATUS_SUCCESS;
+
+			TraceVerbose(
+				TRACE_IPC,
+				"Alternate rumble mode is now %!BOOLEAN!",
+				DeviceContext->RumbleControlState.AltMode.IsEnabled
+			);
+		}
+
+		DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_RESPONSE_INIT(
+			(PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY)MessageHeader,
+			MessageHeader->TargetIndex,
+			applyStatus
 		);
 
 		status = STATUS_SUCCESS;

--- a/driver/IPC.Device.c
+++ b/driver/IPC.Device.c
@@ -201,15 +201,19 @@ DSHM_EvtDispatchDeviceMessage(
 
 			//
 			// Volatile only: do not persist to JSON. A config hot-reload
-			// restores AlternativeMode.IsEnabled from disk.
+			// restores AlternativeMode.IsEnabled from disk. Hold the output
+			// lock so this cannot tear against DS3_PROCESS_RUMBLE_STRENGTH.
 			// 
+			WdfWaitLockAcquire(DeviceContext->OutputReport.Lock, NULL);
 			DeviceContext->RumbleControlState.AltMode.IsEnabled = request->IsEnabled ? TRUE : FALSE;
+			const BOOLEAN isEnabled = DeviceContext->RumbleControlState.AltMode.IsEnabled;
+			WdfWaitLockRelease(DeviceContext->OutputReport.Lock);
 			applyStatus = STATUS_SUCCESS;
 
 			TraceVerbose(
 				TRACE_IPC,
 				"Alternate rumble mode is now %!BOOLEAN!",
-				DeviceContext->RumbleControlState.AltMode.IsEnabled
+				isEnabled
 			);
 		}
 

--- a/driver/IPC.h
+++ b/driver/IPC.h
@@ -98,6 +98,14 @@ typedef enum
 	// Sends the console USB power-off sequence (zero output report + disable)
 	// 
 	DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF,
+	//
+	// Updates rumble motor strengths (volatile, not persisted)
+	// 
+	DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE,
+	//
+	// Enables or disables alternative rumble mode at runtime
+	// 
+	DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE,
 } DSHM_IPC_MSG_CMD_DEVICE;
 
 //
@@ -222,6 +230,61 @@ typedef struct _DSHM_IPC_MSG_USB_POWER_OFF_REPLY
 
 } DSHM_IPC_MSG_USB_POWER_OFF_REPLY, *PDSHM_IPC_MSG_USB_POWER_OFF_REPLY;
 
+//
+// Updates rumble motor strengths on a given device
+// 
+typedef struct _DSHM_IPC_MSG_SET_RUMBLE_REQUEST
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	//
+	// Heavy / left motor strength (0-255)
+	// 
+	UCHAR LargeMotor;
+
+	//
+	// Light / right motor strength (0-255)
+	// 
+	UCHAR SmallMotor;
+
+} DSHM_IPC_MSG_SET_RUMBLE_REQUEST, *PDSHM_IPC_MSG_SET_RUMBLE_REQUEST;
+
+//
+// Reply to struct _DSHM_IPC_MSG_SET_RUMBLE_REQUEST
+// 
+typedef struct _DSHM_IPC_MSG_SET_RUMBLE_REPLY
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	NTSTATUS NtStatus;
+
+} DSHM_IPC_MSG_SET_RUMBLE_REPLY, *PDSHM_IPC_MSG_SET_RUMBLE_REPLY;
+
+//
+// Toggles alternative rumble mode for a given device (volatile)
+// 
+typedef struct _DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	//
+	// TRUE enables alternative rumble mode; FALSE restores normal processing
+	// 
+	BOOLEAN IsEnabled;
+
+} DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST, *PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST;
+
+//
+// Reply to struct _DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST
+// 
+typedef struct _DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	NTSTATUS NtStatus;
+
+} DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY, *PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY;
+
 typedef
 _Function_class_(EVT_DSHM_IPC_DispatchDeviceMessage)
 _IRQL_requires_same_
@@ -306,7 +369,7 @@ DSHM_IPC_MSG_SET_PLAYER_INDEX_RESPONSE_INIT(
 
 	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
 	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
-	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO;
+	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_SET_PLAYER_INDEX;
 	Message->Header.TargetIndex = DeviceIndex;
 	Message->Header.Size = size;
 
@@ -333,6 +396,46 @@ DSHM_IPC_MSG_USB_POWER_OFF_RESPONSE_INIT(
 
 	Message->IndicatorsOffStatus = IndicatorsOffStatus;
 	Message->ShutdownStatus = ShutdownStatus;
+}
+
+VOID
+FORCEINLINE
+DSHM_IPC_MSG_SET_RUMBLE_RESPONSE_INIT(
+	_Inout_ PDSHM_IPC_MSG_SET_RUMBLE_REPLY Message,
+	_In_ UINT32 DeviceIndex,
+	_In_ NTSTATUS Status
+)
+{
+	const UINT32 size = sizeof(DSHM_IPC_MSG_SET_RUMBLE_REPLY);
+	RtlZeroMemory(Message, size);
+
+	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
+	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE;
+	Message->Header.TargetIndex = DeviceIndex;
+	Message->Header.Size = size;
+
+	Message->NtStatus = Status;
+}
+
+VOID
+FORCEINLINE
+DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_RESPONSE_INIT(
+	_Inout_ PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY Message,
+	_In_ UINT32 DeviceIndex,
+	_In_ NTSTATUS Status
+)
+{
+	const UINT32 size = sizeof(DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY);
+	RtlZeroMemory(Message, size);
+
+	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
+	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE;
+	Message->Header.TargetIndex = DeviceIndex;
+	Message->Header.Size = size;
+
+	Message->NtStatus = Status;
 }
 
 

--- a/ipctest/Program.cs
+++ b/ipctest/Program.cs
@@ -1,9 +1,12 @@
-﻿// See https://aka.ms/new-console-template for more information
+// See https://aka.ms/new-console-template for more information
 
 using System.Diagnostics;
 
 using Nefarius.DsHidMini.IPC;
 #if INPUT_TEST
+using Nefarius.DsHidMini.IPC.Models.Public;
+#endif
+#if RUNTIME_OUTPUT_TEST
 using Nefarius.DsHidMini.IPC.Models.Public;
 #endif
 
@@ -38,6 +41,15 @@ do
             {
                 Console.WriteLine("Cross pressed");
             }
+#elif RUNTIME_OUTPUT_TEST
+            // Volatile runtime output (issue #379). Rebuild without this define
+            // for the default ping throughput loop.
+            uint playerStatus = ipc.SetPlayerIndex(1, 1);
+            uint rumbleStatus = ipc.SetRumble(1, 0x40, 0x00);
+            uint altStatus = ipc.SetAlternateRumbleMode(1, false);
+            Console.WriteLine(
+                $"SetPlayerIndex=0x{playerStatus:X} SetRumble=0x{rumbleStatus:X} SetAlternateRumbleMode=0x{altStatus:X} flags={Ds3PlayerLeds.TryGetFlags(1, out byte flags) && flags == Ds3PlayerLeds.Led1}");
+            break;
 #else
             ipc.SendPing();
 #endif
@@ -49,6 +61,8 @@ do
 
 #if INPUT_TEST
         Console.WriteLine($"Read {executionCount} input reports in one second.");
+#elif RUNTIME_OUTPUT_TEST
+        Console.WriteLine("Sent one volatile LED/rumble/alternate-mode command set.");
 #else
         Console.WriteLine($"Executed {executionCount} PINGs in one second.");
 #endif


### PR DESCRIPTION
Non-HID clients can now set player LEDs, rumble, and alternate rumble at runtime without going through the HID stack or persisted JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added IPC support for setting DualShock 3 rumble motor strengths.
  - Added session-only alternate rumble mode control.
  - Added player-index LED mapping for indices 1–7, including combined LED patterns.
  - Added runtime handling for player-index LED updates with status reporting.

- **Bug Fixes**
  - Corrected player-index response tagging and strengthened malformed-request validation.

- **Documentation**
  - Updated SDK documentation for rumble, LED, and player-index behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->