### PR TITLE
Replace JSON hot-reload pairing with explicit IPC device actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
         id: version
         shell: pwsh
         run: |
-          $buildVersion = "3.5.$([int]$env:BUILD_VERSION_OFFSET + ${{ github.run_number }}).0"
+          $buildVersion = "3.6.$([int]$env:BUILD_VERSION_OFFSET + ${{ github.run_number }}).0"
           echo "BUILD_VERSION=$buildVersion" >> $env:GITHUB_ENV
           echo "build-version=$buildVersion" >> $env:GITHUB_OUTPUT
           Write-Output "Building version $buildVersion"

--- a/ControlApp.Tests/DriverConfigContractTests.cs
+++ b/ControlApp.Tests/DriverConfigContractTests.cs
@@ -31,6 +31,7 @@ public class DriverConfigContractTests
         Assert.Null(root["Global"]!["DisableAutoPairing"]);
         Assert.Null(root["Global"]!["IsQuickDisconnectComboEnabled"]);
         Assert.Null(root["Global"]!["IsOutputDeduplicatorEnabled"]);
+        Assert.Null(root["Global"]!["PairOnHotReload"]);
         Assert.Equal("XInput", root["Global"]!["HidDeviceMode"]!.GetValue<string>());
     }
 
@@ -168,6 +169,25 @@ public class DriverConfigContractTests
         DeviceSettings restored = new();
         DshmManagerToDriverConversion.ConvertDriverFormatToDeviceSettings(parsed.Global, restored);
         Assert.Equal(transport, restored.OutputReport.BluetoothOutputReportTransport);
+    }
+
+    [Fact]
+    public void Deserialize_LegacyPairOnHotReload_IsIgnored()
+    {
+        const string json = """
+            {
+              "Global": {
+                "HidDeviceMode": "XInput",
+                "DevicePairingMode": "Auto",
+                "PairOnHotReload": true
+              },
+              "Devices": {}
+            }
+            """;
+
+        DshmConfiguration parsed = DshmConfigSerialization.Deserialize(json);
+        Assert.Equal(DevicePairingMode.Auto, parsed.Global.DevicePairingMode);
+        Assert.Null(parsed.Global.GetType().GetProperty("PairOnHotReload"));
     }
 
     [Fact]

--- a/ControlApp.Tests/IpcRuntimeOutputTests.cs
+++ b/ControlApp.Tests/IpcRuntimeOutputTests.cs
@@ -47,6 +47,9 @@ public class IpcRuntimeOutputTests
         Assert.Equal(3u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_USB_POWER_OFF);
         Assert.Equal(4u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_RUMBLE);
         Assert.Equal(5u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE);
+        Assert.Equal(6u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST);
+        Assert.Equal(7u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_DISCONNECT_BLUETOOTH);
+        Assert.Equal(8u, (uint)DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN);
     }
 
     [Fact]
@@ -79,6 +82,125 @@ public class IpcRuntimeOutputTests
         Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_RUMBLE_REPLY>());
         Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REQUEST>());
         Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY>());
+        Assert.Equal(20, Marshal.SizeOf<DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST>());
+        Assert.Equal(28, Marshal.SizeOf<DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY>());
+        Assert.Equal(20, Marshal.SizeOf<DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY>());
+        Assert.Equal(6, Marshal.SizeOf<DSHM_IPC_LED_EFFECT>());
+        Assert.Equal(48, Marshal.SizeOf<DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST>());
+        Assert.Equal(24, Marshal.SizeOf<DSHM_IPC_MSG_SET_LED_PATTERN_REPLY>());
+    }
+
+    [Fact]
+    public void PairToCurrentHostReply_UsesDedicatedCommandTag()
+    {
+        DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY reply = default;
+        reply.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+        reply.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT;
+        reply.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST;
+        reply.Header.TargetIndex = 1;
+        reply.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY>();
+        reply.WriteStatus = StatusSuccess;
+        reply.ReadStatus = StatusSuccess;
+
+        Assert.Equal(
+            DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST,
+            reply.Header.Command.Device);
+        Assert.NotEqual(
+            DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO,
+            reply.Header.Command.Device);
+    }
+
+    [Theory]
+    [InlineData(0x00, true)]
+    [InlineData(Ds3PlayerLeds.Led1, true)]
+    [InlineData(Ds3PlayerLeds.Led1 | Ds3PlayerLeds.Led4, true)]
+    [InlineData(Ds3PlayerLeds.LedOff, true)]
+    [InlineData(0x01, false)]
+    [InlineData(0x40, false)]
+    [InlineData(0xFF, false)]
+    public void LedPattern_RejectsReservedFlagBits(byte flags, bool expected)
+    {
+        Assert.Equal(expected, Ds3LedPattern.AreFlagsValid(flags));
+    }
+
+    [Fact]
+    public void LedPattern_FromPlayerIndex_UsesStaticEffects()
+    {
+        Assert.True(Ds3LedPattern.TryFromPlayerIndex(5, out Ds3LedPattern pattern));
+        Assert.Equal(Ds3PlayerLeds.Led1 | Ds3PlayerLeds.Led4, pattern.Flags);
+        Assert.Equal(Ds3LedEffect.Static.TotalDuration, pattern.Player1.TotalDuration);
+        Assert.Equal(Ds3LedEffect.Static.BasePortionDuration, pattern.Player1.BasePortionDuration);
+        Assert.False(Ds3LedPattern.TryFromPlayerIndex(0, out _));
+    }
+
+    [Fact]
+    public void LedPattern_MarshalsIndependentEffectBlocks()
+    {
+        Ds3LedPattern pattern = new(
+            Ds3PlayerLeds.Led1 | Ds3PlayerLeds.Led2,
+            new Ds3LedEffect(0xFF, 0x0001, 0x00, 0x01),
+            new Ds3LedEffect(0x10, 0x000F, 0x7F, 0x7F),
+            Ds3LedEffect.None,
+            Ds3LedEffect.FastFlash);
+
+        DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST request = new()
+        {
+            Header =
+            {
+                Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_RESPONSE,
+                Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_DEVICE,
+                Command = { Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN },
+                TargetIndex = 1,
+                Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST>()
+            },
+            Flags = pattern.Flags,
+            Player1 =
+            {
+                TotalDuration = pattern.Player1.TotalDuration,
+                BasePortionDuration = pattern.Player1.BasePortionDuration,
+                OffPortionMultiplier = pattern.Player1.OffPortionMultiplier,
+                OnPortionMultiplier = pattern.Player1.OnPortionMultiplier
+            },
+            Player2 =
+            {
+                TotalDuration = pattern.Player2.TotalDuration,
+                BasePortionDuration = pattern.Player2.BasePortionDuration,
+                OffPortionMultiplier = pattern.Player2.OffPortionMultiplier,
+                OnPortionMultiplier = pattern.Player2.OnPortionMultiplier
+            },
+            Player3 =
+            {
+                TotalDuration = pattern.Player3.TotalDuration,
+                BasePortionDuration = pattern.Player3.BasePortionDuration,
+                OffPortionMultiplier = pattern.Player3.OffPortionMultiplier,
+                OnPortionMultiplier = pattern.Player3.OnPortionMultiplier
+            },
+            Player4 =
+            {
+                TotalDuration = pattern.Player4.TotalDuration,
+                BasePortionDuration = pattern.Player4.BasePortionDuration,
+                OffPortionMultiplier = pattern.Player4.OffPortionMultiplier,
+                OnPortionMultiplier = pattern.Player4.OnPortionMultiplier
+            }
+        };
+
+        Assert.Equal(pattern.Flags, request.Flags);
+        Assert.Equal(0x10, request.Player2.TotalDuration);
+        Assert.Equal(0x000F, request.Player2.BasePortionDuration);
+        Assert.Equal(0x00, request.Player3.OnPortionMultiplier);
+        Assert.Equal(Ds3LedEffect.FastFlash.BasePortionDuration, request.Player4.BasePortionDuration);
+        Assert.Equal(48u, request.Header.Size);
+    }
+
+    [Theory]
+    [InlineData(StatusSuccess, StatusSuccess, true)]
+    [InlineData(StatusSuccess, StatusAccessDenied, false)]
+    [InlineData(StatusInvalidParameter, StatusSuccess, false)]
+    public void PairingNtStatus_UsesDriverNtSuccess(uint writeStatus, uint readStatus, bool expected)
+    {
+        SetHostResult result = new() { WriteStatus = writeStatus, ReadStatus = readStatus };
+        Assert.Equal(expected, result.Succeeded);
     }
 
     [Theory]

--- a/ControlApp/Models/DshmConfigManager/DeviceData.cs
+++ b/ControlApp/Models/DshmConfigManager/DeviceData.cs
@@ -1,7 +1,5 @@
 ﻿using Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager.Enums;
 
-using Newtonsoft.Json;
-
 namespace Nefarius.DsHidMini.ControlApp.Models.DshmConfigManager;
 
 public class DeviceData
@@ -16,9 +14,6 @@ public class DeviceData
     public Guid GuidOfProfileToUse { get; set; } = ProfileData.DefaultGuid;
     public BluetoothPairingMode BluetoothPairingMode { get; set; } = BluetoothPairingMode.Auto;
     public string? PairingAddress { get; set; } = "";
-
-    [JsonIgnore] // PairOnHotReload should only be enabled temporarely to prevent pairing requests from being repeteadly sent on hot-reload
-    public bool PairOnHotReload { get; set; } = false;
 
     public SettingsModes SettingsMode { get; set; } = SettingsModes.Global;
 

--- a/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfig.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfig.cs
@@ -14,7 +14,6 @@ public class DshmDeviceSettings
     public bool? AutoRestartOnHidModeMismatch { get; set; }
 
     public DevicePairingMode? DevicePairingMode { get; set; }
-    public bool? PairOnHotReload { get; set; }
     public string? CustomPairingAddress { get; set; }
     public UsbOutputReportTransport? UsbOutputReportTransport { get; set; }
     public BluetoothOutputReportTransport? BluetoothOutputReportTransport { get; set; }

--- a/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfigSerialization.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmConfig/DshmConfigSerialization.cs
@@ -113,7 +113,6 @@ internal static class DshmConfigSerialization
                                  ?? ReadEnum<HidDeviceMode>(element, "HIDDeviceMode");
         settings.AutoRestartOnHidModeMismatch = ReadBool(element, "AutoRestartOnHidModeMismatch");
         settings.DevicePairingMode = ReadEnum<DevicePairingMode>(element, "DevicePairingMode");
-        settings.PairOnHotReload = ReadBool(element, "PairOnHotReload");
         settings.CustomPairingAddress = ReadString(element, "CustomPairingAddress");
         settings.UsbOutputReportTransport = ReadEnum<UsbOutputReportTransport>(element, "UsbOutputReportTransport");
         settings.BluetoothOutputReportTransport =

--- a/ControlApp/Models/DshmConfigManager/DshmDriverConfigMigration.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmDriverConfigMigration.cs
@@ -184,7 +184,6 @@ internal static class DshmDriverConfigMigration
             {
                 DevicePairingMode =
                     DshmManagerToDriverConversion.PairingModeManagerToDriver[device.BluetoothPairingMode],
-                PairOnHotReload = device.PairOnHotReload,
                 CustomPairingAddress = device.BluetoothPairingMode == BluetoothPairingMode.Custom
                     ? MacAddressFormatter.Normalize(device.PairingAddress)
                     : null

--- a/ControlApp/Models/DshmConfigManager/DshmTranslationUtils.cs
+++ b/ControlApp/Models/DshmConfigManager/DshmTranslationUtils.cs
@@ -354,7 +354,6 @@ public class DshmManagerToDriverConversion
         merged.AutoRestartOnHidModeMismatch =
             overlay.AutoRestartOnHidModeMismatch ?? merged.AutoRestartOnHidModeMismatch;
         merged.DevicePairingMode = overlay.DevicePairingMode ?? merged.DevicePairingMode;
-        merged.PairOnHotReload = overlay.PairOnHotReload ?? merged.PairOnHotReload;
         merged.CustomPairingAddress = overlay.CustomPairingAddress ?? merged.CustomPairingAddress;
         merged.UsbOutputReportTransport = overlay.UsbOutputReportTransport ?? merged.UsbOutputReportTransport;
         merged.BluetoothOutputReportTransport =
@@ -569,7 +568,6 @@ public class DshmManagerToDriverConversion
         clone.HidDeviceMode = source.HidDeviceMode;
         clone.AutoRestartOnHidModeMismatch = source.AutoRestartOnHidModeMismatch;
         clone.DevicePairingMode = source.DevicePairingMode;
-        clone.PairOnHotReload = source.PairOnHotReload;
         clone.CustomPairingAddress = source.CustomPairingAddress;
         clone.UsbOutputReportTransport = source.UsbOutputReportTransport;
         clone.BluetoothOutputReportTransport = source.BluetoothOutputReportTransport;

--- a/ControlApp/Models/DshmDevMan.cs
+++ b/ControlApp/Models/DshmDevMan.cs
@@ -1,6 +1,7 @@
 ﻿using Nefarius.DsHidMini.ControlApp.Models.Util;
+using Nefarius.DsHidMini.IPC;
 using Nefarius.DsHidMini.IPC.Models.Drivers;
-using Nefarius.Utilities.Bluetooth;
+using Nefarius.DsHidMini.IPC.Models.Public;
 using Nefarius.Utilities.DeviceManagement.Extensions;
 using Nefarius.Utilities.DeviceManagement.PnP;
 
@@ -73,11 +74,31 @@ public class DshmDevMan
         {
             try
             {
-                HostRadio hostRadio = new();
-                string deviceAddress = device.GetProperty<string>(DsHidMiniDriver.DeviceAddressProperty)!.ToUpper();
-                Log.Logger.Debug("Instructing BT host on disconnecting device of MAC {DeviceAddress}", deviceAddress);
-                hostRadio.DisconnectRemoteDevice(deviceAddress);
-                return true;
+                int? slot = TryGetIpcSlotIndex(device);
+                if (slot is not int deviceIndex)
+                {
+                    Log.Logger.Warning(
+                        "Wireless disconnect skipped for '{InstanceId}': no readable IPC slot.",
+                        device.InstanceId);
+                    return false;
+                }
+
+                if (!DsHidMiniInterop.IsAvailable)
+                {
+                    Log.Logger.Warning(
+                        "Wireless disconnect skipped for '{InstanceId}': driver IPC is not available.",
+                        device.InstanceId);
+                    return false;
+                }
+
+                using DsHidMiniInterop interop = new();
+                uint status = interop.DisconnectBluetoothDevice(deviceIndex);
+                Log.Logger.Debug(
+                    "IPC Bluetooth disconnect for '{InstanceId}' slot {Slot}: 0x{Status:X}",
+                    device.InstanceId,
+                    deviceIndex,
+                    status);
+                return PowerOffUsbResult.IsNtSuccess(status);
             }
             catch (Exception ex)
             {
@@ -98,6 +119,26 @@ public class DshmDevMan
             Log.Logger.Error(e, "Failed to power cycle device's USB port");
             return false;
         }
+    }
+
+    private static int? TryGetIpcSlotIndex(PnPDevice device)
+    {
+        uint slot;
+        try
+        {
+            slot = device.GetProperty<uint>(DsHidMiniDriver.IpcSlotIndexProperty);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        if (slot is < 1 or > byte.MaxValue)
+        {
+            return null;
+        }
+
+        return (int)slot;
     }
 
     public event EventHandler? ConnectedDeviceListUpdated;

--- a/ControlApp/Models/DshmDevMan.cs
+++ b/ControlApp/Models/DshmDevMan.cs
@@ -74,7 +74,7 @@ public class DshmDevMan
         {
             try
             {
-                int? slot = TryGetIpcSlotIndex(device);
+                int? slot = DsHidMiniInterop.TryGetIpcSlotIndex(device);
                 if (slot is not int deviceIndex)
                 {
                     Log.Logger.Warning(
@@ -119,26 +119,6 @@ public class DshmDevMan
             Log.Logger.Error(e, "Failed to power cycle device's USB port");
             return false;
         }
-    }
-
-    private static int? TryGetIpcSlotIndex(PnPDevice device)
-    {
-        uint slot;
-        try
-        {
-            slot = device.GetProperty<uint>(DsHidMiniDriver.IpcSlotIndexProperty);
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-
-        if (slot is < 1 or > byte.MaxValue)
-        {
-            return null;
-        }
-
-        return (int)slot;
     }
 
     public event EventHandler? ConnectedDeviceListUpdated;

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -211,6 +211,28 @@ public class AppSnackbarMessagesService
         );
     }
 
+    public void ShowPairingSucceededMessage()
+    {
+        _snackbarService.Show(
+            "Controller paired",
+            "The host address was written and verified.",
+            ControlAppearance.Success,
+            new SymbolIcon(SymbolRegular.CheckmarkCircle24),
+            TimeSpan.FromSeconds(5)
+        );
+    }
+
+    public void ShowPairingFailedMessage(string detail)
+    {
+        _snackbarService.Show(
+            "Failed to pair controller",
+            detail,
+            ControlAppearance.Danger,
+            new SymbolIcon(SymbolRegular.DismissCircle24),
+            TimeSpan.FromSeconds(8)
+        );
+    }
+
     public void ShowPowerCyclingDeviceMessage(bool isWireless, bool isAppElevated, bool reconnectionResult)
     {
         if (!isWireless && !isAppElevated)

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -338,8 +338,14 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             _pairingMode = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsCustomPairingAddressVisible));
+            OnPropertyChanged(nameof(CanPairNow));
         }
     }
+
+    /// <summary>
+    ///     Pair Now is available when the device can be paired and pairing is not disabled.
+    /// </summary>
+    public bool CanPairNow => SupportsBluetoothPairing && PairingMode != BluetoothPairingMode.Disabled;
 
 
     /// <summary>
@@ -872,51 +878,100 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     }
 
     [RelayCommand]
-    private async Task TriggerPairingOnHotReload()
+    private async Task PairNow()
     {
+        if (!CanPairNow)
+        {
+            _appSnackbarMessagesService.ShowPairingFailedMessage(
+                "Pairing is disabled for this controller.");
+            return;
+        }
+
         _deviceUserData.BluetoothPairingMode = PairingMode;
         _deviceUserData.PairingAddress = MacAddressFormatter.Normalize(CustomPairingAddress);
 
-        try
+        if (!_dshmConfigManager.SaveChangesAndUpdateDsHidMiniConfigFile())
         {
-            _deviceUserData.PairOnHotReload = true;
-            if (!_dshmConfigManager.SaveChangesAndUpdateDsHidMiniConfigFile())
+            _appSnackbarMessagesService.ShowDsHidMiniConfigurationUpdateFailedMessage();
+            return;
+        }
+
+        int? slot = TryGetIpcSlotIndex();
+        if (slot is not int deviceIndex)
+        {
+            Log.Logger.Warning(
+                "Pairing skipped for '{DeviceAddress}': no readable IPC slot.",
+                DeviceAddress);
+            _appSnackbarMessagesService.ShowPairingFailedMessage(
+                "The driver did not report an IPC slot for this device.");
+            return;
+        }
+
+        if (!DsHidMiniInterop.IsAvailable)
+        {
+            _appSnackbarMessagesService.ShowPairingFailedMessage(
+                "Driver IPC is not available. Confirm the controller is still connected.");
+            return;
+        }
+
+        PhysicalAddress? customHostAddress = null;
+        if (PairingMode == BluetoothPairingMode.Custom)
+        {
+            try
             {
-                _appSnackbarMessagesService.ShowDsHidMiniConfigurationUpdateFailedMessage();
+                customHostAddress = ParsePairingAddress();
+            }
+            catch (FormatException ex)
+            {
+                _appSnackbarMessagesService.ShowPairingFailedMessage(ex.Message);
                 return;
             }
-
-            await ShowPairingDialog();
         }
-        finally
+
+        try
         {
-            _deviceUserData.PairOnHotReload = false;
-            if (!_dshmConfigManager.SaveChangesAndUpdateDsHidMiniConfigFile())
+            SetHostResult result = await Task.Run(() =>
             {
-                _appSnackbarMessagesService.ShowDsHidMiniConfigurationUpdateFailedMessage();
+                using DsHidMiniInterop interop = new();
+                return customHostAddress is not null
+                    ? interop.SetHostAddress(deviceIndex, customHostAddress)
+                    : interop.PairToCurrentHost(deviceIndex);
+            });
+
+            Log.Logger.Information(
+                "Pairing for '{DeviceAddress}' slot {Slot}: {Result}",
+                DeviceAddress,
+                deviceIndex,
+                result);
+
+            if (result.Succeeded)
+            {
+                _appSnackbarMessagesService.ShowPairingSucceededMessage();
             }
+            else
+            {
+                _appSnackbarMessagesService.ShowPairingFailedMessage(result.ToString());
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Error(ex, "Pairing failed for '{DeviceAddress}'", DeviceAddress);
+            _appSnackbarMessagesService.ShowPairingFailedMessage(ex.Message);
         }
 
         OnPropertyChanged(nameof(HostAddress));
         OnPropertyChanged(nameof(LastPairingStatusIcon));
     }
 
-    private async Task ShowPairingDialog()
+    private PhysicalAddress ParsePairingAddress()
     {
-        ContentDialogResult result = await _contentDialogService.ShowSimpleDialogAsync(
-            new SimpleContentDialogCreateOptions
-            {
-                Title = "Manual pairing triggered",
-                Content = """
-                          Pairing was requested.
+        string normalized = MacAddressFormatter.Normalize(CustomPairingAddress);
+        if (normalized.Length != 12)
+        {
+            throw new FormatException("Custom pairing address must be a 12-digit Bluetooth MAC.");
+        }
 
-                          Wait 2 or 5 seconds before hitting ok to check for results.
-                          """,
-                //PrimaryButtonText = "Ok",
-                //SecondaryButtonText = "Don't Save",
-                CloseButtonText = "OK"
-            }
-        );
+        return PhysicalAddress.Parse(normalized);
     }
 
     [RelayCommand]

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -808,7 +808,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             return;
         }
 
-        int? slot = TryGetIpcSlotIndex();
+        int? slot = DsHidMiniInterop.TryGetIpcSlotIndex(Device);
         if (slot is not int deviceIndex)
         {
             Log.Logger.Warning(
@@ -857,26 +857,6 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         }
     }
 
-    private int? TryGetIpcSlotIndex()
-    {
-        uint slot;
-        try
-        {
-            slot = Device.GetProperty<uint>(DsHidMiniDriver.IpcSlotIndexProperty);
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-
-        if (slot is < 1 or > byte.MaxValue)
-        {
-            return null;
-        }
-
-        return (int)slot;
-    }
-
     [RelayCommand]
     private async Task PairNow()
     {
@@ -896,7 +876,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             return;
         }
 
-        int? slot = TryGetIpcSlotIndex();
+        int? slot = DsHidMiniInterop.TryGetIpcSlotIndex(Device);
         if (slot is not int deviceIndex)
         {
             Log.Logger.Warning(

--- a/ControlApp/Views/UserControls/DeviceUserControl.xaml
+++ b/ControlApp/Views/UserControls/DeviceUserControl.xaml
@@ -272,10 +272,10 @@
                             <ui:Button
                                 Margin="10,0,0,0"
                                 VerticalAlignment="Stretch"
-                                Command="{Binding TriggerPairingOnHotReloadCommand}"
+                                Command="{Binding PairNowCommand}"
                                 Content="Pair now"
                                 DockPanel.Dock="Right"
-                                IsEnabled="{Binding SupportsBluetoothPairing}" />
+                                IsEnabled="{Binding CanPairNow}" />
 
                             <ComboBox
                                 x:Name="PairingModeComboBox"

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
@@ -610,4 +610,240 @@ public partial class DsHidMiniInterop
             _commandMutex.ReleaseMutex();
         }
     }
+
+    /// <summary>
+    ///     Pairs the given device to the active local Bluetooth radio.
+    ///     Does not persist pairing mode or overwrite the JSON host address.
+    ///     Wired devices only.
+    /// </summary>
+    /// <param name="deviceIndex">The one-based device index.</param>
+    /// <returns>A <see cref="SetHostResult" /> containing write/read NTSTATUS values.</returns>
+    /// <exception cref="DsHidMiniInteropUnavailableException">
+    ///     Driver IPC unavailable, make sure that at least one compatible
+    ///     controller is connected and operational.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropInvalidDeviceIndexException">
+    ///     The <paramref name="deviceIndex" /> was outside the valid range 1..255.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropConcurrencyException">A different thread is currently performing a data exchange.</exception>
+    /// <exception cref="DsHidMiniInteropReplyTimeoutException">The driver didn't respond within an expected period.</exception>
+    /// <exception cref="DsHidMiniInteropUnexpectedReplyException">The driver returned unexpected or malformed data.</exception>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public unsafe SetHostResult PairToCurrentHost(int deviceIndex)
+    {
+        if (_commandMutex is null || _cmdView is null)
+        {
+            throw new DsHidMiniInteropUnavailableException();
+        }
+
+        ValidateDeviceIndex(deviceIndex);
+
+        AcquireCommandLock();
+
+        try
+        {
+            ref DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST request =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST>(_cmdView);
+
+            request.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_RESPONSE;
+            request.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_DEVICE;
+            request.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST;
+            request.Header.TargetIndex = (uint)deviceIndex;
+            request.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST>();
+
+            if (!SendAndWait())
+            {
+                throw new DsHidMiniInteropReplyTimeoutException();
+            }
+
+            ref DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY reply =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY>(_cmdView);
+
+            if (reply.Header is
+                {
+                    Type: DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY,
+                    Target: DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT,
+                    Command.Device: DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST
+                }
+                && reply.Header.TargetIndex == deviceIndex
+                && reply.Header.Size == Marshal.SizeOf<DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY>())
+            {
+                return new SetHostResult { WriteStatus = reply.WriteStatus, ReadStatus = reply.ReadStatus };
+            }
+
+            throw new DsHidMiniInteropUnexpectedReplyException(ref reply.Header);
+        }
+        finally
+        {
+            _commandMutex.ReleaseMutex();
+        }
+    }
+
+    /// <summary>
+    ///     Disconnects a currently wireless device from the host radio.
+    ///     Wired devices return <c>STATUS_NOT_SUPPORTED</c>.
+    /// </summary>
+    /// <param name="deviceIndex">The one-based device index.</param>
+    /// <returns>The NTSTATUS returned by the driver.</returns>
+    /// <exception cref="DsHidMiniInteropUnavailableException">
+    ///     Driver IPC unavailable, make sure that at least one compatible
+    ///     controller is connected and operational.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropInvalidDeviceIndexException">
+    ///     The <paramref name="deviceIndex" /> was outside the valid range 1..255.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropConcurrencyException">A different thread is currently performing a data exchange.</exception>
+    /// <exception cref="DsHidMiniInteropReplyTimeoutException">The driver didn't respond within an expected period.</exception>
+    /// <exception cref="DsHidMiniInteropUnexpectedReplyException">The driver returned unexpected or malformed data.</exception>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public unsafe UInt32 DisconnectBluetoothDevice(int deviceIndex)
+    {
+        if (_commandMutex is null || _cmdView is null)
+        {
+            throw new DsHidMiniInteropUnavailableException();
+        }
+
+        ValidateDeviceIndex(deviceIndex);
+
+        AcquireCommandLock();
+
+        try
+        {
+            ref DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST request =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST>(_cmdView);
+
+            request.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_RESPONSE;
+            request.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_DEVICE;
+            request.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_DISCONNECT_BLUETOOTH;
+            request.Header.TargetIndex = (uint)deviceIndex;
+            request.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST>();
+
+            if (!SendAndWait())
+            {
+                throw new DsHidMiniInteropReplyTimeoutException();
+            }
+
+            ref DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY reply =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY>(_cmdView);
+
+            if (reply.Header is
+                {
+                    Type: DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY,
+                    Target: DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT,
+                    Command.Device: DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_DISCONNECT_BLUETOOTH
+                }
+                && reply.Header.TargetIndex == deviceIndex
+                && reply.Header.Size == Marshal.SizeOf<DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY>())
+            {
+                return reply.NtStatus;
+            }
+
+            throw new DsHidMiniInteropUnexpectedReplyException(ref reply.Header);
+        }
+        finally
+        {
+            _commandMutex.ReleaseMutex();
+        }
+    }
+
+    /// <summary>
+    ///     Applies a full LED pattern (flags plus four independent effect blocks).
+    ///     The change is volatile: Automatic LED authority is handed to the application
+    ///     for the rest of the session. Returns <c>STATUS_ACCESS_DENIED</c> when LED
+    ///     authority is configured as Driver, and <c>STATUS_INVALID_PARAMETER</c> for
+    ///     reserved flag bits.
+    /// </summary>
+    /// <param name="deviceIndex">The one-based device index.</param>
+    /// <param name="pattern">The flags and per-LED effects to apply.</param>
+    /// <returns>The NTSTATUS returned by the driver.</returns>
+    /// <exception cref="DsHidMiniInteropUnavailableException">
+    ///     Driver IPC unavailable, make sure that at least one compatible
+    ///     controller is connected and operational.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropInvalidDeviceIndexException">
+    ///     The <paramref name="deviceIndex" /> was outside the valid range 1..255.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     <paramref name="pattern" /> uses reserved LED flag bits.
+    /// </exception>
+    /// <exception cref="DsHidMiniInteropConcurrencyException">A different thread is currently performing a data exchange.</exception>
+    /// <exception cref="DsHidMiniInteropReplyTimeoutException">The driver didn't respond within an expected period.</exception>
+    /// <exception cref="DsHidMiniInteropUnexpectedReplyException">The driver returned unexpected or malformed data.</exception>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public unsafe UInt32 SetLedPattern(int deviceIndex, Ds3LedPattern pattern)
+    {
+        if (_commandMutex is null || _cmdView is null)
+        {
+            throw new DsHidMiniInteropUnavailableException();
+        }
+
+        ValidateDeviceIndex(deviceIndex);
+
+        if (!Ds3LedPattern.AreFlagsValid(pattern.Flags))
+        {
+            throw new ArgumentOutOfRangeException(nameof(pattern),
+                "LED flags may only use the documented DS3 LED bits (1-4 and off).");
+        }
+
+        AcquireCommandLock();
+
+        try
+        {
+            ref DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST request =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST>(_cmdView);
+
+            request.Header.Type = DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_RESPONSE;
+            request.Header.Target = DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_DEVICE;
+            request.Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN;
+            request.Header.TargetIndex = (uint)deviceIndex;
+            request.Header.Size = (uint)Marshal.SizeOf<DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST>();
+
+            request.Flags = pattern.Flags;
+            request.Reserved0 = 0;
+            request.Reserved1 = 0;
+            request.Reserved2 = 0;
+            request.Player1 = ToIpcLedEffect(pattern.Player1);
+            request.Player2 = ToIpcLedEffect(pattern.Player2);
+            request.Player3 = ToIpcLedEffect(pattern.Player3);
+            request.Player4 = ToIpcLedEffect(pattern.Player4);
+
+            if (!SendAndWait())
+            {
+                throw new DsHidMiniInteropReplyTimeoutException();
+            }
+
+            ref DSHM_IPC_MSG_SET_LED_PATTERN_REPLY reply =
+                ref Unsafe.AsRef<DSHM_IPC_MSG_SET_LED_PATTERN_REPLY>(_cmdView);
+
+            if (reply.Header is
+                {
+                    Type: DSHM_IPC_MSG_TYPE.DSHM_IPC_MSG_TYPE_REQUEST_REPLY,
+                    Target: DSHM_IPC_MSG_TARGET.DSHM_IPC_MSG_TARGET_CLIENT,
+                    Command.Device: DSHM_IPC_MSG_CMD_DEVICE.DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN
+                }
+                && reply.Header.TargetIndex == deviceIndex
+                && reply.Header.Size == Marshal.SizeOf<DSHM_IPC_MSG_SET_LED_PATTERN_REPLY>())
+            {
+                return reply.NtStatus;
+            }
+
+            throw new DsHidMiniInteropUnexpectedReplyException(ref reply.Header);
+        }
+        finally
+        {
+            _commandMutex.ReleaseMutex();
+        }
+    }
+
+    private static DSHM_IPC_LED_EFFECT ToIpcLedEffect(Ds3LedEffect effect)
+    {
+        return new DSHM_IPC_LED_EFFECT
+        {
+            TotalDuration = effect.TotalDuration,
+            Reserved = 0,
+            BasePortionDuration = effect.BasePortionDuration,
+            OffPortionMultiplier = effect.OffPortionMultiplier,
+            OnPortionMultiplier = effect.OnPortionMultiplier
+        };
+    }
 }

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.cs
@@ -274,7 +274,7 @@ public sealed partial class DsHidMiniInterop : IDisposable
     ///     Reads the driver's one-based IPC slot for a device when available (see <see cref="DsHidMiniDriver.IpcSlotIndexProperty" />).
     /// </summary>
     /// <returns>The slot index, or <see langword="null" /> if the property is missing (older driver) or invalid.</returns>
-    private static int? TryGetIpcSlotIndex(PnPDevice device)
+    public static int? TryGetIpcSlotIndex(PnPDevice device)
     {
         uint slot;
         try

--- a/SDK/Nefarius.DsHidMini.IPC/Models/CmdStructs.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/CmdStructs.cs
@@ -219,3 +219,104 @@ internal struct DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY
 
     public UInt32 NtStatus;
 }
+
+/// <summary>
+///     One DS3 LED effect block for IPC. The reserved byte keeps
+///     <see cref="BasePortionDuration" /> naturally aligned.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_LED_EFFECT
+{
+    public byte TotalDuration;
+    public byte Reserved;
+    public ushort BasePortionDuration;
+    public byte OffPortionMultiplier;
+    public byte OnPortionMultiplier;
+}
+
+/// <summary>
+///     Pair a given device to the active local Bluetooth radio.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST
+{
+    public DSHM_IPC_MSG_HEADER Header;
+}
+
+/// <summary>
+///     Reply to <see cref="DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST" />.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    public UInt32 WriteStatus;
+
+    public UInt32 ReadStatus;
+}
+
+/// <summary>
+///     Disconnect a currently wireless device from the host radio.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST
+{
+    public DSHM_IPC_MSG_HEADER Header;
+}
+
+/// <summary>
+///     Reply to <see cref="DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST" />.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    public UInt32 NtStatus;
+}
+
+/// <summary>
+///     Apply a full volatile LED pattern (flags + four independent effects).
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    public byte Flags;
+
+    public byte Reserved0;
+    public byte Reserved1;
+    public byte Reserved2;
+
+    public DSHM_IPC_LED_EFFECT Player1;
+    public DSHM_IPC_LED_EFFECT Player2;
+    public DSHM_IPC_LED_EFFECT Player3;
+    public DSHM_IPC_LED_EFFECT Player4;
+}
+
+/// <summary>
+///     Reply to <see cref="DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST" />.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+internal struct DSHM_IPC_MSG_SET_LED_PATTERN_REPLY
+{
+    public DSHM_IPC_MSG_HEADER Header;
+
+    public UInt32 NtStatus;
+}

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Enums.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Enums.cs
@@ -114,5 +114,20 @@ internal enum DSHM_IPC_MSG_CMD_DEVICE : UInt32
     /// <summary>
     ///     Enables or disables alternative rumble mode at runtime
     /// </summary>
-    DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE
+    DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE,
+
+    /// <summary>
+    ///     Pair a given device to the active local Bluetooth radio
+    /// </summary>
+    DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST,
+
+    /// <summary>
+    ///     Disconnect a currently wireless device from the host radio
+    /// </summary>
+    DSHM_IPC_MSG_CMD_DEVICE_DISCONNECT_BLUETOOTH,
+
+    /// <summary>
+    ///     Apply a full volatile LED pattern (flags + four effect blocks)
+    /// </summary>
+    DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN
 }

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3LedEffect.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3LedEffect.cs
@@ -1,0 +1,40 @@
+namespace Nefarius.DsHidMini.IPC.Models.Public;
+
+/// <summary>
+///     One DualShock 3 LED effect block (duration and flash multipliers).
+///     Values match the driver's <c>DS_LED</c> / named effect macros.
+/// </summary>
+public readonly struct Ds3LedEffect
+{
+    /// <summary>PS3-correct static effect: lasts forever, no flashing.</summary>
+    public static Ds3LedEffect Static { get; } = new(0xFF, 0x0001, 0x00, 0x01);
+
+    /// <summary>Slow flash, used for Low/Dying battery levels.</summary>
+    public static Ds3LedEffect SlowFlash { get; } = new(0xFF, 0x000F, 0x7F, 0x7F);
+
+    /// <summary>Fast flash, used by the DS4Windows high-latency warning.</summary>
+    public static Ds3LedEffect FastFlash { get; } = new(0xFF, 0x0003, 0x7F, 0x7F);
+
+    /// <summary>All-zero effect block for an unlit LED.</summary>
+    public static Ds3LedEffect None { get; } = new(0x00, 0x0000, 0x00, 0x00);
+
+    public Ds3LedEffect(
+        byte totalDuration,
+        ushort basePortionDuration,
+        byte offPortionMultiplier,
+        byte onPortionMultiplier)
+    {
+        TotalDuration = totalDuration;
+        BasePortionDuration = basePortionDuration;
+        OffPortionMultiplier = offPortionMultiplier;
+        OnPortionMultiplier = onPortionMultiplier;
+    }
+
+    public byte TotalDuration { get; }
+
+    public ushort BasePortionDuration { get; }
+
+    public byte OffPortionMultiplier { get; }
+
+    public byte OnPortionMultiplier { get; }
+}

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3LedPattern.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3LedPattern.cs
@@ -1,0 +1,68 @@
+namespace Nefarius.DsHidMini.IPC.Models.Public;
+
+/// <summary>
+///     Full DualShock 3 LED pattern: a flags byte plus four independent
+///     per-LED effect blocks. Used by <see cref="DsHidMiniInterop.SetLedPattern" />.
+/// </summary>
+public readonly struct Ds3LedPattern
+{
+    /// <summary>
+    ///     Documented DS3 LED bits: physical LEDs 1-4 and the explicit off marker.
+    /// </summary>
+    public const byte ValidFlagsMask =
+        Ds3PlayerLeds.Led1 | Ds3PlayerLeds.Led2 | Ds3PlayerLeds.Led3 | Ds3PlayerLeds.Led4 | Ds3PlayerLeds.LedOff;
+
+    public Ds3LedPattern(
+        byte flags,
+        Ds3LedEffect player1,
+        Ds3LedEffect player2,
+        Ds3LedEffect player3,
+        Ds3LedEffect player4)
+    {
+        Flags = flags;
+        Player1 = player1;
+        Player2 = player2;
+        Player3 = player3;
+        Player4 = player4;
+    }
+
+    public byte Flags { get; }
+
+    public Ds3LedEffect Player1 { get; }
+
+    public Ds3LedEffect Player2 { get; }
+
+    public Ds3LedEffect Player3 { get; }
+
+    public Ds3LedEffect Player4 { get; }
+
+    /// <summary>
+    ///     Returns <see langword="true" /> when <paramref name="flags" /> uses only
+    ///     documented DS3 LED bits. Zero (all off) is valid.
+    /// </summary>
+    public static bool AreFlagsValid(byte flags)
+    {
+        return (flags & ~ValidFlagsMask) == 0;
+    }
+
+    /// <summary>
+    ///     Static player-index pattern for slots 1-7 (same mapping as
+    ///     <see cref="DsHidMiniInterop.SetPlayerIndex" />).
+    /// </summary>
+    public static bool TryFromPlayerIndex(byte playerIndex, out Ds3LedPattern pattern)
+    {
+        if (!Ds3PlayerLeds.TryGetFlags(playerIndex, out byte flags))
+        {
+            pattern = default;
+            return false;
+        }
+
+        pattern = new Ds3LedPattern(
+            flags,
+            Ds3LedEffect.Static,
+            Ds3LedEffect.Static,
+            Ds3LedEffect.Static,
+            Ds3LedEffect.Static);
+        return true;
+    }
+}

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3PlayerLeds.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/Ds3PlayerLeds.cs
@@ -18,6 +18,9 @@ public static class Ds3PlayerLeds
     /// <summary>Physical LED 4 bit.</summary>
     public const byte Led4 = 0x10;
 
+    /// <summary>Explicit all-off marker used by the hardware and custom patterns.</summary>
+    public const byte LedOff = 0x20;
+
     /// <summary>
     ///     Maps a player index (1-7) to the DS3 LED flags byte. Indices 5-7 use the
     ///     extra combinations the hardware uses once four physical LEDs are exhausted.

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/SetHostResult.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/SetHostResult.cs
@@ -12,6 +12,11 @@ public struct SetHostResult
     /// </summary>
     public UInt32 ReadStatus;
 
+    /// <summary>
+    ///     <see langword="true" /> when both the pairing write and the verify read succeeded.
+    /// </summary>
+    public bool Succeeded => PowerOffUsbResult.IsNtSuccess(WriteStatus) && PowerOffUsbResult.IsNtSuccess(ReadStatus);
+
     public override string ToString()
     {
         return $"Pairing result: 0x{WriteStatus:X}, query result: 0x{ReadStatus:X}";

--- a/SDK/Nefarius.DsHidMini.IPC/README.md
+++ b/SDK/Nefarius.DsHidMini.IPC/README.md
@@ -119,6 +119,7 @@ if (gotReport)
 | Member | Description |
 |--------|-------------|
 | **`static bool IsAvailable`** | `true` if the driver’s shared memory is present (at least one device active). Check this before constructing. |
+| **`static int? TryGetIpcSlotIndex(PnPDevice device)`** | Reads the driver’s one-based IPC slot from `DsHidMiniDriver.IpcSlotIndexProperty`. Returns `null` when the property is missing or outside 1…255. |
 | **`DsHidMiniInterop()`** | Connects to the driver IPC. Throws if not available. Subscribes to device arrival/removal for reconnection. |
 | **`void Dispose()`** | Releases mapped views, file mapping, and events. Implement `IDisposable` and dispose when done. |
 | **`void Reconnect()`** | Re-opens mutex, events, and shared memory (e.g. after all devices were removed). Throws if still no device. |
@@ -141,7 +142,7 @@ All device-indexed APIs use a **one-based** device index (see [Device index](#de
 
 - **Valid range:** `1` … `255` (inclusive).  
 - **Meaning:** The index is the driver’s **IPC slot** (`SlotIndex`): shared HID memory, per-slot wait events (`Global\DsHidMiniHidReportEvent` + index), and IPC `TargetIndex` all use this same one-based value.  
-- **Discovery:** Read the read-only device property **`DsHidMiniDriver.IpcSlotIndexProperty`** (`DEVPROP_TYPE_UINT32`, same value the driver publishes after claiming a slot). Enumerate DsHidMini device interfaces and query this property per `PnPDevice`—do **not** assume SetupAPI / `CM_Get_Device_Interface_List` ordering matches slot order (e.g. after a middle device disconnects, remaining devices may occupy non-contiguous slots such as `1` and `3`).  
+- **Discovery:** Use **`DsHidMiniInterop.TryGetIpcSlotIndex(PnPDevice)`**, which reads the read-only device property **`DsHidMiniDriver.IpcSlotIndexProperty`** (`DEVPROP_TYPE_UINT32`, same value the driver publishes after claiming a slot). Enumerate DsHidMini device interfaces and query this property per `PnPDevice`—do **not** assume SetupAPI / `CM_Get_Device_Interface_List` ordering matches slot order (e.g. after a middle device disconnects, remaining devices may occupy non-contiguous slots such as `1` and `3`).  
 - **Older drivers:** If the property is absent, fall back to your own mapping; ordering-only heuristics may be wrong when slots are not contiguous.  
 - **Invalid index:** APIs throw `DsHidMiniInteropInvalidDeviceIndexException` if `deviceIndex` is ≤ 0 or &gt; 255.
 

--- a/SDK/Nefarius.DsHidMini.IPC/README.md
+++ b/SDK/Nefarius.DsHidMini.IPC/README.md
@@ -37,10 +37,12 @@ Use it from a .NET Standard 2.0 consumer or a .NET 10 Windows application (deskt
 | Capability | Description |
 |------------|-------------|
 | **Read raw input** | Poll or wait for `DS3_RAW_INPUT_REPORT` (buttons, sticks, pressure, motion) |
-| **Pair to host** | Set the Bluetooth host address the controller pairs to (`SetHostAddress`) |
+| **Pair to host** | Set the Bluetooth host address the controller pairs to (`SetHostAddress`) or pair to the active local radio (`PairToCurrentHost`) |
 | **Player index** | Set the player LED slot (1–7) with `SetPlayerIndex` (volatile) |
+| **LED pattern** | Apply flags plus four independent effect blocks with `SetLedPattern` (volatile) |
 | **Rumble** | Send motor strengths with `SetRumble` (volatile; uses driver rescale / keep-alive) |
 | **Alternate rumble** | Toggle alternative rumble mode with `SetAlternateRumbleMode` (volatile; not written to JSON) |
+| **Bluetooth disconnect** | Disconnect a wireless device with `DisconnectBluetoothDevice` |
 | **USB power-off** | Send the console USB power-off sequence with `PowerOffUsbDevice` |
 | **Liveness check** | Verify driver is responsive with `SendPing` |
 
@@ -122,8 +124,11 @@ if (gotReport)
 | **`void Reconnect()`** | Re-opens mutex, events, and shared memory (e.g. after all devices were removed). Throws if still no device. |
 | **`bool GetRawInputReport(int deviceIndex, ref DS3_RAW_INPUT_REPORT report, TimeSpan? timeout)`** | Fills `report` with the last or next raw HID report. Use `timeout: null` for immediate read; use e.g. `TimeSpan.FromMilliseconds(20)` for event-based waiting on the driver’s named per-slot manual-reset event (`Global\DsHidMiniHidReportEvent` + index). Multiple clients can wait on the same slot. Returns `false` if the slot is empty, or if a timeout was requested and no wait object exists for that slot (nothing connected there). |
 | **`void SendPing()`** | Sends a ping to the driver and waits for a reply (liveness check). |
-| **`SetHostResult SetHostAddress(int deviceIndex, PhysicalAddress hostAddress)`** | Writes the new Bluetooth host address (pairing). Returns write/read NTSTATUS in `SetHostResult`. |
+| **`SetHostResult SetHostAddress(int deviceIndex, PhysicalAddress hostAddress)`** | Writes the new Bluetooth host address (pairing). Does not persist pairing mode. Returns write/read NTSTATUS in `SetHostResult`. |
+| **`SetHostResult PairToCurrentHost(int deviceIndex)`** | Pairs the device to the active local Bluetooth radio. Wired devices only; does not persist pairing mode. |
+| **`uint DisconnectBluetoothDevice(int deviceIndex)`** | Disconnects a currently wireless device. Returns NTSTATUS (`STATUS_NOT_SUPPORTED` when the device is wired). |
 | **`uint SetPlayerIndex(int deviceIndex, byte playerIndex)`** | Sets the player LED index (1–7). Volatile: Automatic LED authority is handed to the application so driver battery refreshes do not overwrite the slot. Returns NTSTATUS (`STATUS_ACCESS_DENIED` when LED authority is Driver). |
+| **`uint SetLedPattern(int deviceIndex, Ds3LedPattern pattern)`** | Applies a full LED pattern (flags + four effect blocks). Volatile; same authority rules as `SetPlayerIndex`. Reserved flag bits throw before the driver is called. |
 | **`uint SetRumble(int deviceIndex, byte largeMotor, byte smallMotor)`** | Sets heavy/left and light/right motor strengths (0–255). Volatile; processed through rescale, alternative mode, keep-alive, and Navigation suppression. Returns NTSTATUS. |
 | **`uint SetAlternateRumbleMode(int deviceIndex, bool enabled)`** | Enables or disables alternative rumble mode for the current session only. A config reload restores the JSON value. Returns NTSTATUS. |
 | **`PowerOffUsbResult PowerOffUsbDevice(int deviceIndex)`** | Sends the PlayStation 3 USB power-off sequence (zero output report, then Feature 0xF4 disable). Wired devices only; the controller stays enumerated. |
@@ -156,10 +161,19 @@ All device-indexed APIs use a **one-based** device index (see [Device index](#de
 
 - **`WriteStatus`** — NTSTATUS of the “pair to host” write.  
 - **`ReadStatus`** — NTSTATUS of the subsequent read-back of the address.
+- **`Succeeded`** — `true` when both the write and the verify read completed successfully.
 
 ### `Ds3PlayerLeds` (player LED mapping)
 
 - **`TryGetFlags(byte playerIndex, out byte flags)`** — maps 1–7 to the DS3 LED mask (`0x02`, `0x04`, `0x08`, `0x10`, plus 5=`1+4`, 6=`2+4`, 7=`3+4`).
+- **`LedOff`** — explicit all-off marker (`0x20`).
+
+### `Ds3LedPattern` / `Ds3LedEffect` (direct LED output)
+
+- **`Ds3LedEffect`** — duration and flash multipliers, with named `Static`, `SlowFlash`, `FastFlash`, and `None` presets.
+- **`Ds3LedPattern`** — flags plus four independent per-LED effect blocks.
+- **`AreFlagsValid(byte flags)`** — accepts only documented DS3 LED bits (1–4 and off). Zero is valid.
+- **`TryFromPlayerIndex(byte playerIndex, out Ds3LedPattern pattern)`** — builds a static player-index pattern.
 
 ### `PowerOffUsbResult` (USB power-off)
 

--- a/driver/Configuration.c
+++ b/driver/Configuration.c
@@ -566,12 +566,6 @@ static void ConfigNodeParse(
 		EventWriteOverrideSettingUInt(ParentNode->string, "DevicePairingMode", pCfg->DevicePairingMode);
 	}
 
-	if ((pNode = cJSON_GetObjectItem(ParentNode, "PairOnHotReload")))
-	{
-		pCfg->PairOnHotReload = (BOOLEAN)cJSON_IsTrue(pNode);
-		EventWriteOverrideSettingUInt(ParentNode->string, "PairOnHotReload", pCfg->PairOnHotReload);
-	}
-
 	if ((pNode = cJSON_GetObjectItem(ParentNode, "CustomPairingAddress")))
 	{
 		char* eptr; // not used
@@ -1065,7 +1059,6 @@ ConfigSetDefaults(
 
 	Config->HidDeviceMode = DsHidMiniDeviceModeXInputHIDCompatible;
 	Config->DevicePairingMode = DsDevicePairingModeAuto;
-	Config->PairOnHotReload = FALSE;
 	Config->AutoRestartOnHidModeMismatch = TRUE;
 	Config->UsbOutputReportTransport = DsUsbOutputReportTransportAuto;
 	Config->BluetoothOutputReportTransport = DsBluetoothOutputReportTransportControl;

--- a/driver/Device.c
+++ b/driver/Device.c
@@ -1135,17 +1135,6 @@ DsDevice_HotReloadEventCallback(
 		WdfWaitLockRelease(pDevCtx->ConfigurationDirectoryWatcherLock);
 
 		//
-		// If PairOnHotReload is enabled and not in disabled pairing mode then attempt pairing process followed by requesting currently set host address
-		//
-		if (pDevCtx->ConnectionType == DsDeviceConnectionTypeUsb
-			&& pDevCtx->Configuration.PairOnHotReload
-			&& pDevCtx->Configuration.DevicePairingMode != DsDevicePairingModeDisabled)
-		{
-			WDFDEVICE wdfDev = DMF_ParentDeviceGet(pDevCtx->DsHidMiniModule);
-			DsUsb_Ds3PairAndVerify(wdfDev, NULL);
-		}
-
-		//
 		// Restore the Automatic authority hand-off for this reload before
 		// recomputing LED state: without this, OutputReport.Mode would stay
 		// latched at whatever an application last wrote (or its power-up

--- a/driver/Ds3.c
+++ b/driver/Ds3.c
@@ -713,6 +713,134 @@ NTSTATUS DS3_GetActiveRadioAddress(BD_ADDR* Address)
 }
 
 //
+// Sends a pairing write for an already-resolved host address. Does not
+// consult or mutate DevicePairingMode / CustomHostAddress.
+// 
+static
+NTSTATUS
+DsUsb_Ds3PairToSpecifiedHost(
+	_In_ WDFDEVICE Device,
+	_In_ BD_ADDR NewHostAddress
+)
+{
+	NTSTATUS status = STATUS_UNSUCCESSFUL;
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
+
+	FuncEntry(TRACE_DS3);
+
+	do
+	{
+		if (!pDevCtx->SupportsBluetoothAddressReports)
+		{
+			//
+			// This device never reported its own Bluetooth MAC (see issue
+			// #321), so it cannot meaningfully be paired to a host either;
+			// the address the console/host would store against is not one
+			// this device recognizes. Callers already tolerate this status.
+			// 
+			TraceInformation(
+				TRACE_DS3,
+				"Device does not support Bluetooth address reports, skipping pairing"
+			);
+			status = STATUS_NOT_SUPPORTED;
+			break;
+		}
+
+		//
+		// Don't issue request when addresses already match
+		// 
+		if (RtlCompareMemory(
+				&NewHostAddress,
+				&pDevCtx->HostAddress.Address[0],
+				sizeof(BD_ADDR)
+			) == sizeof(BD_ADDR)
+			)
+		{
+			TraceInformation(
+				TRACE_DS3,
+				"Device's current host address equals desired new address, skipping"
+			);
+
+			EventWriteAlreadyPaired(pDevCtx->DeviceAddressString);
+
+			status = STATUS_SUCCESS;
+			break;
+		}
+
+		if (!NT_SUCCESS(status = DsUsb_Ds3SendPairingRequest(Device, NewHostAddress)))
+		{
+			TraceError(
+				TRACE_DS3,
+				"DsUsb_Ds3SendPairingRequest failed with status %!STATUS!",
+				status
+			);
+			break;
+		}
+
+		status = STATUS_SUCCESS;
+
+	} while (FALSE);
+
+	FuncExit(TRACE_DS3, "status=%!STATUS!", status);
+
+	return status;
+}
+
+//
+// Re-reads the host address after a pairing write (or skip). Shared by
+// configured, explicit-address, and active-radio pairing paths.
+// 
+static
+NTSTATUS
+DsUsb_Ds3VerifyAfterPair(
+	_In_ WDFDEVICE Device,
+	_In_ NTSTATUS WriteStatus,
+	_Out_opt_ PNTSTATUS ReadStatus
+)
+{
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
+
+	if (WriteStatus == STATUS_NOT_SUPPORTED || !pDevCtx->SupportsBluetoothAddressReports)
+	{
+		WDF_DEVICE_PROPERTY_DATA propertyData;
+		NTSTATUS notSupportedStatus = STATUS_NOT_SUPPORTED;
+
+		WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_LastHostRequestStatus);
+		propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
+		propertyData.Lcid = LOCALE_NEUTRAL;
+
+		(VOID)WdfDeviceAssignProperty(
+			Device,
+			&propertyData,
+			DEVPROP_TYPE_NTSTATUS,
+			sizeof(NTSTATUS),
+			&notSupportedStatus
+		);
+
+		if (ReadStatus)
+		{
+			*ReadStatus = STATUS_NOT_SUPPORTED;
+		}
+
+		return WriteStatus;
+	}
+
+	if (NT_SUCCESS(WriteStatus))
+	{
+		Sleep(DS3_PAIRING_VERIFY_DELAY_MS);
+	}
+
+	const NTSTATUS readStatus = DsUsb_Ds3RequestHostAddress(Device);
+
+	if (ReadStatus)
+	{
+		*ReadStatus = readStatus;
+	}
+
+	return WriteStatus;
+}
+
+//
 // Pairs DS3 to current BT host or to user defined host address, depending on current pairing mode
 // 
 NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device)
@@ -727,12 +855,6 @@ NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device)
 	{
 		if (!pDevCtx->SupportsBluetoothAddressReports)
 		{
-			//
-			// This device never reported its own Bluetooth MAC (see issue
-			// #321), so it cannot meaningfully be paired to a host either;
-			// the address the console/host would store against is not one
-			// this device recognizes. Callers already tolerate this status.
-			// 
 			TraceInformation(
 				TRACE_DS3,
 				"Device does not support Bluetooth address reports, skipping pairing"
@@ -758,7 +880,7 @@ NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device)
 				"Pairing device to active radio host address"
 			);
 
-			if (!NT_SUCCESS(DS3_GetActiveRadioAddress(&newHostAddress)))
+			if (!NT_SUCCESS(status = DS3_GetActiveRadioAddress(&newHostAddress)))
 			{
 				TraceError(
 					TRACE_DS3,
@@ -768,9 +890,6 @@ NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device)
 			}
 		}
 
-		//
-		// Use configured custom mac address if in custom mode
-		//
 		if (pDevCtx->Configuration.DevicePairingMode == DsDevicePairingModeCustom)
 		{
 			TraceInformation(
@@ -778,47 +897,14 @@ NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device)
 				"Pairing device to user defined MAC address"
 			);
 
-			for (int i = 0; i < sizeof(BD_ADDR); i++)
-			{
-				newHostAddress.Address[i] = pDevCtx->Configuration.CustomHostAddress[i];
-			}
-		}
-
-		//
-		// Don't issue request when addresses already match
-		// 
-		if (RtlCompareMemory(
+			RtlCopyMemory(
 				&newHostAddress,
-				&pDevCtx->HostAddress.Address[0],
+				pDevCtx->Configuration.CustomHostAddress,
 				sizeof(BD_ADDR)
-			) == sizeof(BD_ADDR)
-			)
-		{
-			TraceInformation(
-				TRACE_DS3,
-				"Device's current host address equals desired new address, skipping"
 			);
-
-			EventWriteAlreadyPaired(pDevCtx->DeviceAddressString);
-
-			status = STATUS_SUCCESS;
-			break;
 		}
 
-		//
-		// Send pairing request
-		//
-		if (!NT_SUCCESS(status = DsUsb_Ds3SendPairingRequest(Device, newHostAddress)))
-		{
-			TraceError(
-				TRACE_DS3,
-				"DsUsb_Ds3SendPairingRequest failed with status %!STATUS!",
-				status
-			);
-			break;
-		}
-
-		status = STATUS_SUCCESS;
+		status = DsUsb_Ds3PairToSpecifiedHost(Device, newHostAddress);
 
 	} while (FALSE);
 
@@ -829,69 +915,77 @@ NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device)
 
 //
 // Pairs to the configured host (or skips it, see DsUsb_Ds3PairToNewHost) and
-// then re-reads the host address to verify/reflect the outcome, waiting a
-// short delay in between. The PS3 itself leaves 27-75 ms between its SET
-// Feature 0xF5 and the verifying GET Feature 0xF5 across capture samples;
-// mirrored here as a single fixed delay so a freshly-paired device has
-// settled before being read back. Used by every call site that used to
-// call DsUsb_Ds3PairToNewHost followed by DsUsb_Ds3RequestHostAddress
-// directly, so the delay only needs to live in one place. See issue #321.
+// then re-reads the host address to verify/reflect the outcome. See issue #321.
 // 
 NTSTATUS DsUsb_Ds3PairAndVerify(_In_ WDFDEVICE Device, _Out_opt_ PNTSTATUS ReadStatus)
 {
 	FuncEntry(TRACE_DS3);
 
-	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
+	const NTSTATUS writeStatus = DsUsb_Ds3VerifyAfterPair(
+		Device,
+		DsUsb_Ds3PairToNewHost(Device),
+		ReadStatus
+	);
 
-	const NTSTATUS writeStatus = DsUsb_Ds3PairToNewHost(Device);
+	FuncExit(TRACE_DS3, "writeStatus=%!STATUS!", writeStatus);
 
-	//
-	// A device that never reported its own Bluetooth MAC (see issue #321)
-	// doesn't support the host-address feature report either; skip the
-	// verify read so we don't emit a spurious failed-host-request trace
-	// and event for an expected, already-logged condition, and keep
-	// reporting the not-supported status instead of overwriting it with
-	// whatever the (equally unsupported) read attempt would have failed
-	// with.
-	// 
-	if (writeStatus == STATUS_NOT_SUPPORTED || !pDevCtx->SupportsBluetoothAddressReports)
+	return writeStatus;
+}
+
+_Use_decl_annotations_
+NTSTATUS
+DsUsb_Ds3PairToAddressAndVerify(
+	_In_ WDFDEVICE Device,
+	_In_ BD_ADDR NewHostAddress,
+	_Out_opt_ PNTSTATUS ReadStatus
+)
+{
+	FuncEntry(TRACE_DS3);
+
+	const NTSTATUS writeStatus = DsUsb_Ds3VerifyAfterPair(
+		Device,
+		DsUsb_Ds3PairToSpecifiedHost(Device, NewHostAddress),
+		ReadStatus
+	);
+
+	FuncExit(TRACE_DS3, "writeStatus=%!STATUS!", writeStatus);
+
+	return writeStatus;
+}
+
+_Use_decl_annotations_
+NTSTATUS
+DsUsb_Ds3PairToActiveRadioAndVerify(
+	_In_ WDFDEVICE Device,
+	_Out_opt_ PNTSTATUS ReadStatus
+)
+{
+	BD_ADDR newHostAddress = { 0 };
+
+	FuncEntry(TRACE_DS3);
+
+	const NTSTATUS radioStatus = DS3_GetActiveRadioAddress(&newHostAddress);
+	if (!NT_SUCCESS(radioStatus))
 	{
-		WDF_DEVICE_PROPERTY_DATA propertyData;
-		NTSTATUS notSupportedStatus = STATUS_NOT_SUPPORTED;
-
-		WDF_DEVICE_PROPERTY_DATA_INIT(&propertyData, &DEVPKEY_DsHidMini_RO_LastHostRequestStatus);
-		propertyData.Flags |= PLUGPLAY_PROPERTY_PERSISTENT;
-		propertyData.Lcid = LOCALE_NEUTRAL;
-
-		(VOID)WdfDeviceAssignProperty(
-			Device,
-			&propertyData,
-			DEVPROP_TYPE_NTSTATUS,
-			sizeof(NTSTATUS),
-			&notSupportedStatus
+		TraceError(
+			TRACE_DS3,
+			"Failed to get active radio host address"
 		);
 
 		if (ReadStatus)
 		{
-			*ReadStatus = STATUS_NOT_SUPPORTED;
+			*ReadStatus = radioStatus;
 		}
 
-		FuncExit(TRACE_DS3, "writeStatus=%!STATUS!", writeStatus);
-
-		return writeStatus;
+		FuncExit(TRACE_DS3, "writeStatus=%!STATUS!", radioStatus);
+		return radioStatus;
 	}
 
-	if (NT_SUCCESS(writeStatus))
-	{
-		Sleep(DS3_PAIRING_VERIFY_DELAY_MS);
-	}
-
-	const NTSTATUS readStatus = DsUsb_Ds3RequestHostAddress(Device);
-
-	if (ReadStatus)
-	{
-		*ReadStatus = readStatus;
-	}
+	const NTSTATUS writeStatus = DsUsb_Ds3PairToAddressAndVerify(
+		Device,
+		newHostAddress,
+		ReadStatus
+	);
 
 	FuncExit(TRACE_DS3, "writeStatus=%!STATUS!", writeStatus);
 

--- a/driver/Ds3.h
+++ b/driver/Ds3.h
@@ -227,6 +227,17 @@ NTSTATUS DsUsb_Ds3PairToNewHost(WDFDEVICE Device);
 
 NTSTATUS DsUsb_Ds3PairAndVerify(_In_ WDFDEVICE Device, _Out_opt_ PNTSTATUS ReadStatus);
 
+NTSTATUS DsUsb_Ds3PairToAddressAndVerify(
+	_In_ WDFDEVICE Device,
+	_In_ BD_ADDR NewHostAddress,
+	_Out_opt_ PNTSTATUS ReadStatus
+);
+
+NTSTATUS DsUsb_Ds3PairToActiveRadioAndVerify(
+	_In_ WDFDEVICE Device,
+	_Out_opt_ PNTSTATUS ReadStatus
+);
+
 NTSTATUS DsBth_Ds3SixaxisInit(PDEVICE_CONTEXT Context);
 
 NTSTATUS DsUsb_Ds3RequestHostAddress(WDFDEVICE Device);

--- a/driver/DsCommon.h
+++ b/driver/DsCommon.h
@@ -624,11 +624,6 @@ typedef struct _DS_DRIVER_CONFIGURATION
 	UCHAR CustomHostAddress[6];
 
 	//
-	// When set, the pairing process will occur after hot-reloading configurations
-	//
-	BOOLEAN PairOnHotReload;
-
-	//
 	// Which USB transport to use for output reports (LEDs/rumble). Can't be
 	// altered at runtime; only evaluated once during PrepareHardware.
 	// 

--- a/driver/DsHidMini.json
+++ b/driver/DsHidMini.json
@@ -3,7 +3,6 @@
     "HidDeviceMode": "DS4Windows",
     "AutoRestartOnHidModeMismatch": true,
     "DevicePairingMode": "Auto",
-    "PairOnHotReload": false,
     "BluetoothOutputReportTransport": "Control",
     "IsOutputRateControlEnabled": true,
     "OutputRateControlPeriodMs": 150,
@@ -367,7 +366,6 @@
     "44D832809FCD": {
       "HidDeviceMode": "SDF",
       "DevicePairingMode": "Auto",
-      "PairOnHotReload": false,
       "IsOutputRateControlEnabled": true,
       "OutputRateControlPeriodMs": 150,
       "IsOutputDeduplicatorEnabled": false,
@@ -384,7 +382,6 @@
     "0019C1637EA0": {
       "HidDeviceMode": "GPJ",
       "DevicePairingMode": "Auto",
-      "PairOnHotReload": false,
       "IsOutputRateControlEnabled": true,
       "OutputRateControlPeriodMs": 150,
       "IsOutputDeduplicatorEnabled": false,

--- a/driver/DsLed.c
+++ b/driver/DsLed.c
@@ -542,3 +542,103 @@ DsLed_ApplyIpcPlayerIndex(
 
 	return status;
 }
+
+//
+// IPC LED-pattern write: same authority hand-off as player-index, but
+// applies four independent effect blocks like a custom pattern.
+// 
+_Use_decl_annotations_
+BOOLEAN
+DsLed_AreIpcFlagsValid(
+	_In_ UCHAR Flags
+)
+{
+	const UCHAR validMask = DS3_LED_1 | DS3_LED_2 | DS3_LED_3 | DS3_LED_4 | DS3_LED_OFF;
+
+	return (Flags & ~validMask) == 0;
+}
+
+_Use_decl_annotations_
+NTSTATUS
+DsLed_ApplyIpcPattern(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ UCHAR Flags,
+	_In_ const DS_LED Effects[4]
+)
+{
+	FuncEntry(TRACE_LED);
+
+	NTSTATUS status = STATUS_INVALID_PARAMETER;
+
+	if (!DsLed_AreIpcFlagsValid(Flags))
+	{
+		FuncExit(TRACE_LED, "status=%!STATUS!", status);
+		return status;
+	}
+
+	if (Context->Configuration.LEDSettings.Authority == DsLEDAuthorityDriver)
+	{
+		status = STATUS_ACCESS_DENIED;
+		FuncExit(TRACE_LED, "status=%!STATUS!", status);
+		return status;
+	}
+
+	WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+
+	Context->OutputReport.Mode = Ds3OutputReportModeWriteReportPassThrough;
+
+	const UCHAR clamped = DsLedClampFlagsForDevice(Context, Flags);
+
+	DsLed_SetFlags(Context, clamped);
+
+	DsLed_SetEffect(
+		Context,
+		0,
+		Effects[0].TotalDuration,
+		Effects[0].BasePortionDuration,
+		Effects[0].OffPortionMultiplier,
+		Effects[0].OnPortionMultiplier
+	);
+
+	if (Context->DeviceType == DsDeviceTypeNavigation)
+	{
+		DsLed_SetEffect(Context, 1, 0, 0, 0, 0);
+		DsLed_SetEffect(Context, 2, 0, 0, 0, 0);
+		DsLed_SetEffect(Context, 3, 0, 0, 0, 0);
+	}
+	else
+	{
+		DsLed_SetEffect(
+			Context,
+			1,
+			Effects[1].TotalDuration,
+			Effects[1].BasePortionDuration,
+			Effects[1].OffPortionMultiplier,
+			Effects[1].OnPortionMultiplier
+		);
+		DsLed_SetEffect(
+			Context,
+			2,
+			Effects[2].TotalDuration,
+			Effects[2].BasePortionDuration,
+			Effects[2].OffPortionMultiplier,
+			Effects[2].OnPortionMultiplier
+		);
+		DsLed_SetEffect(
+			Context,
+			3,
+			Effects[3].TotalDuration,
+			Effects[3].BasePortionDuration,
+			Effects[3].OffPortionMultiplier,
+			Effects[3].OnPortionMultiplier
+		);
+	}
+
+	status = DSHM_SendOutputReportUnlocked(Context, Ds3OutputReportSourceIpc);
+
+	WdfWaitLockRelease(Context->OutputReport.Lock);
+
+	FuncExit(TRACE_LED, "status=%!STATUS!", status);
+
+	return status;
+}

--- a/driver/DsLed.h
+++ b/driver/DsLed.h
@@ -156,3 +156,26 @@ DsLed_ApplyIpcPlayerIndex(
 	_In_ PDEVICE_CONTEXT Context,
 	_In_ BYTE PlayerIndex
 );
+
+//
+// Returns TRUE when Flags uses only the documented DS3 LED bits
+// (DS3_LED_1..4 and DS3_LED_OFF). Zero (all off) is valid.
+// 
+BOOLEAN
+DsLed_AreIpcFlagsValid(
+	_In_ UCHAR Flags
+);
+
+//
+// Applies an IPC LED pattern: marks LEDs application-owned for Automatic
+// authority, writes flags plus four independent effect blocks, and sends
+// the report under one hold of Context->OutputReport.Lock. Returns
+// STATUS_INVALID_PARAMETER for reserved flag bits and STATUS_ACCESS_DENIED
+// when LED authority is Driver.
+// 
+NTSTATUS
+DsLed_ApplyIpcPattern(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ UCHAR Flags,
+	_In_ const DS_LED Effects[4]
+);

--- a/driver/IPC.Device.c
+++ b/driver/IPC.Device.c
@@ -45,21 +45,33 @@ DSHM_EvtDispatchDeviceMessage(
 			request->Address.Address[5]
 		);
 
-		// TODO: this changes state for runtime settings, improve
-		DeviceContext->Configuration.DevicePairingMode = DsDevicePairingModeCustom;
-		RtlCopyMemory(&DeviceContext->Configuration.CustomHostAddress, &request->Address, sizeof(BD_ADDR));
+		NTSTATUS writeStatus = STATUS_NOT_SUPPORTED;
+		NTSTATUS readStatus = STATUS_NOT_SUPPORTED;
 
-		const WDFDEVICE device = WdfObjectContextGetObject(DeviceContext);
-
-		NTSTATUS readStatus = STATUS_UNSUCCESSFUL;
-		const NTSTATUS writeStatus = DsUsb_Ds3PairAndVerify(device, &readStatus);
-		if (!NT_SUCCESS(readStatus))
+		if (DeviceContext->ConnectionType != DsDeviceConnectionTypeUsb)
 		{
-			TraceError(
+			TraceWarning(
 				TRACE_IPC,
-				"DsUsb_Ds3RequestHostAddress failed with status %!STATUS!",
-				readStatus
+				"Pair-to-address requested for a non-USB device"
 			);
+		}
+		else
+		{
+			const WDFDEVICE device = WdfObjectContextGetObject(DeviceContext);
+
+			writeStatus = DsUsb_Ds3PairToAddressAndVerify(
+				device,
+				request->Address,
+				&readStatus
+			);
+			if (!NT_SUCCESS(readStatus))
+			{
+				TraceError(
+					TRACE_IPC,
+					"Pair-to-address verify failed with status %!STATUS!",
+					readStatus
+				);
+			}
 		}
 
 		DSHM_IPC_MSG_PAIR_TO_RESPONSE_INIT(
@@ -219,6 +231,124 @@ DSHM_EvtDispatchDeviceMessage(
 
 		DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_RESPONSE_INIT(
 			(PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY)MessageHeader,
+			MessageHeader->TargetIndex,
+			applyStatus
+		);
+
+		status = STATUS_SUCCESS;
+	}
+	else if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST)
+	{
+		NTSTATUS writeStatus = STATUS_INVALID_USER_BUFFER;
+		NTSTATUS readStatus = STATUS_INVALID_USER_BUFFER;
+
+		if (MessageHeader->Size < sizeof(DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST))
+		{
+			writeStatus = STATUS_INVALID_USER_BUFFER;
+			readStatus = STATUS_INVALID_USER_BUFFER;
+		}
+		else if (DeviceContext->ConnectionType != DsDeviceConnectionTypeUsb)
+		{
+			writeStatus = STATUS_NOT_SUPPORTED;
+			readStatus = STATUS_NOT_SUPPORTED;
+			TraceWarning(
+				TRACE_IPC,
+				"Pair-to-current-host requested for a non-USB device"
+			);
+		}
+		else
+		{
+			const WDFDEVICE device = WdfObjectContextGetObject(DeviceContext);
+
+			writeStatus = DsUsb_Ds3PairToActiveRadioAndVerify(device, &readStatus);
+			if (!NT_SUCCESS(readStatus))
+			{
+				TraceError(
+					TRACE_IPC,
+					"Pair-to-current-host verify failed with status %!STATUS!",
+					readStatus
+				);
+			}
+		}
+
+		DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_RESPONSE_INIT(
+			(PDSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY)MessageHeader,
+			MessageHeader->TargetIndex,
+			writeStatus,
+			readStatus
+		);
+
+		status = STATUS_SUCCESS;
+	}
+	else if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_DISCONNECT_BLUETOOTH)
+	{
+		NTSTATUS applyStatus = STATUS_INVALID_USER_BUFFER;
+
+		if (MessageHeader->Size >= sizeof(DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST))
+		{
+			if (DeviceContext->ConnectionType != DsDeviceConnectionTypeBth)
+			{
+				applyStatus = STATUS_NOT_SUPPORTED;
+				TraceWarning(
+					TRACE_IPC,
+					"Bluetooth disconnect requested for a non-wireless device"
+				);
+			}
+			else
+			{
+				applyStatus = DsBth_SendDisconnectRequest(DeviceContext);
+			}
+		}
+
+		DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_RESPONSE_INIT(
+			(PDSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY)MessageHeader,
+			MessageHeader->TargetIndex,
+			applyStatus
+		);
+
+		status = STATUS_SUCCESS;
+	}
+	else if (MessageHeader->Command.Device == DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN)
+	{
+		NTSTATUS applyStatus = STATUS_INVALID_USER_BUFFER;
+
+		if (MessageHeader->Size >= sizeof(DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST))
+		{
+			const PDSHM_IPC_MSG_SET_LED_PATTERN_REQUEST request =
+				(PDSHM_IPC_MSG_SET_LED_PATTERN_REQUEST)MessageHeader;
+			DS_LED effects[4];
+
+			effects[0].TotalDuration = request->Player1.TotalDuration;
+			effects[0].BasePortionDuration = request->Player1.BasePortionDuration;
+			effects[0].OffPortionMultiplier = request->Player1.OffPortionMultiplier;
+			effects[0].OnPortionMultiplier = request->Player1.OnPortionMultiplier;
+
+			effects[1].TotalDuration = request->Player2.TotalDuration;
+			effects[1].BasePortionDuration = request->Player2.BasePortionDuration;
+			effects[1].OffPortionMultiplier = request->Player2.OffPortionMultiplier;
+			effects[1].OnPortionMultiplier = request->Player2.OnPortionMultiplier;
+
+			effects[2].TotalDuration = request->Player3.TotalDuration;
+			effects[2].BasePortionDuration = request->Player3.BasePortionDuration;
+			effects[2].OffPortionMultiplier = request->Player3.OffPortionMultiplier;
+			effects[2].OnPortionMultiplier = request->Player3.OnPortionMultiplier;
+
+			effects[3].TotalDuration = request->Player4.TotalDuration;
+			effects[3].BasePortionDuration = request->Player4.BasePortionDuration;
+			effects[3].OffPortionMultiplier = request->Player4.OffPortionMultiplier;
+			effects[3].OnPortionMultiplier = request->Player4.OnPortionMultiplier;
+
+			TraceVerbose(
+				TRACE_IPC,
+				"Received LED pattern request: flags=0x%02X",
+				request->Flags
+			);
+
+			applyStatus = DsLed_ApplyIpcPattern(DeviceContext, request->Flags, effects);
+		}
+
+		DSHM_IPC_MSG_SET_LED_PATTERN_RESPONSE_INIT(
+			(PDSHM_IPC_MSG_SET_LED_PATTERN_REPLY)MessageHeader,
 			MessageHeader->TargetIndex,
 			applyStatus
 		);

--- a/driver/IPC.h
+++ b/driver/IPC.h
@@ -106,6 +106,18 @@ typedef enum
 	// Enables or disables alternative rumble mode at runtime
 	// 
 	DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE,
+	//
+	// Pair a given device to the active local Bluetooth radio
+	// 
+	DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST,
+	//
+	// Disconnect a currently wireless device from the host radio
+	// 
+	DSHM_IPC_MSG_CMD_DEVICE_DISCONNECT_BLUETOOTH,
+	//
+	// Apply a full volatile LED pattern (flags + four effect blocks)
+	// 
+	DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN,
 } DSHM_IPC_MSG_CMD_DEVICE;
 
 //
@@ -285,6 +297,98 @@ typedef struct _DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY
 
 } DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY, *PDSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_REPLY;
 
+//
+// One DS3 LED effect block for IPC. Explicit reserved byte keeps the
+// USHORT naturally aligned so C and C# Sequential layouts stay 6 bytes.
+// 
+typedef struct _DSHM_IPC_LED_EFFECT
+{
+	UCHAR TotalDuration;
+	UCHAR Reserved;
+	USHORT BasePortionDuration;
+	UCHAR OffPortionMultiplier;
+	UCHAR OnPortionMultiplier;
+
+} DSHM_IPC_LED_EFFECT, *PDSHM_IPC_LED_EFFECT;
+
+//
+// Pair a given device to the active local Bluetooth radio (no address payload)
+// 
+typedef struct _DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+} DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST, *PDSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST;
+
+//
+// Reply to struct _DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REQUEST
+// 
+typedef struct _DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	NTSTATUS WriteStatus;
+
+	NTSTATUS ReadStatus;
+
+} DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY, *PDSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY;
+
+//
+// Disconnect a currently wireless device from the host radio
+// 
+typedef struct _DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+} DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST, *PDSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST;
+
+//
+// Reply to struct _DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REQUEST
+// 
+typedef struct _DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	NTSTATUS NtStatus;
+
+} DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY, *PDSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY;
+
+//
+// Apply a full volatile LED pattern (flags + four independent effects)
+// 
+typedef struct _DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	//
+	// DS3 LED flags byte (DS3_LED_1..4 and/or DS3_LED_OFF). Reserved bits
+	// are rejected by the driver.
+	// 
+	UCHAR Flags;
+
+	//
+	// Pad so Player1 starts on a 4-byte boundary (header is 20 bytes).
+	// 
+	UCHAR Reserved[3];
+
+	DSHM_IPC_LED_EFFECT Player1;
+	DSHM_IPC_LED_EFFECT Player2;
+	DSHM_IPC_LED_EFFECT Player3;
+	DSHM_IPC_LED_EFFECT Player4;
+
+} DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST, *PDSHM_IPC_MSG_SET_LED_PATTERN_REQUEST;
+
+//
+// Reply to struct _DSHM_IPC_MSG_SET_LED_PATTERN_REQUEST
+// 
+typedef struct _DSHM_IPC_MSG_SET_LED_PATTERN_REPLY
+{
+	DSHM_IPC_MSG_HEADER Header;
+
+	NTSTATUS NtStatus;
+
+} DSHM_IPC_MSG_SET_LED_PATTERN_REPLY, *PDSHM_IPC_MSG_SET_LED_PATTERN_REPLY;
+
 typedef
 _Function_class_(EVT_DSHM_IPC_DispatchDeviceMessage)
 _IRQL_requires_same_
@@ -432,6 +536,68 @@ DSHM_IPC_MSG_SET_ALTERNATE_RUMBLE_MODE_RESPONSE_INIT(
 	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
 	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
 	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_SET_ALTERNATE_RUMBLE_MODE;
+	Message->Header.TargetIndex = DeviceIndex;
+	Message->Header.Size = size;
+
+	Message->NtStatus = Status;
+}
+
+VOID
+FORCEINLINE
+DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_RESPONSE_INIT(
+	_Inout_ PDSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY Message,
+	_In_ UINT32 DeviceIndex,
+	_In_ NTSTATUS WriteStatus,
+	_In_ NTSTATUS ReadStatus
+)
+{
+	const UINT32 size = sizeof(DSHM_IPC_MSG_PAIR_TO_CURRENT_HOST_REPLY);
+	RtlZeroMemory(Message, size);
+
+	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
+	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_PAIR_TO_CURRENT_HOST;
+	Message->Header.TargetIndex = DeviceIndex;
+	Message->Header.Size = size;
+
+	Message->WriteStatus = WriteStatus;
+	Message->ReadStatus = ReadStatus;
+}
+
+VOID
+FORCEINLINE
+DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_RESPONSE_INIT(
+	_Inout_ PDSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY Message,
+	_In_ UINT32 DeviceIndex,
+	_In_ NTSTATUS Status
+)
+{
+	const UINT32 size = sizeof(DSHM_IPC_MSG_DISCONNECT_BLUETOOTH_REPLY);
+	RtlZeroMemory(Message, size);
+
+	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
+	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_DISCONNECT_BLUETOOTH;
+	Message->Header.TargetIndex = DeviceIndex;
+	Message->Header.Size = size;
+
+	Message->NtStatus = Status;
+}
+
+VOID
+FORCEINLINE
+DSHM_IPC_MSG_SET_LED_PATTERN_RESPONSE_INIT(
+	_Inout_ PDSHM_IPC_MSG_SET_LED_PATTERN_REPLY Message,
+	_In_ UINT32 DeviceIndex,
+	_In_ NTSTATUS Status
+)
+{
+	const UINT32 size = sizeof(DSHM_IPC_MSG_SET_LED_PATTERN_REPLY);
+	RtlZeroMemory(Message, size);
+
+	Message->Header.Type = DSHM_IPC_MSG_TYPE_REQUEST_REPLY;
+	Message->Header.Target = DSHM_IPC_MSG_TARGET_CLIENT;
+	Message->Header.Command.Device = DSHM_IPC_MSG_CMD_DEVICE_SET_LED_PATTERN;
 	Message->Header.TargetIndex = DeviceIndex;
 	Message->Header.Size = size;
 

--- a/ipctest/Program.cs
+++ b/ipctest/Program.cs
@@ -47,8 +47,12 @@ do
             uint playerStatus = ipc.SetPlayerIndex(1, 1);
             uint rumbleStatus = ipc.SetRumble(1, 0x40, 0x00);
             uint altStatus = ipc.SetAlternateRumbleMode(1, false);
+            uint ledStatus = Ds3LedPattern.TryFromPlayerIndex(1, out Ds3LedPattern pattern)
+                ? ipc.SetLedPattern(1, pattern)
+                : 0xC000000D;
+            SetHostResult pairResult = ipc.PairToCurrentHost(1);
             Console.WriteLine(
-                $"SetPlayerIndex=0x{playerStatus:X} SetRumble=0x{rumbleStatus:X} SetAlternateRumbleMode=0x{altStatus:X} flags={Ds3PlayerLeds.TryGetFlags(1, out byte flags) && flags == Ds3PlayerLeds.Led1}");
+                $"SetPlayerIndex=0x{playerStatus:X} SetRumble=0x{rumbleStatus:X} SetAlternateRumbleMode=0x{altStatus:X} SetLedPattern=0x{ledStatus:X} PairToCurrentHost={pairResult} flags={Ds3PlayerLeds.TryGetFlags(1, out byte flags) && flags == Ds3PlayerLeds.Led1}");
             break;
 #else
             ipc.SendPing();
@@ -62,7 +66,7 @@ do
 #if INPUT_TEST
         Console.WriteLine($"Read {executionCount} input reports in one second.");
 #elif RUNTIME_OUTPUT_TEST
-        Console.WriteLine("Sent one volatile LED/rumble/alternate-mode command set.");
+        Console.WriteLine("Sent one volatile LED/rumble/alternate-mode/pairing command set.");
 #else
         Console.WriteLine($"Executed {executionCount} PINGs in one second.");
 #endif


### PR DESCRIPTION
One-shot pairing, Bluetooth disconnect, and full LED patterns belong on the command channel so ControlApp no longer has to flip PairOnHotReload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added direct controller pairing with the current Bluetooth host.
  - Added Bluetooth disconnection controls.
  - Added customizable four-player LED patterns with static and flashing effects.
  - Pairing and LED operations now provide clearer success and failure feedback.

- **Changes**
  - Removed automatic Bluetooth pairing during hot reload.
  - Removed the legacy hot-reload pairing setting from configuration.

- **Documentation**
  - Added guidance for pairing, disconnection, LED patterns, and supported device behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->