### PR TITLE
Make tagged vMAJOR.MINOR.PATCH builds the only release path.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,13 @@ jobs:
       - name: 'Resolve driver and setup versions'
         id: resolve
         shell: pwsh
+        env:
+          RELEASE_REF: ${{ github.ref }}
         run: |
           $ErrorActionPreference = 'Stop'
           . ./build/ReleaseVersion.ps1
           $version = ConvertTo-DsHidMiniReleaseVersion `
-            -Ref '${{ github.ref }}' `
+            -Ref $env:RELEASE_REF `
             -RunNumber ${{ github.run_number }} `
             -BuildVersionOffset ([int]$env:BUILD_VERSION_OFFSET)
           Write-DsHidMiniReleaseVersionOutputs -Version $version -GitHubOutput $env:GITHUB_OUTPUT
@@ -390,7 +392,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: 'Sign ControlApp'
-        uses: nefarius/SignRelay@v1.0.0-pre010
+        uses: nefarius/SignRelay@7ba3699f7ad863d66d4d69cbf31828753d24d525
         with:
           server: ${{ env.SIGN_RELAY_SERVER }}
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}
@@ -398,7 +400,7 @@ jobs:
           files: bin/ControlApp.exe
 
       - name: 'Sign XInput DLLs'
-        uses: nefarius/SignRelay@v1.0.0-pre010
+        uses: nefarius/SignRelay@7ba3699f7ad863d66d4d69cbf31828753d24d525
         with:
           server: ${{ env.SIGN_RELAY_SERVER }}
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}
@@ -553,7 +555,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: 'Sign driver DLLs'
-        uses: nefarius/SignRelay@v1.0.0-pre010
+        uses: nefarius/SignRelay@7ba3699f7ad863d66d4d69cbf31828753d24d525
         with:
           server: ${{ env.SIGN_RELAY_SERVER }}
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}
@@ -598,7 +600,7 @@ jobs:
           Write-Output "Created disk1\$cabName"
 
       - name: 'Sign partner CAB'
-        uses: nefarius/SignRelay@v1.0.0-pre010
+        uses: nefarius/SignRelay@7ba3699f7ad863d66d4d69cbf31828753d24d525
         with:
           server: ${{ env.SIGN_RELAY_SERVER }}
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
 
 concurrency:
   group: build-${{ github.ref }}
@@ -35,13 +34,47 @@ env:
   VCPKG_BINARY_SOURCES: 'clear'
 
 jobs:
+  version:
+    name: 'Resolve version'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is-release: ${{ steps.resolve.outputs.is-release }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      setup-version: ${{ steps.resolve.outputs.setup-version }}
+      driver-version: ${{ steps.resolve.outputs.driver-version }}
+      revision: ${{ steps.resolve.outputs.revision }}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            build
+
+      - name: 'Resolve driver and setup versions'
+        id: resolve
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . ./build/ReleaseVersion.ps1
+          $version = ConvertTo-DsHidMiniReleaseVersion `
+            -Ref '${{ github.ref }}' `
+            -RunNumber ${{ github.run_number }} `
+            -BuildVersionOffset ([int]$env:BUILD_VERSION_OFFSET)
+          Write-DsHidMiniReleaseVersionOutputs -Version $version -GitHubOutput $env:GITHUB_OUTPUT
+          Write-Output "is-release=$($version.IsRelease) tag=$($version.Tag) setup=$($version.SetupVersion) driver=$($version.DriverVersion)"
+
   build:
     name: 'Platform: ${{ matrix.platform }}'
+    needs: version
     # VS 2026 / MSBuild 18 is required by .NET SDK 10.0.2xx+ (windows-2022 is MSBuild 17.14).
     runs-on: windows-2025-vs2026
     permissions:
       contents: read
     env:
+      BUILD_VERSION: ${{ needs.version.outputs.driver-version }}
       # Secrets can't be referenced directly in `if:` conditions, only in `env:`/`with:`,
       # so promote it here and check env.VCPKG_NUGET_TOKEN in the step below instead.
       VCPKG_NUGET_TOKEN: ${{ secrets.VCPKG_NUGET_TOKEN }}
@@ -50,7 +83,7 @@ jobs:
       matrix:
         platform: [x64, ARM64, x86]
     outputs:
-      build-version: ${{ steps.version.outputs.build-version }}
+      build-version: ${{ needs.version.outputs.driver-version }}
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
@@ -144,15 +177,6 @@ jobs:
             throw 'Kit installers finished but UMDF/km headers were not found.'
           }
           Write-Output "WDK installed ($($present.Name))."
-
-      - name: 'Compute build version'
-        id: version
-        shell: pwsh
-        run: |
-          $buildVersion = "3.6.$([int]$env:BUILD_VERSION_OFFSET + ${{ github.run_number }}).0"
-          echo "BUILD_VERSION=$buildVersion" >> $env:GITHUB_ENV
-          echo "build-version=$buildVersion" >> $env:GITHUB_OUTPUT
-          Write-Output "Building version $buildVersion"
 
       - name: 'Bootstrap vcpkg'
         shell: cmd
@@ -254,6 +278,11 @@ jobs:
         shell: cmd
         run: .\build.cmd TestConfigParser --target-platform x64
 
+      - name: 'Test release pipeline'
+        if: matrix.platform == 'x64'
+        shell: cmd
+        run: .\build.cmd TestReleasePipeline
+
       - name: 'Build'
         shell: cmd
         run: .\build.cmd Compile ${{ matrix.platform == 'x64' && 'PublishControlApp' || '' }} --target-platform ${{ matrix.platform }} ${{ steps.dmf-cache.outputs.cache-hit == 'true' && '--skip BuildDmf' || '' }}
@@ -279,8 +308,8 @@ jobs:
 
   control-app:
     name: 'Sign and mirror ControlApp and XInput'
-    needs: build
-    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+    needs: [version, build]
+    if: needs.version.outputs.is-release == 'true'
     runs-on: windows-2022
     permissions:
       contents: read
@@ -361,7 +390,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: 'Sign ControlApp'
-        uses: nefarius/SignRelay@master
+        uses: nefarius/SignRelay@v1.0.0-pre010
         with:
           server: ${{ env.SIGN_RELAY_SERVER }}
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}
@@ -369,11 +398,12 @@ jobs:
           files: bin/ControlApp.exe
 
       - name: 'Sign XInput DLLs'
-        uses: nefarius/SignRelay@master
+        uses: nefarius/SignRelay@v1.0.0-pre010
         with:
           server: ${{ env.SIGN_RELAY_SERVER }}
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}
           in-place: true
+          skip-tool-install: true
           files: |
             bin/x64/XInput1_3.dll
             bin/x86/XInput1_3.dll
@@ -460,14 +490,16 @@ jobs:
 
   partner-cab:
     name: 'Partner Portal CAB'
-    needs: [build, control-app]
-    if: github.event_name == 'workflow_dispatch'
+    needs: [version, build]
+    if: needs.version.outputs.is-release == 'true'
     runs-on: windows-2022
     permissions:
       contents: read
       actions: read
     env:
-      BUILD_VERSION: ${{ needs.build.outputs.build-version }}
+      BUILD_VERSION: ${{ needs.version.outputs.driver-version }}
+      SETUP_VERSION: ${{ needs.version.outputs.setup-version }}
+      RELEASE_TAG: ${{ needs.version.outputs.tag }}
       SIGN_RELAY_SERVER: ${{ vars.SIGN_RELAY_SERVER }}
       SIGN_RELAY_CI_TOKEN: ${{ secrets.SIGN_RELAY_CI_TOKEN }}
     steps:
@@ -521,7 +553,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: 'Sign driver DLLs'
-        uses: nefarius/SignRelay@master
+        uses: nefarius/SignRelay@v1.0.0-pre010
         with:
           server: ${{ env.SIGN_RELAY_SERVER }}
           token: ${{ env.SIGN_RELAY_CI_TOKEN }}
@@ -591,12 +623,53 @@ jobs:
           }
           Write-Output "Signed: $cab (Status=$($sig.Status); Subject=$($sig.SignerCertificate.Subject))"
 
+      - name: 'Write release metadata'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $cab = $env:PARTNER_CAB
+          $sha = (Get-FileHash -LiteralPath $cab -Algorithm SHA256).Hash.ToLowerInvariant()
+          $metadata = [ordered]@{
+            schemaVersion = 1
+            tag = $env:RELEASE_TAG
+            setupVersion = $env:SETUP_VERSION
+            driverVersion = $env:BUILD_VERSION
+            commit = '${{ github.sha }}'
+            runId = [int64]'${{ github.run_id }}'
+            repository = '${{ github.repository }}'
+            publisherSubject = 'Nefarius Software Solutions e.U.'
+            artifacts = [ordered]@{
+              partnerSubmission = 'dshidmini-partner-submission'
+              controlApp = 'control-app'
+              platforms = @('dshidmini-x64', 'dshidmini-ARM64', 'dshidmini-x86')
+              metadata = 'release-metadata'
+            }
+            files = [ordered]@{
+              partnerCab = [ordered]@{
+                name = [IO.Path]::GetFileName($cab)
+                sha256 = $sha
+              }
+            }
+          }
+          $json = $metadata | ConvertTo-Json -Depth 6
+          $out = 'release-metadata.json'
+          [IO.File]::WriteAllText((Join-Path $pwd $out), $json, [Text.UTF8Encoding]::new($false))
+          echo "RELEASE_METADATA=$out" >> $env:GITHUB_ENV
+          Write-Output $json
+
       - name: 'Upload partner submission CAB'
         uses: actions/upload-artifact@v4
         with:
           name: dshidmini-partner-submission
           if-no-files-found: error
           path: ${{ env.PARTNER_CAB }}
+
+      - name: 'Upload release metadata'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-metadata
+          if-no-files-found: error
+          path: ${{ env.RELEASE_METADATA }}
 
       - name: 'Mirror partner submission CAB'
         uses: nefarius/AppVeyorArtifactsReceiver@master

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -34,11 +34,14 @@
         "CompileXInputBridge",
         "DownloadCiArtifacts",
         "HardwareTestXInputBridge",
+        "IngestMicrosoftPackage",
         "PublishControlApp",
         "Restore",
-        "SignProductionBinaries",
+        "StageIgfilter",
         "TestConfigParser",
-        "TestXInputBridge"
+        "TestReleasePipeline",
+        "TestXInputBridge",
+        "ValidateSetupInputs"
       ]
     },
     "Verbosity": {
@@ -114,11 +117,7 @@
       "properties": {
         "ArtifactsPath": {
           "type": "string",
-          "description": "Output path for DownloadCiArtifacts artifacts. Default: ./artifacts"
-        },
-        "BuildVersion": {
-          "type": "string",
-          "description": "GitHub Actions run ID for DownloadCiArtifacts artifact download"
+          "description": "Output path for release staging. Default: ./artifacts"
         },
         "Configuration": {
           "type": "string",
@@ -128,13 +127,21 @@
             "Release"
           ]
         },
-        "NoSigning": {
-          "type": "boolean",
-          "description": "Skip signing in DownloadCiArtifacts"
+        "IgfilterPath": {
+          "type": "string",
+          "description": "Path to the maintainer-supplied igfilter packages (directory containing nssmkig_x64 and nssmkig_ARM64)"
+        },
+        "MicrosoftPackagePath": {
+          "type": "string",
+          "description": "Path to the Microsoft-attested driver package (zip, cab, or extracted directory)"
+        },
+        "RunId": {
+          "type": "string",
+          "description": "GitHub Actions run ID used by DownloadCiArtifacts"
         },
         "SetupVersion": {
           "type": "string",
-          "description": "Setup version for BuildSetup (e.g. 3.0.0)"
+          "description": "Three-part setup version for BuildSetup (e.g. 3.6.0). Defaults to release-metadata.json when omitted"
         },
         "SignToolPath": {
           "type": "string",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See the [issue tracker](https://github.com/nefarius/DsHidMini/issues) for known 
 |------|--------------|
 | [driver/](driver/README.md) | UMDF driver: HID modes, USB/Bth, config, build (WDK, DMF) |
 | [XInputBridge/](XInputBridge/README.md) | XInput proxy DLL (`XInput1_3.dll`), extended API for DS3 pressure data |
-| [setup/](setup/README.md) | MSI installer (WixSharp), release packaging |
+| [setup/](setup/README.md) | MSI installer (WixSharp). Release procedure: [docs/RELEASE.md](docs/RELEASE.md) |
 | [ControlApp/](ControlApp/) | Configuration app (WPF) |
 | [DSHMC/](DSHMC/) | **Deprecated** legacy control utility. Use [ControlApp/](ControlApp/) |
 | [docs/](docs/README.md) | R&D notes; official docs at [docs.nefarius.at](https://docs.nefarius.at/projects/DsHidMini/) |
@@ -58,7 +58,7 @@ For **how the driver works** (UMDF, DMF, config) and **build prerequisites** (Vi
 
 ### Building
 
-From the repo root, run `build.cmd` or open `dshidmini.sln` in Visual Studio. Driver and bridge build steps are in [driver/README.md](driver/README.md) and [XInputBridge/README.md](XInputBridge/README.md).
+From the repo root, run `build.cmd` or open `dshidmini.sln` in Visual Studio. Driver and bridge build steps are in [driver/README.md](driver/README.md) and [XInputBridge/README.md](XInputBridge/README.md). Tagged production releases (Partner Center CAB, attested drivers, MSI) are documented in [docs/RELEASE.md](docs/RELEASE.md).
 
 ## Licensing
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -15,7 +15,7 @@ using Nuke.Common.Tooling;
 
 using Serilog;
 
-class Build : NukeBuild
+partial class Build : NukeBuild
 {
     [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
     readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
@@ -26,17 +26,20 @@ class Build : NukeBuild
     [Parameter("Target platform for BuildDmf on CI (x64, ARM64 or x86). Not needed for local builds.")]
     readonly string TargetPlatform = "";
 
-    [Parameter("GitHub Actions run ID for DownloadCiArtifacts artifact download")]
-    readonly string BuildVersion = "";
+    [Parameter("GitHub Actions run ID used by DownloadCiArtifacts")]
+    readonly string RunId = "";
 
-    [Parameter("Output path for DownloadCiArtifacts artifacts. Default: ./artifacts")]
+    [Parameter("Output path for release staging. Default: ./artifacts")]
     readonly string ArtifactsPath = "./artifacts";
 
-    [Parameter("Skip signing in DownloadCiArtifacts")]
-    readonly bool NoSigning;
-
-    [Parameter("Setup version for BuildSetup (e.g. 3.0.0)")]
+    [Parameter("Three-part setup version for BuildSetup (e.g. 3.6.0). Defaults to release-metadata.json when omitted.")]
     readonly string SetupVersion = "";
+
+    [Parameter("Path to the Microsoft-attested driver package (zip, cab, or extracted directory)")]
+    readonly string MicrosoftPackagePath = "";
+
+    [Parameter("Path to the maintainer-supplied igfilter packages (directory containing nssmkig_x64 and nssmkig_ARM64)")]
+    readonly string IgfilterPath = "";
 
     [Parameter("Path to signtool.exe. When not set, Nefarius.Tools.WDKWhere is used to run signtool.")]
     readonly string SignToolPath = "";
@@ -214,8 +217,8 @@ class Build : NukeBuild
 
                     settings = settings
                         .SetTargetPlatform((MSBuildTargetPlatform)TargetPlatform)
-                        // Partner Portal submissions require an unsigned driver DLL. Force this
-                        // at the MSBuild command line so CI never inherits a local test signature.
+                        // Compile produces unsigned driver DLLs. The partner-cab job EV-signs
+                        // those binaries immediately before packing the submission CAB.
                         .SetProperty("SignMode", "Off");
                 }
 
@@ -285,120 +288,6 @@ class Build : NukeBuild
             });
 
             Log.Information("ControlApp published to {PublishOutput}", publishOutput);
-        });
-
-    /// <summary>
-    /// Download GitHub Actions build artifacts (ARM64, x64, x86) for a tagged run and optionally sign CABs, EXEs,
-    /// and driver/XInput DLLs. Requires BuildVersion (a GitHub Actions run ID) and the "gh" CLI to be authenticated
-    /// (run "gh auth login" once). Use --NoSigning to skip signing.
-    /// </summary>
-    [UsedImplicitly]
-    public Target DownloadCiArtifacts => _ => _
-        .Executes(() =>
-        {
-            if (string.IsNullOrWhiteSpace(BuildVersion))
-            {
-                throw new InvalidOperationException(
-                    "DownloadCiArtifacts requires BuildVersion (a GitHub Actions run ID, see the \"Build\" workflow run URL).");
-            }
-
-            string artifactsDir = ResolvedArtifactsPath;
-            Directory.CreateDirectory(artifactsDir);
-
-            ProcessTasks.StartProcess("gh",
-                    $"run download {BuildVersion} --repo nefarius/DsHidMini --dir \"{artifactsDir}\" --pattern \"dshidmini-*\"")
-                .AssertZeroExitCode();
-
-            if (!NoSigning)
-            {
-                string[] patterns = ["*.cab", "*.exe", "dshidmini.dll", "XInput1_3.dll"];
-                List<string> existingFiles = patterns
-                    .SelectMany(pattern => Directory.GetFiles(artifactsDir, pattern, SearchOption.AllDirectories))
-                    .ToList();
-
-                if (existingFiles.Count > 0)
-                {
-                    InvokeSignTool(
-                        $"sign /v /n \"{SignCertName}\" /tr {SignTimestampUrl} /fd sha256 /td sha256 {string.Join(" ", existingFiles.Select(f => $"\"{f}\""))}");
-                }
-                else
-                {
-                    Log.Warning("No files found to sign under {ArtifactsDir}", artifactsDir);
-                }
-            }
-
-            Log.Information("Helper job names for sign portal:");
-            Log.Information("DsHidMini ARM64 v{BuildVersion} {Date:dd.MM.yyyy}", BuildVersion, DateTime.Now);
-            Log.Information("DsHidMini x64 v{BuildVersion} {Date:dd.MM.yyyy}", BuildVersion, DateTime.Now);
-        });
-
-    /// <summary>
-    /// Sign driver DLLs (append signature) under artifacts/drivers.
-    /// </summary>
-    [UsedImplicitly]
-    public Target SignProductionBinaries => _ => _
-        .Executes(() =>
-        {
-            string artifactsDir = ResolvedArtifactsPath;
-            string[] patterns =
-            [
-                Path.Combine(artifactsDir, "drivers", "ARM64", "*.dll"),
-                Path.Combine(artifactsDir, "drivers", "x64", "*.dll")
-            ];
-            List<string> files = new();
-            foreach (string pattern in patterns)
-            {
-                string dir = Path.GetDirectoryName(pattern)!;
-                if (Directory.Exists(dir))
-                {
-                    files.AddRange(Directory.GetFiles(dir, Path.GetFileName(pattern)));
-                }
-            }
-
-            if (files.Count == 0)
-            {
-                Log.Warning("No driver DLLs found under {ArtifactsPath}", artifactsDir);
-                return;
-            }
-
-            InvokeSignTool(
-                $"sign /v /as /n \"{SignCertName}\" /tr {SignTimestampUrl} /fd sha256 /td sha256 {string.Join(" ", files.Select(f => $"\"{f}\""))}");
-        });
-
-    /// <summary>
-    /// Build setup MSI and sign it. Requires SetupVersion (e.g. 3.0.0).
-    /// </summary>
-    [UsedImplicitly]
-    public Target BuildSetup => _ => _
-        .Executes(() =>
-        {
-            if (string.IsNullOrWhiteSpace(SetupVersion))
-            {
-                throw new InvalidOperationException("BuildSetup requires SetupVersion.");
-            }
-
-            AbsolutePath setupProject = RootDirectory / "setup" / "DsHidMini.Installer.csproj";
-            if (!File.Exists(setupProject))
-            {
-                throw new InvalidOperationException($"Setup project not found at {setupProject}");
-            }
-
-            DotNetTasks.DotNetBuild(s => s
-                .SetProjectFile(setupProject)
-                .SetConfiguration(Configuration.Release)
-                .SetProperty("SetupVersion", SetupVersion));
-
-            string msiName = $"Nefarius_DsHidMini_Drivers_x64_arm64_v{SetupVersion}.msi";
-            AbsolutePath msiInSetup = RootDirectory / "setup" / msiName;
-            AbsolutePath msiInBin = RootDirectory / "setup" / "bin" / "Release" / "net48" / msiName;
-            AbsolutePath msiPath = File.Exists(msiInSetup) ? msiInSetup : msiInBin;
-            if (!File.Exists(msiPath))
-            {
-                throw new InvalidOperationException($"MSI not found: {msiInSetup} or {msiInBin}");
-            }
-
-            InvokeSignTool(
-                $"sign /v /n \"{SignCertName}\" /tr {SignTimestampUrl} /fd sha256 /td sha256 \"{msiPath}\"");
         });
 
     IEnumerable<(Configuration config, MSBuildTargetPlatform platform)> XInputBridgeBuildCombinations()

--- a/build/ReleasePipeline.cs
+++ b/build/ReleasePipeline.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 static class ReleaseStaging
 {
@@ -140,20 +141,22 @@ static class ReleaseStaging
         File.Copy(cab, cabDest, overwrite: true);
 
         ReleaseMetadata parsed = ReadMetadata(MetadataPath(artifactsRoot));
-        if (parsed.Files?.PartnerCab != null)
+        if (parsed.Files?.PartnerCab is not { } partnerCab)
         {
-            string actualHash = Sha256File(cabDest);
-            if (!string.Equals(actualHash, parsed.Files.PartnerCab.Sha256, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidOperationException(
-                    $"Partner CAB hash mismatch. Metadata has {parsed.Files.PartnerCab.Sha256}, file is {actualHash}.");
-            }
+            throw new InvalidOperationException("Release metadata is missing files.partnerCab.");
+        }
 
-            if (!string.Equals(Path.GetFileName(cabDest), parsed.Files.PartnerCab.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidOperationException(
-                    $"Partner CAB name mismatch. Metadata has {parsed.Files.PartnerCab.Name}, file is {Path.GetFileName(cabDest)}.");
-            }
+        string actualHash = Sha256File(cabDest);
+        if (!string.Equals(actualHash, partnerCab.Sha256, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Partner CAB hash mismatch. Metadata has {partnerCab.Sha256}, file is {actualHash}.");
+        }
+
+        if (!string.Equals(Path.GetFileName(cabDest), partnerCab.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Partner CAB name mismatch. Metadata has {partnerCab.Name}, file is {Path.GetFileName(cabDest)}.");
         }
     }
 
@@ -217,11 +220,15 @@ static class ReleaseStaging
             };
             using Process process = Process.Start(info)
                                     ?? throw new InvalidOperationException("Failed to start expand.exe.");
+            Task<string> standardOutput = process.StandardOutput.ReadToEndAsync();
+            Task<string> standardError = process.StandardError.ReadToEndAsync();
             process.WaitForExit();
+            _ = standardOutput.GetAwaiter().GetResult();
+            string error = standardError.GetAwaiter().GetResult();
             if (process.ExitCode != 0)
             {
                 throw new InvalidOperationException(
-                    $"expand.exe failed ({process.ExitCode}) for {archivePath}: {process.StandardError.ReadToEnd()}");
+                    $"expand.exe failed ({process.ExitCode}) for {archivePath}: {error}");
             }
 
             return;
@@ -502,10 +509,36 @@ static class ReleaseStaging
 
     public static IReadOnlyList<string> ParseIssuedTo(string signToolOutput)
     {
-        return Regex.Matches(signToolOutput, @"Issued to:\s*(.+)")
-            .Select(match => match.Groups[1].Value.Trim())
-            .Where(value => !string.IsNullOrWhiteSpace(value))
-            .ToList();
+        if (string.IsNullOrWhiteSpace(signToolOutput))
+        {
+            return [];
+        }
+
+        List<string> subjects = [];
+        string[] sections = Regex.Split(signToolOutput, @"Signing Certificate Chain:\s*", RegexOptions.IgnoreCase);
+        for (int i = 1; i < sections.Length; i++)
+        {
+            string section = sections[i];
+            int timestampIndex = section.IndexOf("Timestamp Verified by:", StringComparison.OrdinalIgnoreCase);
+            if (timestampIndex >= 0)
+            {
+                section = section[..timestampIndex];
+            }
+
+            Match match = Regex.Match(section, @"Issued to:\s*(.+)");
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            string value = match.Groups[1].Value.Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                subjects.Add(value);
+            }
+        }
+
+        return subjects;
     }
 
     public static void RequireDualDriverSigners(IReadOnlyList<string> issuedTo, string file)
@@ -638,6 +671,16 @@ sealed class ReleaseMetadata
         if (RunId <= 0)
         {
             throw new InvalidOperationException("Release metadata runId is missing.");
+        }
+
+        if (Files?.PartnerCab is not { } partnerCab)
+        {
+            throw new InvalidOperationException("Release metadata is missing files.partnerCab.");
+        }
+
+        if (string.IsNullOrWhiteSpace(partnerCab.Name) || string.IsNullOrWhiteSpace(partnerCab.Sha256))
+        {
+            throw new InvalidOperationException("Release metadata files.partnerCab must include name and sha256.");
         }
     }
 }

--- a/build/ReleasePipeline.cs
+++ b/build/ReleasePipeline.cs
@@ -1,0 +1,677 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+static class ReleaseStaging
+{
+    public const string PublisherSubject = "Nefarius Software Solutions e.U.";
+    public const string MicrosoftSignerHint = "Microsoft";
+    public const string MetadataFileName = "release-metadata.json";
+
+    public static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static string DriversDirectory(string artifactsRoot) => Path.Combine(artifactsRoot, "drivers");
+
+    public static string BinDirectory(string artifactsRoot) => Path.Combine(artifactsRoot, "bin");
+
+    public static string SubmissionDirectory(string artifactsRoot) => Path.Combine(artifactsRoot, "submission");
+
+    public static string IgfilterDirectory(string artifactsRoot) => Path.Combine(artifactsRoot, "igfilter");
+
+    public static string MetadataPath(string artifactsRoot) => Path.Combine(artifactsRoot, MetadataFileName);
+
+    public static ReleaseMetadata ReadMetadata(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new InvalidOperationException($"Release metadata not found: {path}");
+        }
+
+        string json = File.ReadAllText(path);
+        ReleaseMetadata metadata = JsonSerializer.Deserialize<ReleaseMetadata>(json, JsonOptions)
+                                   ?? throw new InvalidOperationException($"Release metadata is empty or invalid: {path}");
+        metadata.ValidateIdentity();
+        return metadata;
+    }
+
+    public static void WriteMetadata(string path, ReleaseMetadata metadata)
+    {
+        string directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(path, JsonSerializer.Serialize(metadata, JsonOptions), new UTF8Encoding(false));
+    }
+
+    public static string Sha256File(string path)
+    {
+        using FileStream stream = File.OpenRead(path);
+        byte[] hash = SHA256.HashData(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    public static Version ReadFileVersion(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new InvalidOperationException($"File not found: {path}");
+        }
+
+        FileVersionInfo info = FileVersionInfo.GetVersionInfo(path);
+        if (string.IsNullOrWhiteSpace(info.FileVersion) || !Version.TryParse(info.FileVersion, out Version version))
+        {
+            throw new InvalidOperationException($"File version is missing or invalid on {path}");
+        }
+
+        return version;
+    }
+
+    public static void RequireFileVersion(string path, Version expected)
+    {
+        Version actual = ReadFileVersion(path);
+        if (actual != expected)
+        {
+            throw new InvalidOperationException(
+                $"File version mismatch for {path}: expected {expected}, found {actual}.");
+        }
+    }
+
+    public static string FindExistingFile(string root, params string[] relativeCandidates)
+    {
+        foreach (string relative in relativeCandidates)
+        {
+            string path = Path.Combine(root, relative);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        IEnumerable<string> matches = Directory.Exists(root)
+            ? relativeCandidates.SelectMany(name =>
+                Directory.GetFiles(root, Path.GetFileName(name), SearchOption.AllDirectories)
+                    .Where(path => path.Replace('\\', '/').EndsWith(name.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase)))
+            : [];
+
+        return matches.FirstOrDefault();
+    }
+
+    public static void ArrangeDownloadedArtifacts(string downloadDir, string artifactsRoot)
+    {
+        if (!Directory.Exists(downloadDir))
+        {
+            throw new InvalidOperationException($"Download directory not found: {downloadDir}");
+        }
+
+        Directory.CreateDirectory(artifactsRoot);
+        Directory.CreateDirectory(BinDirectory(artifactsRoot));
+        Directory.CreateDirectory(SubmissionDirectory(artifactsRoot));
+
+        string controlApp = FindExistingFile(downloadDir, Path.Combine("bin", "ControlApp.exe"), "ControlApp.exe")
+                            ?? throw new InvalidOperationException(
+                                "Downloaded artifacts are missing ControlApp.exe from the control-app artifact.");
+        File.Copy(controlApp, Path.Combine(BinDirectory(artifactsRoot), "ControlApp.exe"), overwrite: true);
+
+        string metadata = FindExistingFile(downloadDir, MetadataFileName)
+                          ?? throw new InvalidOperationException(
+                              "Downloaded artifacts are missing release-metadata.json. Use a tagged Build workflow run.");
+        File.Copy(metadata, MetadataPath(artifactsRoot), overwrite: true);
+        ReadMetadata(MetadataPath(artifactsRoot));
+
+        string cab = Directory.GetFiles(downloadDir, "dshidmini_*.cab", SearchOption.AllDirectories).SingleOrDefault()
+                     ?? throw new InvalidOperationException(
+                         "Downloaded artifacts are missing the dshidmini-partner-submission CAB.");
+        string cabDest = Path.Combine(SubmissionDirectory(artifactsRoot), Path.GetFileName(cab));
+        File.Copy(cab, cabDest, overwrite: true);
+
+        ReleaseMetadata parsed = ReadMetadata(MetadataPath(artifactsRoot));
+        if (parsed.Files?.PartnerCab != null)
+        {
+            string actualHash = Sha256File(cabDest);
+            if (!string.Equals(actualHash, parsed.Files.PartnerCab.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Partner CAB hash mismatch. Metadata has {parsed.Files.PartnerCab.Sha256}, file is {actualHash}.");
+            }
+
+            if (!string.Equals(Path.GetFileName(cabDest), parsed.Files.PartnerCab.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Partner CAB name mismatch. Metadata has {parsed.Files.PartnerCab.Name}, file is {Path.GetFileName(cabDest)}.");
+            }
+        }
+    }
+
+    public static IReadOnlyList<string> FindDriverPackages(string root)
+    {
+        if (!Directory.Exists(root))
+        {
+            return [];
+        }
+
+        if (File.Exists(Path.Combine(root, "dshidmini.inf")))
+        {
+            return [Path.GetFullPath(root)];
+        }
+
+        return Directory.GetDirectories(root, "dshidmini", SearchOption.AllDirectories)
+            .Where(directory => File.Exists(Path.Combine(directory, "dshidmini.inf")))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public static string FindUniqueDriverPackage(string root)
+    {
+        IReadOnlyList<string> packages = FindDriverPackages(root);
+        if (packages.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No dshidmini driver package (folder containing dshidmini.inf) was found under {root}.");
+        }
+
+        if (packages.Count > 1)
+        {
+            throw new InvalidOperationException(
+                "Multiple dshidmini driver packages were found; refusing to guess. Packages:" +
+                Environment.NewLine + string.Join(Environment.NewLine, packages));
+        }
+
+        return packages[0];
+    }
+
+    public static void ExtractArchive(string archivePath, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        string extension = Path.GetExtension(archivePath);
+        if (extension.Equals(".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            ZipFile.ExtractToDirectory(archivePath, destination, overwriteFiles: true);
+            return;
+        }
+
+        if (extension.Equals(".cab", StringComparison.OrdinalIgnoreCase))
+        {
+            ProcessStartInfo info = new()
+            {
+                FileName = "expand.exe",
+                Arguments = $"-F:* \"{archivePath}\" \"{destination}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using Process process = Process.Start(info)
+                                    ?? throw new InvalidOperationException("Failed to start expand.exe.");
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"expand.exe failed ({process.ExitCode}) for {archivePath}: {process.StandardError.ReadToEnd()}");
+            }
+
+            return;
+        }
+
+        throw new InvalidOperationException($"Unsupported Microsoft package archive: {archivePath}");
+    }
+
+    public static void IngestMicrosoftPackage(string source, string driversDir)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            throw new InvalidOperationException("MicrosoftPackagePath is required.");
+        }
+
+        string resolved = Path.GetFullPath(source);
+        string packageRoot;
+        string temp = null;
+
+        try
+        {
+            if (File.Exists(resolved))
+            {
+                temp = Directory.CreateTempSubdirectory("dshm-msft-").FullName;
+                ExtractArchive(resolved, temp);
+                packageRoot = FindUniqueDriverPackage(temp);
+            }
+            else if (Directory.Exists(resolved))
+            {
+                packageRoot = FindUniqueDriverPackage(resolved);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Microsoft package not found: {resolved}");
+            }
+
+            RequireDriverLayout(packageRoot);
+
+            if (Directory.Exists(driversDir))
+            {
+                Directory.Delete(driversDir, recursive: true);
+            }
+
+            CopyDirectory(packageRoot, driversDir);
+            RequireDriverLayout(driversDir);
+        }
+        finally
+        {
+            if (temp != null && Directory.Exists(temp))
+            {
+                Directory.Delete(temp, recursive: true);
+            }
+        }
+    }
+
+    public static void RequireDriverLayout(string driversDir)
+    {
+        string[] required =
+        [
+            Path.Combine(driversDir, "dshidmini.inf"),
+            Path.Combine(driversDir, "dshidmini.cat"),
+            Path.Combine(driversDir, "x64", "dshidmini.dll"),
+            Path.Combine(driversDir, "ARM64", "dshidmini.dll")
+        ];
+
+        string arm64Alias = Path.Combine(driversDir, "arm64", "dshidmini.dll");
+        if (!File.Exists(required[3]) && File.Exists(arm64Alias))
+        {
+            string destDir = Path.Combine(driversDir, "ARM64");
+            Directory.CreateDirectory(destDir);
+            File.Copy(arm64Alias, Path.Combine(destDir, "dshidmini.dll"), overwrite: true);
+        }
+
+        List<string> missing = required.Where(path => !File.Exists(path)).ToList();
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Driver package is missing required files:" + Environment.NewLine +
+                string.Join(Environment.NewLine, missing) + Environment.NewLine +
+                "Expected artifacts/drivers/{dshidmini.inf,dshidmini.cat,x64/dshidmini.dll,ARM64/dshidmini.dll}.");
+        }
+    }
+
+    public static void StageIgfilter(string source, string destination)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            throw new InvalidOperationException("IgfilterPath is required.");
+        }
+
+        string resolved = Path.GetFullPath(source);
+        if (!Directory.Exists(resolved))
+        {
+            throw new InvalidOperationException($"igfilter source directory not found: {resolved}");
+        }
+
+        string x64 = FindIgfilterPackage(resolved, "x64");
+        string arm64 = FindIgfilterPackage(resolved, "ARM64");
+
+        if (Directory.Exists(destination))
+        {
+            Directory.Delete(destination, recursive: true);
+        }
+
+        CopyDirectory(x64, Path.Combine(destination, "nssmkig_x64"));
+        CopyDirectory(arm64, Path.Combine(destination, "nssmkig_ARM64"));
+        RequireIgfilterLayout(destination);
+    }
+
+    public static void RequireIgfilterLayout(string igfilterDir)
+    {
+        string[] required =
+        [
+            Path.Combine(igfilterDir, "nssmkig_x64", "igfilter.inf"),
+            Path.Combine(igfilterDir, "nssmkig_x64", "nssmkig.sys"),
+            Path.Combine(igfilterDir, "nssmkig_ARM64", "igfilter.inf"),
+            Path.Combine(igfilterDir, "nssmkig_ARM64", "nssmkig.sys")
+        ];
+
+        List<string> missing = required.Where(path => !File.Exists(path)).ToList();
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "igfilter packages are missing required files:" + Environment.NewLine +
+                string.Join(Environment.NewLine, missing));
+        }
+    }
+
+    public static string FindIgfilterPackage(string root, string architecture)
+    {
+        string[] names = architecture.Equals("ARM64", StringComparison.OrdinalIgnoreCase)
+            ? ["nssmkig_ARM64", "nssmkig_arm64"]
+            : ["nssmkig_x64"];
+
+        foreach (string name in names)
+        {
+            string direct = Path.Combine(root, name);
+            if (Directory.Exists(direct) && File.Exists(Path.Combine(direct, "igfilter.inf")))
+            {
+                return direct;
+            }
+
+            if (Path.GetFileName(root).Equals(name, StringComparison.OrdinalIgnoreCase) &&
+                File.Exists(Path.Combine(root, "igfilter.inf")))
+            {
+                return root;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find nssmkig_{architecture} (must contain igfilter.inf) under {root}.");
+    }
+
+    public static SetupInputReport ValidateSetupInputs(
+        string artifactsRoot,
+        string requestedSetupVersion,
+        bool requireSignatures,
+        Func<string, string> verifyTool = null)
+    {
+        List<string> errors = [];
+        SetupInputReport report = new();
+
+        try
+        {
+            report.Metadata = ReadMetadata(MetadataPath(artifactsRoot));
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+        }
+
+        if (report.Metadata != null && !string.IsNullOrWhiteSpace(requestedSetupVersion) &&
+            requestedSetupVersion != report.Metadata.SetupVersion)
+        {
+            errors.Add(
+                $"SetupVersion {requestedSetupVersion} does not match release metadata {report.Metadata.SetupVersion}.");
+        }
+
+        report.ResolvedSetupVersion = string.IsNullOrWhiteSpace(requestedSetupVersion)
+            ? report.Metadata?.SetupVersion
+            : requestedSetupVersion;
+
+        if (string.IsNullOrWhiteSpace(report.ResolvedSetupVersion))
+        {
+            errors.Add("SetupVersion is empty and release metadata has no setupVersion.");
+        }
+        else if (!Regex.IsMatch(report.ResolvedSetupVersion, @"^\d+\.\d+\.\d+$"))
+        {
+            errors.Add($"SetupVersion must be MAJOR.MINOR.PATCH. Got: {report.ResolvedSetupVersion}");
+        }
+
+        try
+        {
+            RequireDriverLayout(DriversDirectory(artifactsRoot));
+            string x64Dll = Path.Combine(DriversDirectory(artifactsRoot), "x64", "dshidmini.dll");
+            string armDll = Path.Combine(DriversDirectory(artifactsRoot), "ARM64", "dshidmini.dll");
+            report.DriverVersion = ReadFileVersion(x64Dll);
+            Version armVersion = ReadFileVersion(armDll);
+            if (armVersion != report.DriverVersion)
+            {
+                errors.Add($"x64 driver version {report.DriverVersion} does not match ARM64 {armVersion}.");
+            }
+
+            if (report.Metadata != null &&
+                Version.TryParse(report.Metadata.DriverVersion, out Version expectedDriver) &&
+                report.DriverVersion != expectedDriver)
+            {
+                errors.Add(
+                    $"Staged driver version {report.DriverVersion} does not match metadata {expectedDriver}.");
+            }
+
+            if (requireSignatures)
+            {
+                if (verifyTool == null)
+                {
+                    throw new InvalidOperationException("Signature verification was requested but no SignTool callback was provided.");
+                }
+
+                VerifyDualDriverSignatures(x64Dll, verifyTool, errors);
+                VerifyDualDriverSignatures(armDll, verifyTool, errors);
+                VerifyCatalogBinding(
+                    Path.Combine(DriversDirectory(artifactsRoot), "dshidmini.cat"),
+                    x64Dll,
+                    verifyTool,
+                    errors);
+                VerifyCatalogBinding(
+                    Path.Combine(DriversDirectory(artifactsRoot), "dshidmini.cat"),
+                    armDll,
+                    verifyTool,
+                    errors);
+            }
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+        }
+
+        string controlApp = Path.Combine(BinDirectory(artifactsRoot), "ControlApp.exe");
+        if (!File.Exists(controlApp))
+        {
+            errors.Add($"ControlApp.exe is missing at {controlApp}.");
+        }
+        else if (requireSignatures && verifyTool != null)
+        {
+            VerifyPublisherSignature(controlApp, verifyTool, errors);
+        }
+
+        try
+        {
+            RequireIgfilterLayout(IgfilterDirectory(artifactsRoot));
+            if (requireSignatures && verifyTool != null)
+            {
+                VerifyPublisherSignature(
+                    Path.Combine(IgfilterDirectory(artifactsRoot), "nssmkig_x64", "nssmkig.sys"),
+                    verifyTool,
+                    errors);
+                VerifyPublisherSignature(
+                    Path.Combine(IgfilterDirectory(artifactsRoot), "nssmkig_ARM64", "nssmkig.sys"),
+                    verifyTool,
+                    errors);
+            }
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+        }
+
+        report.Errors = errors;
+        if (errors.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Setup inputs failed validation:" + Environment.NewLine +
+                string.Join(Environment.NewLine, errors.Select(error => "- " + error)));
+        }
+
+        return report;
+    }
+
+    public static IReadOnlyList<string> ParseIssuedTo(string signToolOutput)
+    {
+        return Regex.Matches(signToolOutput, @"Issued to:\s*(.+)")
+            .Select(match => match.Groups[1].Value.Trim())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .ToList();
+    }
+
+    public static void RequireDualDriverSigners(IReadOnlyList<string> issuedTo, string file)
+    {
+        bool publisher = issuedTo.Any(value =>
+            value.Contains(PublisherSubject, StringComparison.OrdinalIgnoreCase));
+        bool microsoft = issuedTo.Any(value =>
+            value.Contains(MicrosoftSignerHint, StringComparison.OrdinalIgnoreCase) &&
+            !value.Contains(PublisherSubject, StringComparison.OrdinalIgnoreCase));
+
+        if (!publisher || !microsoft)
+        {
+            throw new InvalidOperationException(
+                $"{file} must contain both the publisher signature ({PublisherSubject}) and the Microsoft attestation signature. Signers found: {string.Join("; ", issuedTo)}");
+        }
+    }
+
+    public static void RequirePublisherSigner(IReadOnlyList<string> issuedTo, string file)
+    {
+        if (!issuedTo.Any(value => value.Contains(PublisherSubject, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"{file} is missing the publisher signature ({PublisherSubject}). Signers found: {string.Join("; ", issuedTo)}");
+        }
+    }
+
+    static void VerifyDualDriverSignatures(string path, Func<string, string> verifyTool, List<string> errors)
+    {
+        try
+        {
+            string output = verifyTool($"verify /pa /all /v \"{path}\"");
+            RequireDualDriverSigners(ParseIssuedTo(output), path);
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+        }
+    }
+
+    static void VerifyPublisherSignature(string path, Func<string, string> verifyTool, List<string> errors)
+    {
+        try
+        {
+            string output = verifyTool($"verify /pa /all /v \"{path}\"");
+            RequirePublisherSigner(ParseIssuedTo(output), path);
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+        }
+    }
+
+    static void VerifyCatalogBinding(string catalog, string file, Func<string, string> verifyTool, List<string> errors)
+    {
+        try
+        {
+            verifyTool($"verify /pa /v /c \"{catalog}\" \"{file}\"");
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Catalog binding failed for {file}: {ex.Message}");
+        }
+    }
+
+    static void CopyDirectory(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        foreach (string directory in Directory.GetDirectories(source, "*", SearchOption.AllDirectories))
+        {
+            Directory.CreateDirectory(directory.Replace(source, destination, StringComparison.OrdinalIgnoreCase));
+        }
+
+        foreach (string file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+        {
+            string dest = file.Replace(source, destination, StringComparison.OrdinalIgnoreCase);
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            File.Copy(file, dest, overwrite: true);
+        }
+    }
+}
+
+sealed class ReleaseMetadata
+{
+    public int SchemaVersion { get; set; }
+
+    public string Tag { get; set; }
+
+    public string SetupVersion { get; set; }
+
+    public string DriverVersion { get; set; }
+
+    public string Commit { get; set; }
+
+    public long RunId { get; set; }
+
+    public string Repository { get; set; }
+
+    public string PublisherSubject { get; set; }
+
+    public ReleaseArtifactNames Artifacts { get; set; }
+
+    public ReleaseFiles Files { get; set; }
+
+    public void ValidateIdentity()
+    {
+        if (string.IsNullOrWhiteSpace(Tag) || !Regex.IsMatch(Tag, @"^v\d+\.\d+\.\d+$"))
+        {
+            throw new InvalidOperationException($"Release metadata tag is missing or not vMAJOR.MINOR.PATCH: '{Tag}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(SetupVersion) || SetupVersion != Tag[1..])
+        {
+            throw new InvalidOperationException(
+                $"Release metadata setupVersion '{SetupVersion}' must match tag '{Tag}' without the v prefix.");
+        }
+
+        if (string.IsNullOrWhiteSpace(DriverVersion) ||
+            DriverVersion.Split('.').Length != 4 ||
+            !Version.TryParse(DriverVersion, out _))
+        {
+            throw new InvalidOperationException($"Release metadata driverVersion is invalid: '{DriverVersion}'.");
+        }
+
+        if (!DriverVersion.StartsWith(SetupVersion + ".", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Release metadata driverVersion '{DriverVersion}' is not derived from setupVersion '{SetupVersion}'.");
+        }
+
+        if (RunId <= 0)
+        {
+            throw new InvalidOperationException("Release metadata runId is missing.");
+        }
+    }
+}
+
+sealed class ReleaseArtifactNames
+{
+    public string PartnerSubmission { get; set; }
+
+    public string ControlApp { get; set; }
+
+    public List<string> Platforms { get; set; }
+
+    public string Metadata { get; set; }
+}
+
+sealed class ReleaseFiles
+{
+    public ReleaseFile PartnerCab { get; set; }
+}
+
+sealed class ReleaseFile
+{
+    public string Name { get; set; }
+
+    public string Sha256 { get; set; }
+}
+
+sealed class SetupInputReport
+{
+    public ReleaseMetadata Metadata { get; set; }
+
+    public string ResolvedSetupVersion { get; set; }
+
+    public Version DriverVersion { get; set; }
+
+    public List<string> Errors { get; set; } = [];
+}

--- a/build/ReleasePipelineTests.cs
+++ b/build/ReleasePipelineTests.cs
@@ -32,6 +32,12 @@ static class ReleasePipelineTests
         path = Path.Combine(scope.Root, "bad.json");
         ReleaseStaging.WriteMetadata(path, metadata);
         AssertThrows(() => ReleaseStaging.ReadMetadata(path), "four-part metadata tag");
+
+        metadata.Tag = "v3.6.0";
+        metadata.Files = null;
+        path = Path.Combine(scope.Root, "no-cab.json");
+        ReleaseStaging.WriteMetadata(path, metadata);
+        AssertThrows(() => ReleaseStaging.ReadMetadata(path), "missing partnerCab");
     }
 
     static void TestArrangeDownloadedArtifacts()
@@ -129,10 +135,25 @@ static class ReleasePipelineTests
     static void TestSignatureParser()
     {
         const string output = """
-            Issued to: Nefarius Software Solutions e.U.
-            Issued to: Microsoft Windows Hardware Compatibility Publisher
+            Signing Certificate Chain:
+                Issued to: Nefarius Software Solutions e.U.
+                Issued by: Intermediate CA
+                    Issued to: Intermediate CA
+                    Issued by: Root CA
+            The signature is timestamped: Thu Jan 01 00:00:00 2026
+            Timestamp Verified by:
+                Issued to: Timestamp Authority
+                Issued by: Timestamp Root
+            Signing Certificate Chain:
+                Issued to: Microsoft Windows Hardware Compatibility Publisher
+                Issued by: Microsoft Windows Third Party Component CA 2014
+                    Issued to: Microsoft Windows Third Party Component CA 2014
+                    Issued by: Microsoft Root Certificate Authority 2010
             """;
         var issued = ReleaseStaging.ParseIssuedTo(output);
+        AssertEqual(string.Join("|", issued),
+            "Nefarius Software Solutions e.U.|Microsoft Windows Hardware Compatibility Publisher",
+            nameof(TestSignatureParser));
         ReleaseStaging.RequireDualDriverSigners(issued, "dshidmini.dll");
         ReleaseStaging.RequirePublisherSigner(issued, "ControlApp.exe");
 

--- a/build/ReleasePipelineTests.cs
+++ b/build/ReleasePipelineTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+
+static class ReleasePipelineTests
+{
+    public static void Run()
+    {
+        TestMetadataRoundTrip();
+        TestArrangeDownloadedArtifacts();
+        TestUniquePackageDetection();
+        TestIngestFromDirectoryAndZip();
+        TestIgfilterStaging();
+        TestSetupValidationWithoutSignatures();
+        TestSignatureParser();
+        Console.WriteLine("ReleasePipeline fixture tests passed");
+    }
+
+    static void TestMetadataRoundTrip()
+    {
+        using TempScope scope = new();
+        ReleaseMetadata metadata = SampleMetadata();
+        string path = Path.Combine(scope.Root, ReleaseStaging.MetadataFileName);
+        ReleaseStaging.WriteMetadata(path, metadata);
+        ReleaseMetadata loaded = ReleaseStaging.ReadMetadata(path);
+        AssertEqual(loaded.Tag, "v3.6.0", nameof(TestMetadataRoundTrip));
+        AssertEqual(loaded.DriverVersion, "3.6.0.2145", nameof(TestMetadataRoundTrip));
+
+        metadata.Tag = "v3.6.0.1";
+        path = Path.Combine(scope.Root, "bad.json");
+        ReleaseStaging.WriteMetadata(path, metadata);
+        AssertThrows(() => ReleaseStaging.ReadMetadata(path), "four-part metadata tag");
+    }
+
+    static void TestArrangeDownloadedArtifacts()
+    {
+        using TempScope scope = new();
+        string download = Path.Combine(scope.Root, "download");
+        string artifacts = Path.Combine(scope.Root, "artifacts");
+        ReleaseMetadata metadata = SampleMetadata();
+        string cab = Path.Combine(download, "dshidmini-partner-submission", metadata.Files.PartnerCab.Name);
+        Directory.CreateDirectory(Path.GetDirectoryName(cab)!);
+        File.WriteAllText(cab, "cab-bytes");
+        metadata.Files.PartnerCab.Sha256 = ReleaseStaging.Sha256File(cab);
+        ReleaseStaging.WriteMetadata(Path.Combine(download, "release-metadata", ReleaseStaging.MetadataFileName), metadata);
+        Directory.CreateDirectory(Path.Combine(download, "control-app", "bin"));
+        File.WriteAllText(Path.Combine(download, "control-app", "bin", "ControlApp.exe"), "app");
+
+        ReleaseStaging.ArrangeDownloadedArtifacts(download, artifacts);
+        AssertTrue(File.Exists(Path.Combine(artifacts, "bin", "ControlApp.exe")), "control app staged");
+        AssertTrue(File.Exists(Path.Combine(artifacts, "submission", metadata.Files.PartnerCab.Name)), "cab staged");
+
+        metadata.Files.PartnerCab.Sha256 = new string('0', 64);
+        ReleaseStaging.WriteMetadata(Path.Combine(download, "release-metadata", ReleaseStaging.MetadataFileName), metadata);
+        AssertThrows(() => ReleaseStaging.ArrangeDownloadedArtifacts(download, artifacts), "hash mismatch");
+    }
+
+    static void TestUniquePackageDetection()
+    {
+        using TempScope scope = new();
+        AssertThrows(() => ReleaseStaging.FindUniqueDriverPackage(scope.Root), "no package");
+
+        string first = Path.Combine(scope.Root, "a", "dshidmini");
+        Directory.CreateDirectory(first);
+        File.WriteAllText(Path.Combine(first, "dshidmini.inf"), "inf");
+        AssertEqual(ReleaseStaging.FindUniqueDriverPackage(scope.Root), Path.GetFullPath(first), "one package");
+
+        string second = Path.Combine(scope.Root, "b", "dshidmini");
+        Directory.CreateDirectory(second);
+        File.WriteAllText(Path.Combine(second, "dshidmini.inf"), "inf");
+        AssertThrows(() => ReleaseStaging.FindUniqueDriverPackage(scope.Root), "two packages");
+    }
+
+    static void TestIngestFromDirectoryAndZip()
+    {
+        using TempScope scope = new();
+        string package = WriteDriverPackage(Path.Combine(scope.Root, "extracted", "dshidmini"));
+        string drivers = Path.Combine(scope.Root, "drivers");
+        ReleaseStaging.IngestMicrosoftPackage(package, drivers);
+        ReleaseStaging.RequireDriverLayout(drivers);
+
+        string zip = Path.Combine(scope.Root, "signed.zip");
+        ZipFile.CreateFromDirectory(Path.Combine(scope.Root, "extracted"), zip);
+        string driversFromZip = Path.Combine(scope.Root, "drivers-zip");
+        ReleaseStaging.IngestMicrosoftPackage(zip, driversFromZip);
+        ReleaseStaging.RequireDriverLayout(driversFromZip);
+
+        string missing = Path.Combine(scope.Root, "bad", "dshidmini");
+        Directory.CreateDirectory(missing);
+        File.WriteAllText(Path.Combine(missing, "dshidmini.inf"), "inf");
+        AssertThrows(
+            () => ReleaseStaging.IngestMicrosoftPackage(missing, Path.Combine(scope.Root, "drivers-bad")),
+            "incomplete package");
+    }
+
+    static void TestIgfilterStaging()
+    {
+        using TempScope scope = new();
+        string source = Path.Combine(scope.Root, "ig-src");
+        WriteIgfilterPackage(Path.Combine(source, "nssmkig_x64"));
+        WriteIgfilterPackage(Path.Combine(source, "nssmkig_arm64"));
+        string dest = Path.Combine(scope.Root, "igfilter");
+        ReleaseStaging.StageIgfilter(source, dest);
+        ReleaseStaging.RequireIgfilterLayout(dest);
+        AssertTrue(Directory.Exists(Path.Combine(dest, "nssmkig_ARM64")), "arm64 normalized");
+
+        AssertThrows(() => ReleaseStaging.StageIgfilter(Path.Combine(scope.Root, "empty"), dest), "missing igfilter");
+    }
+
+    static void TestSetupValidationWithoutSignatures()
+    {
+        using TempScope scope = new();
+        string artifacts = Path.Combine(scope.Root, "artifacts");
+        ReleaseMetadata metadata = SampleMetadata();
+        ReleaseStaging.WriteMetadata(ReleaseStaging.MetadataPath(artifacts), metadata);
+        WriteDriverPackage(ReleaseStaging.DriversDirectory(artifacts), includeBinaries: false);
+        Directory.CreateDirectory(ReleaseStaging.BinDirectory(artifacts));
+        File.WriteAllText(Path.Combine(ReleaseStaging.BinDirectory(artifacts), "ControlApp.exe"), "app");
+        WriteIgfilterPackage(Path.Combine(ReleaseStaging.IgfilterDirectory(artifacts), "nssmkig_x64"));
+        WriteIgfilterPackage(Path.Combine(ReleaseStaging.IgfilterDirectory(artifacts), "nssmkig_ARM64"));
+
+        AssertThrows(
+            () => ReleaseStaging.ValidateSetupInputs(artifacts, "3.6.0", requireSignatures: false),
+            "driver files without versions fail");
+    }
+
+    static void TestSignatureParser()
+    {
+        const string output = """
+            Issued to: Nefarius Software Solutions e.U.
+            Issued to: Microsoft Windows Hardware Compatibility Publisher
+            """;
+        var issued = ReleaseStaging.ParseIssuedTo(output);
+        ReleaseStaging.RequireDualDriverSigners(issued, "dshidmini.dll");
+        ReleaseStaging.RequirePublisherSigner(issued, "ControlApp.exe");
+
+        AssertThrows(
+            () => ReleaseStaging.RequireDualDriverSigners(["Nefarius Software Solutions e.U."], "dshidmini.dll"),
+            "publisher-only rejected");
+        AssertThrows(
+            () => ReleaseStaging.RequireDualDriverSigners(["Microsoft Windows Hardware Compatibility Publisher"], "dshidmini.dll"),
+            "microsoft-only rejected");
+    }
+
+    static ReleaseMetadata SampleMetadata() => new()
+    {
+        SchemaVersion = 1,
+        Tag = "v3.6.0",
+        SetupVersion = "3.6.0",
+        DriverVersion = "3.6.0.2145",
+        Commit = "abc",
+        RunId = 123,
+        Repository = "nefarius/DsHidMini",
+        PublisherSubject = ReleaseStaging.PublisherSubject,
+        Artifacts = new ReleaseArtifactNames
+        {
+            PartnerSubmission = "dshidmini-partner-submission",
+            ControlApp = "control-app",
+            Metadata = "release-metadata"
+        },
+        Files = new ReleaseFiles
+        {
+            PartnerCab = new ReleaseFile
+            {
+                Name = "dshidmini_3.6.0.2145.cab",
+                Sha256 = new string('a', 64)
+            }
+        }
+    };
+
+    static string WriteDriverPackage(string directory, bool includeBinaries = true)
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "dshidmini.inf"), "[Version]");
+        File.WriteAllText(Path.Combine(directory, "dshidmini.cat"), "cat");
+        Directory.CreateDirectory(Path.Combine(directory, "x64"));
+        Directory.CreateDirectory(Path.Combine(directory, "ARM64"));
+        if (includeBinaries)
+        {
+            File.WriteAllText(Path.Combine(directory, "x64", "dshidmini.dll"), "x64");
+            File.WriteAllText(Path.Combine(directory, "ARM64", "dshidmini.dll"), "arm");
+        }
+
+        return directory;
+    }
+
+    static void WriteIgfilterPackage(string directory)
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "igfilter.inf"), "[Version]");
+        File.WriteAllText(Path.Combine(directory, "nssmkig.sys"), "sys");
+    }
+
+    static void AssertEqual(string actual, string expected, string name)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"FAIL {name}: expected '{expected}', got '{actual}'");
+        }
+    }
+
+    static void AssertTrue(bool condition, string name)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException($"FAIL {name}");
+        }
+    }
+
+    static void AssertThrows(Action action, string name)
+    {
+        try
+        {
+            action();
+        }
+        catch
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"FAIL {name}: expected an exception");
+    }
+
+    sealed class TempScope : IDisposable
+    {
+        public string Root { get; } = Directory.CreateTempSubdirectory("dshm-reltest-").FullName;
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+}

--- a/build/ReleaseTargets.cs
+++ b/build/ReleaseTargets.cs
@@ -15,6 +15,8 @@ partial class Build
 {
     AbsolutePath ReleaseDownloadDirectory => ResolvedArtifactsPath / "ci";
 
+    SetupInputReport _validatedSetupInputs;
+
     /// <summary>
     /// Downloads the tagged-run artifacts needed to continue a release: signed ControlApp,
     /// the EV-signed partner submission CAB, and release-metadata.json. Does not sign anything.
@@ -124,17 +126,17 @@ partial class Build
     public Target ValidateSetupInputs => _ => _
         .Executes(() =>
         {
-            SetupInputReport report = ReleaseStaging.ValidateSetupInputs(
+            _validatedSetupInputs = ReleaseStaging.ValidateSetupInputs(
                 ResolvedArtifactsPath,
                 SetupVersion,
                 requireSignatures: true,
                 verifyTool: CaptureSignTool);
 
             Log.Information("Setup inputs are valid for {SetupVersion} (driver {DriverVersion}, tag {Tag}, run {RunId})",
-                report.ResolvedSetupVersion,
-                report.DriverVersion,
-                report.Metadata.Tag,
-                report.Metadata.RunId);
+                _validatedSetupInputs.ResolvedSetupVersion,
+                _validatedSetupInputs.DriverVersion,
+                _validatedSetupInputs.Metadata.Tag,
+                _validatedSetupInputs.Metadata.RunId);
         });
 
     /// <summary>
@@ -145,11 +147,8 @@ partial class Build
         .DependsOn(ValidateSetupInputs)
         .Executes(() =>
         {
-            SetupInputReport report = ReleaseStaging.ValidateSetupInputs(
-                ResolvedArtifactsPath,
-                SetupVersion,
-                requireSignatures: true,
-                verifyTool: CaptureSignTool);
+            SetupInputReport report = _validatedSetupInputs
+                ?? throw new InvalidOperationException("Setup inputs were not validated.");
 
             string setupVersion = report.ResolvedSetupVersion;
             AbsolutePath setupProject = RootDirectory / "setup" / "DsHidMini.Installer.csproj";
@@ -193,6 +192,7 @@ partial class Build
             AbsolutePath tests = RootDirectory / "build" / "ReleaseVersion.Tests.ps1";
             string shell = ToolPathResolver.TryGetEnvironmentExecutable("pwsh.exe")
                            ?? ToolPathResolver.TryGetEnvironmentExecutable("pwsh")
+                           ?? TryGetPathExecutable("pwsh")
                            ?? "powershell";
             ProcessTasks.StartProcess(shell, $"-NoProfile -File \"{tests}\"")
                 .AssertZeroExitCode();
@@ -200,6 +200,18 @@ partial class Build
             ReleasePipelineTests.Run();
             Log.Information("Release pipeline tests passed");
         });
+
+    static string TryGetPathExecutable(string name)
+    {
+        try
+        {
+            return ToolPathResolver.GetPathExecutable(name);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
 
     string CaptureSignTool(string arguments)
     {

--- a/build/ReleaseTargets.cs
+++ b/build/ReleaseTargets.cs
@@ -1,0 +1,218 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using JetBrains.Annotations;
+
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tooling;
+
+using Serilog;
+
+partial class Build
+{
+    AbsolutePath ReleaseDownloadDirectory => ResolvedArtifactsPath / "ci";
+
+    /// <summary>
+    /// Downloads the tagged-run artifacts needed to continue a release: signed ControlApp,
+    /// the EV-signed partner submission CAB, and release-metadata.json. Does not sign anything.
+    /// </summary>
+    [UsedImplicitly]
+    public Target DownloadCiArtifacts => _ => _
+        .Executes(() =>
+        {
+            if (string.IsNullOrWhiteSpace(RunId))
+            {
+                throw new InvalidOperationException(
+                    "DownloadCiArtifacts requires RunId (the numeric GitHub Actions run ID from the Build workflow URL).");
+            }
+
+            if (!long.TryParse(RunId, out long parsedRunId) || parsedRunId <= 0)
+            {
+                throw new InvalidOperationException($"RunId must be a positive GitHub Actions run ID. Got: '{RunId}'.");
+            }
+
+            string artifactsDir = ResolvedArtifactsPath;
+            string downloadDir = ReleaseDownloadDirectory;
+            if (Directory.Exists(downloadDir))
+            {
+                Directory.Delete(downloadDir, recursive: true);
+            }
+
+            Directory.CreateDirectory(downloadDir);
+
+            string[] patterns = ["release-metadata", "control-app", "dshidmini-partner-submission"];
+            foreach (string pattern in patterns)
+            {
+                ProcessTasks.StartProcess("gh",
+                        $"run download {RunId} --repo nefarius/DsHidMini --dir \"{downloadDir}\" --pattern \"{pattern}\"")
+                    .AssertZeroExitCode();
+            }
+
+            ReleaseStaging.ArrangeDownloadedArtifacts(downloadDir, artifactsDir);
+            ReleaseMetadata metadata = ReleaseStaging.ReadMetadata(ReleaseStaging.MetadataPath(artifactsDir));
+            if (metadata.RunId != parsedRunId)
+            {
+                throw new InvalidOperationException(
+                    $"Downloaded metadata runId {metadata.RunId} does not match requested RunId {parsedRunId}.");
+            }
+
+            Log.Information("Staged release {Tag} / driver {DriverVersion} from run {RunId}",
+                metadata.Tag, metadata.DriverVersion, metadata.RunId);
+            Log.Information("Partner CAB is in {Submission}", ReleaseStaging.SubmissionDirectory(artifactsDir));
+            Log.Information("Next: submit that CAB to Partner Center, then IngestMicrosoftPackage.");
+        });
+
+    /// <summary>
+    /// Copies the unique dshidmini package returned by Microsoft into artifacts/drivers.
+    /// </summary>
+    [UsedImplicitly]
+    public Target IngestMicrosoftPackage => _ => _
+        .Executes(() =>
+        {
+            string source = MicrosoftPackagePath;
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                throw new InvalidOperationException(
+                    "IngestMicrosoftPackage requires MicrosoftPackagePath (zip, cab, or extracted directory).");
+            }
+
+            string artifactsDir = ResolvedArtifactsPath;
+            ReleaseMetadata metadata = ReleaseStaging.ReadMetadata(ReleaseStaging.MetadataPath(artifactsDir));
+            ReleaseStaging.IngestMicrosoftPackage(source, ReleaseStaging.DriversDirectory(artifactsDir));
+
+            string x64Dll = Path.Combine(ReleaseStaging.DriversDirectory(artifactsDir), "x64", "dshidmini.dll");
+            string armDll = Path.Combine(ReleaseStaging.DriversDirectory(artifactsDir), "ARM64", "dshidmini.dll");
+            Version expected = Version.Parse(metadata.DriverVersion);
+            ReleaseStaging.RequireFileVersion(x64Dll, expected);
+            ReleaseStaging.RequireFileVersion(armDll, expected);
+
+            Func<string, string> verify = CaptureSignTool;
+            ReleaseStaging.RequireDualDriverSigners(
+                ReleaseStaging.ParseIssuedTo(verify($"verify /pa /all /v \"{x64Dll}\"")), x64Dll);
+            ReleaseStaging.RequireDualDriverSigners(
+                ReleaseStaging.ParseIssuedTo(verify($"verify /pa /all /v \"{armDll}\"")), armDll);
+
+            Log.Information("Ingested Microsoft-attested package for {DriverVersion} into {Drivers}",
+                metadata.DriverVersion, ReleaseStaging.DriversDirectory(artifactsDir));
+        });
+
+    /// <summary>
+    /// Copies maintainer-supplied igfilter packages into artifacts/igfilter.
+    /// </summary>
+    [UsedImplicitly]
+    public Target StageIgfilter => _ => _
+        .Executes(() =>
+        {
+            if (string.IsNullOrWhiteSpace(IgfilterPath))
+            {
+                throw new InvalidOperationException(
+                    "StageIgfilter requires IgfilterPath (directory containing nssmkig_x64 and nssmkig_ARM64).");
+            }
+
+            ReleaseStaging.StageIgfilter(IgfilterPath, ReleaseStaging.IgfilterDirectory(ResolvedArtifactsPath));
+            Log.Information("Staged igfilter packages into {Igfilter}",
+                ReleaseStaging.IgfilterDirectory(ResolvedArtifactsPath));
+        });
+
+    /// <summary>
+    /// Verifies the staged MSI inputs, including publisher-plus-Microsoft driver signatures.
+    /// </summary>
+    [UsedImplicitly]
+    public Target ValidateSetupInputs => _ => _
+        .Executes(() =>
+        {
+            SetupInputReport report = ReleaseStaging.ValidateSetupInputs(
+                ResolvedArtifactsPath,
+                SetupVersion,
+                requireSignatures: true,
+                verifyTool: CaptureSignTool);
+
+            Log.Information("Setup inputs are valid for {SetupVersion} (driver {DriverVersion}, tag {Tag}, run {RunId})",
+                report.ResolvedSetupVersion,
+                report.DriverVersion,
+                report.Metadata.Tag,
+                report.Metadata.RunId);
+        });
+
+    /// <summary>
+    /// Builds and EV-signs the MSI after validating staged inputs.
+    /// </summary>
+    [UsedImplicitly]
+    public Target BuildSetup => _ => _
+        .DependsOn(ValidateSetupInputs)
+        .Executes(() =>
+        {
+            SetupInputReport report = ReleaseStaging.ValidateSetupInputs(
+                ResolvedArtifactsPath,
+                SetupVersion,
+                requireSignatures: true,
+                verifyTool: CaptureSignTool);
+
+            string setupVersion = report.ResolvedSetupVersion;
+            AbsolutePath setupProject = RootDirectory / "setup" / "DsHidMini.Installer.csproj";
+            if (!File.Exists(setupProject))
+            {
+                throw new InvalidOperationException($"Setup project not found at {setupProject}");
+            }
+
+            DotNetTasks.DotNetBuild(s => s
+                .SetProjectFile(setupProject)
+                .SetConfiguration(Configuration.Release)
+                .SetProperty("SetupVersion", setupVersion)
+                .SetProperty("GenerateMsi", true));
+
+            string msiName = $"Nefarius_DsHidMini_Drivers_x64_arm64_v{setupVersion}.msi";
+            AbsolutePath msiInSetup = RootDirectory / "setup" / msiName;
+            AbsolutePath msiInBin = RootDirectory / "setup" / "bin" / "Release" / "net48" / msiName;
+            AbsolutePath msiPath = File.Exists(msiInSetup) ? msiInSetup : msiInBin;
+            if (!File.Exists(msiPath))
+            {
+                throw new InvalidOperationException($"MSI not found: {msiInSetup} or {msiInBin}");
+            }
+
+            InvokeSignTool(
+                $"sign /v /n \"{SignCertName}\" /tr {SignTimestampUrl} /fd sha256 /td sha256 \"{msiPath}\"");
+            ReleaseStaging.RequirePublisherSigner(
+                ReleaseStaging.ParseIssuedTo(CaptureSignTool($"verify /pa /all /v \"{msiPath}\"")),
+                msiPath);
+
+            string hash = ReleaseStaging.Sha256File(msiPath);
+            Log.Information("Signed MSI {Msi} SHA256={Hash}", msiPath, hash);
+        });
+
+    /// <summary>
+    /// Runs non-production release-pipeline unit checks (version parsing and staging fixtures).
+    /// </summary>
+    [UsedImplicitly]
+    public Target TestReleasePipeline => _ => _
+        .Executes(() =>
+        {
+            AbsolutePath tests = RootDirectory / "build" / "ReleaseVersion.Tests.ps1";
+            string shell = ToolPathResolver.TryGetEnvironmentExecutable("pwsh.exe")
+                           ?? ToolPathResolver.TryGetEnvironmentExecutable("pwsh")
+                           ?? "powershell";
+            ProcessTasks.StartProcess(shell, $"-NoProfile -File \"{tests}\"")
+                .AssertZeroExitCode();
+
+            ReleasePipelineTests.Run();
+            Log.Information("Release pipeline tests passed");
+        });
+
+    string CaptureSignTool(string arguments)
+    {
+        if (!string.IsNullOrWhiteSpace(SignToolPath) && File.Exists(SignToolPath))
+        {
+            return string.Join(Environment.NewLine,
+                ProcessTasks.StartProcess(SignToolPath, arguments)
+                    .AssertZeroExitCode()
+                    .Output
+                    .Select(line => line.Text));
+        }
+
+        var result = WdkWhere.Invoke($"run signtool {arguments:nq}");
+        return string.Join(Environment.NewLine, result.Select(line => line.Text));
+    }
+}

--- a/build/ReleaseVersion.Tests.ps1
+++ b/build/ReleaseVersion.Tests.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $here 'ReleaseVersion.ps1')
+
+function Assert-Equal($Actual, $Expected, [string] $Name) {
+    if ($Actual -cne $Expected) {
+        throw "FAIL ${Name}: expected '${Expected}', got '${Actual}'"
+    }
+    Write-Output "PASS $Name"
+}
+
+function Assert-Throws([scriptblock] $Action, [string] $Name) {
+    $threw = $false
+    try {
+        & $Action
+    }
+    catch {
+        $threw = $true
+    }
+
+    if (-not $threw) {
+        throw "FAIL ${Name}: expected an exception"
+    }
+
+    Write-Output "PASS $Name"
+}
+
+$release = ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/v3.6.0' -RunNumber 145 -BuildVersionOffset 2000
+Assert-Equal $release.IsRelease $true 'tag is release'
+Assert-Equal $release.Tag 'v3.6.0' 'tag name'
+Assert-Equal $release.SetupVersion '3.6.0' 'setup version'
+Assert-Equal $release.DriverVersion '3.6.0.2145' 'driver version uses offset plus run number'
+Assert-Equal $release.Revision 2145 'revision'
+
+$bare = ConvertTo-DsHidMiniReleaseVersion -Ref 'v3.6.0' -RunNumber 1 -BuildVersionOffset 2000
+Assert-Equal $bare.DriverVersion '3.6.0.2001' 'bare tag ref'
+
+$ci = ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/heads/master' -RunNumber 12 -BuildVersionOffset 2000
+Assert-Equal $ci.IsRelease $false 'master is not a release'
+Assert-Equal $ci.SetupVersion '' 'master has no setup version'
+Assert-Equal $ci.DriverVersion '0.0.0.2012' 'master uses CI-only version'
+
+Assert-Throws { ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/v3.6.0.1' -RunNumber 1 -BuildVersionOffset 2000 } 'four-part tag rejected'
+Assert-Throws { ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/v3.6.0-pre1' -RunNumber 1 -BuildVersionOffset 2000 } 'prerelease tag rejected'
+Assert-Throws { ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/setup-v3.6.0' -RunNumber 1 -BuildVersionOffset 2000 } 'setup tag rejected'
+Assert-Throws { ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/v3.6.0' -RunNumber 0 -BuildVersionOffset 2000 } 'run number must be positive'
+Assert-Throws { ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/v3.6.0' -RunNumber 1 -BuildVersionOffset -1 } 'negative offset rejected'
+Assert-Throws { ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/v3.6.0' -RunNumber 1 -BuildVersionOffset 70000 } 'offset range rejected'
+Assert-Throws { ConvertTo-DsHidMiniReleaseVersion -Ref 'refs/tags/v3.6.0' -RunNumber 50000 -BuildVersionOffset 20000 } 'revision overflow rejected'
+
+$output = Join-Path ([IO.Path]::GetTempPath()) ("dshm-version-" + [guid]::NewGuid().ToString('N') + ".txt")
+try {
+    $lines = Write-DsHidMiniReleaseVersionOutputs -Version $release -GitHubOutput $output
+    $text = [IO.File]::ReadAllText($output)
+    if ($text -notmatch 'is-release=true') { throw 'FAIL github output is-release' }
+    if ($text -notmatch 'driver-version=3.6.0.2145') { throw 'FAIL github output driver-version' }
+    if ($text -notmatch 'setup-version=3.6.0') { throw 'FAIL github output setup-version' }
+    Write-Output 'PASS github output file'
+}
+finally {
+    if (Test-Path -LiteralPath $output) { Remove-Item -LiteralPath $output -Force }
+}
+
+Write-Output 'ReleaseVersion tests passed'

--- a/build/ReleaseVersion.ps1
+++ b/build/ReleaseVersion.ps1
@@ -1,0 +1,109 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Resolves the DsHidMini driver/setup versions for a GitHub Actions run.
+
+.DESCRIPTION
+    Release tags must be exactly vMAJOR.MINOR.PATCH (example: v3.6.0). Those
+    produce DriverVersion MAJOR.MINOR.PATCH.(BuildVersionOffset + RunNumber)
+    and SetupVersion MAJOR.MINOR.PATCH.
+
+    Non-tag refs (master, pull requests) produce a CI-only DriverVersion of
+    0.0.0.(BuildVersionOffset + RunNumber) and no setup version.
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-DsHidMiniReleaseVersion {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $Ref,
+
+        [Parameter(Mandatory)]
+        [int] $RunNumber,
+
+        [Parameter(Mandatory)]
+        [int] $BuildVersionOffset
+    )
+
+    if ($RunNumber -lt 1) {
+        throw "RunNumber must be a positive integer. Got: $RunNumber"
+    }
+
+    if ($BuildVersionOffset -lt 0 -or $BuildVersionOffset -gt 60000) {
+        throw "BuildVersionOffset must be in 0..60000. Got: $BuildVersionOffset"
+    }
+
+    $revision = $BuildVersionOffset + $RunNumber
+    if ($revision -lt 0 -or $revision -gt 65535) {
+        throw "Computed file-version revision $revision is outside 0..65535."
+    }
+
+    $tag = $Ref.Trim()
+    if ($tag -match '^refs/tags/(.+)$') {
+        $tag = $Matches[1]
+    }
+
+    $isTagRef = $Ref -match '^refs/tags/' -or $tag -match '^v\d'
+
+    if ($isTagRef) {
+        if ($tag -notmatch '^v(\d+)\.(\d+)\.(\d+)$') {
+            throw "Release tags must be vMAJOR.MINOR.PATCH (example: v3.6.0). Got: '$tag'"
+        }
+
+        $major = [int]$Matches[1]
+        $minor = [int]$Matches[2]
+        $patch = [int]$Matches[3]
+        foreach ($part in @($major, $minor, $patch)) {
+            if ($part -gt 65535) {
+                throw "Version component $part exceeds the 16-bit file-version maximum (65535)."
+            }
+        }
+
+        $setup = "$major.$minor.$patch"
+        return [pscustomobject]@{
+            IsRelease     = $true
+            Tag           = $tag
+            SetupVersion  = $setup
+            DriverVersion = "$setup.$revision"
+            Revision      = $revision
+        }
+    }
+
+    return [pscustomobject]@{
+        IsRelease     = $false
+        Tag           = ''
+        SetupVersion  = ''
+        DriverVersion = "0.0.0.$revision"
+        Revision      = $revision
+    }
+}
+
+function Write-DsHidMiniReleaseVersionOutputs {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Version,
+
+        [Parameter(Mandatory)]
+        [string] $GitHubOutput
+    )
+
+    $lines = @(
+        "is-release=$($Version.IsRelease.ToString().ToLowerInvariant())"
+        "tag=$($Version.Tag)"
+        "setup-version=$($Version.SetupVersion)"
+        "driver-version=$($Version.DriverVersion)"
+        "revision=$($Version.Revision)"
+    )
+
+    $directory = Split-Path -Parent $GitHubOutput
+    if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    Add-Content -LiteralPath $GitHubOutput -Value $lines -Encoding utf8
+    return $lines
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ The official project documentation can be found here: [docs.nefarius.at/projects
 
 In-repo notes:
 
+- [RELEASE.md](RELEASE.md) — tagged driver build, Partner Center attestation, MSI packaging
 - [NAVIGATION_CONTROLLER.md](NAVIGATION_CONTROLLER.md) — Navigation Controller capabilities and HID-mode limits
 - [PS3_USB_STARTUP.md](PS3_USB_STARTUP.md) — observed PS3 USB startup sequence
 - [MOTION.md](MOTION.md) — Feature 0x01 identification and motion research

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,226 @@
+# DsHidMini tagged driver release
+
+This is the maintainer and agent runbook for producing a production MSI. Partner Center upload and download is the only human gate. Every other step is a NUKE target invoked with `.\build.cmd` from the repository root.
+
+Do not use `nuke ...` directly, do not use Visual Studio to emit the MSI, and do not mix artifacts from different GitHub Actions runs.
+
+## Version invariants
+
+| Item | Rule | Example |
+|------|------|---------|
+| Driver tag | Exactly `vMAJOR.MINOR.PATCH` | `v3.6.0` |
+| Setup tag | `setup-vMAJOR.MINOR.PATCH` after the MSI exists | `setup-v3.6.0` |
+| Driver file version | `MAJOR.MINOR.PATCH.(2000 + github.run_number)` | `3.6.0.2145` |
+| MSI product version | Same three-part value as the driver tag | `3.6.0` |
+
+`2000` is `BUILD_VERSION_OFFSET` in [`.github/workflows/build.yml`](../.github/workflows/build.yml). The revision must stay in `0..65535`.
+
+Rejected tags (the `version` job fails): `v3.6.0.1`, `v3.6.0-pre1`, `setup-v3.6.0`, `sdk-v1.0.0-pre001`.
+
+Non-tag CI (master / pull request) stamps binaries `0.0.0.(2000 + run_number)` and does **not** sign ControlApp, create a partner CAB, or write release metadata.
+
+## Prerequisites
+
+Local machine:
+
+- Windows, `gh` authenticated (`gh auth login`, `repo` scope)
+- Visual Studio 2026 / MSBuild 18 and Windows SDK/WDK 10.0.28000 (same pair CI installs)
+- EV code-signing certificate whose subject contains `Nefarius Software Solutions e.U.`
+- SignTool on PATH via WDK, or pass `--sign-tool-path`
+- Maintainer-supplied `igfilter` packages (private; not built or downloaded by this repository)
+
+GitHub Actions secrets/variables used by tagged runs:
+
+- `SIGN_RELAY_SERVER` (variable)
+- `SIGN_RELAY_CI_TOKEN` (secret)
+- `WEBHOOK_URL` (secret; artifact mirror)
+
+## CI jobs and artifacts
+
+Pushing `vMAJOR.MINOR.PATCH` to `nefarius/DsHidMini` runs [`.github/workflows/build.yml`](../.github/workflows/build.yml):
+
+```text
+version
+  -> build (x64, ARM64, x86)          unsigned driver DLLs + per-arch CABs
+  -> control-app                      EV-signs ControlApp.exe and XInput1_3.dll
+  -> partner-cab                      EV-signs driver DLLs, packs dual-arch CAB, EV-signs CAB
+```
+
+`partner-cab` does not depend on `control-app`. The compile job must leave `dshidmini.dll` unsigned. Immediately before `makecab` of [`DsHidMini_combined.ddf`](../DsHidMini_combined.ddf), both architecture DLLs are EV-signed. Microsoft attestation **adds** its signature; it does not replace the publisher signature.
+
+| Artifact | When | Contents |
+|----------|------|----------|
+| `dshidmini-{x64,ARM64,x86}` | every build | unsigned driver/XInput binaries, per-arch CABs, PDBs |
+| `control-app` | release tags only | EV-signed `bin/ControlApp.exe` and XInput DLLs |
+| `dshidmini-partner-submission` | release tags only | `dshidmini_{DriverVersion}.cab` (EV-signed) |
+| `release-metadata` | release tags only | `release-metadata.json` (tag, versions, run ID, CAB SHA-256) |
+
+Per-architecture CABs (`dshidmini_x64.cab` / `dshidmini_ARM64.cab`) are CI archives only. Never submit them to Partner Center.
+
+## Signing identities
+
+| File | After CI `partner-cab` | After Microsoft returns the package | After `BuildSetup` |
+|------|------------------------|-------------------------------------|--------------------|
+| `dshidmini.dll` (x64, ARM64) | publisher EV | publisher EV **plus** Microsoft attestation | unchanged |
+| Partner CAB | publisher EV | n/a (not shipped) | n/a |
+| `ControlApp.exe` | publisher EV | n/a | packaged as signed |
+| MSI | n/a | n/a | publisher EV |
+
+Do not run the retired `SignProductionBinaries` target. Appending another publisher signature after attestation is incorrect.
+
+## Directory contract
+
+After a successful local staging sequence:
+
+```text
+artifacts/
+  release-metadata.json
+  ci/                             raw gh downloads (do not edit)
+  submission/dshidmini_*.cab      EV-signed CAB to upload
+  bin/ControlApp.exe              EV-signed
+  drivers/
+    dshidmini.inf                 dual-arch INF from Microsoft
+    dshidmini.cat                 Microsoft-issued catalog
+    x64/dshidmini.dll
+    ARM64/dshidmini.dll
+  igfilter/
+    nssmkig_x64/igfilter.inf
+    nssmkig_x64/nssmkig.sys
+    nssmkig_ARM64/igfilter.inf
+    nssmkig_ARM64/nssmkig.sys
+```
+
+The catalog is bound to the dual-arch INF. Do not split the package back into per-architecture INFs.
+
+## Procedure
+
+### 1. Tag the driver build
+
+```powershell
+git checkout master
+git pull
+git tag v3.6.0
+git push origin v3.6.0
+```
+
+Wait for the Build workflow to finish. Copy the numeric run ID from the run URL (`https://github.com/nefarius/DsHidMini/actions/runs/<run-id>`).
+
+Restart point: if the workflow failed, delete the tag only if you will recreate the same three-part version; otherwise use the next patch.
+
+### 2. Download CI outputs
+
+```powershell
+.\build.cmd DownloadCiArtifacts --run-id 123456789
+```
+
+This target does **not** sign files. It requires `release-metadata`, `control-app`, and `dshidmini-partner-submission` from that exact run and checks the CAB SHA-256 against the metadata.
+
+Restart point: rerun the same command; it replaces `artifacts/ci` and restages ControlApp, metadata, and the CAB.
+
+### 3. Submit the CAB (human gate)
+
+Microsoft documentation: [Attestation sign Windows drivers](https://learn.microsoft.com/en-us/windows-hardware/drivers/dashboard/code-signing-attestation).
+
+1. Open the [Partner Center hardware dashboard](https://partner.microsoft.com/dashboard/hardware).
+2. Submit new hardware.
+3. Product name: `DsHidMini <setupVersion> <yyyy-MM-dd>` (searchable; not the file version).
+4. Upload `artifacts/submission/dshidmini_<driverVersion>.cab`.
+5. Leave both test-signing options **unchecked**.
+6. Requested signatures: **Windows 10/11 attestation for x64 and ARM64**.
+7. Submit and wait until the dashboard marks the submission complete.
+8. Download the signed driver package (zip).
+
+This project's verified behavior: Microsoft **adds** its signature to the already EV-signed DLLs and replaces the catalog. If a returned DLL has only a Microsoft signer, stop and investigate; do not continue to MSI.
+
+### 4. Ingest the signed package
+
+```powershell
+.\build.cmd IngestMicrosoftPackage --microsoft-package-path "D:\inbox\DsHidMini-signed.zip"
+```
+
+Accepts a `.zip`, `.cab`, or an already extracted directory. It locates the unique `dshidmini` folder (the folder that contains `dshidmini.inf`, not the parent), copies its contents into `artifacts/drivers`, and requires:
+
+- layout `dshidmini.inf`, `dshidmini.cat`, `x64/dshidmini.dll`, `ARM64/dshidmini.dll`
+- file versions equal to `release-metadata.json` `driverVersion`
+- both publisher and Microsoft signers on each DLL
+
+Restart point: rerun with the same or a corrected package; `artifacts/drivers` is replaced.
+
+### 5. Stage igfilter
+
+`igfilter` / `nssmkig` is a private maintainer payload. Point at a directory that already contains both architecture packages:
+
+```powershell
+.\build.cmd StageIgfilter --igfilter-path "D:\payloads\igfilter"
+```
+
+Required children: `nssmkig_x64\` and `nssmkig_ARM64\` (or `nssmkig_arm64`, which is normalized). Each folder must contain `igfilter.inf` and `nssmkig.sys`. Both `.sys` files must carry the publisher EV signature.
+
+### 6. Validate and build the MSI
+
+```powershell
+.\build.cmd ValidateSetupInputs
+.\build.cmd BuildSetup --setup-version 3.6.0
+```
+
+`BuildSetup` depends on `ValidateSetupInputs`. If `--setup-version` is omitted, the value from `release-metadata.json` is used. If it is supplied, it must match the metadata (and therefore the driver tag).
+
+Output:
+
+```text
+setup\Nefarius_DsHidMini_Drivers_x64_arm64_v3.6.0.msi
+```
+
+The target EV-signs the MSI, verifies the publisher signature, and logs the SHA-256. Building `setup/DsHidMini.Installer.csproj` without `GenerateMsi=true` only compiles; it does not emit an MSI.
+
+### 7. Publish
+
+```powershell
+gh release create setup-v3.6.0 `
+  --title "DsHidMini Driver v3.6.0" `
+  --notes-file path\to\notes.md `
+  .\setup\Nefarius_DsHidMini_Drivers_x64_arm64_v3.6.0.msi
+```
+
+`setup-v*` does not trigger the Build workflow. That is intentional.
+
+## Do not
+
+- Submit per-architecture CABs or unsigned DLLs to Partner Center.
+- Download a master/PR run and expect a partner CAB or `release-metadata.json`.
+- Mix a CAB from run A with a Microsoft package from run B.
+- Split the returned dual-arch INF/CAT into x64-only and ARM64-only packages.
+- EV-sign driver DLLs again after Microsoft returns them.
+- Use `workflow_dispatch` (removed) or a four-part `v*` tag to start a release.
+- Treat `artifacts/` as source-controlled input; it is gitignored staging.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| `version` job: tag must be `vMAJOR.MINOR.PATCH` | Four-part or prerelease tag |
+| `DownloadCiArtifacts` missing `release-metadata` | Run was not a three-part release tag |
+| Partner CAB hash mismatch | Incomplete download or wrong run ID |
+| Multiple `dshidmini` packages | Point `MicrosoftPackagePath` at the zip or the single package folder |
+| DLL missing Microsoft signer | Downloaded the submission CAB instead of the dashboard's signed package |
+| DLL missing publisher signer | Microsoft package is not from this pipeline's EV-signed CAB |
+| `StageIgfilter` cannot find `nssmkig_ARM64` | Source tree is incomplete or named differently |
+| MSI build missing files | `ValidateSetupInputs` was skipped or staging was cleaned |
+| `BuildSetup` SetupVersion mismatch | Typed `3.6.1` against a `v3.6.0` run |
+
+## Related code
+
+| Path | Role |
+|------|------|
+| [`build/ReleaseVersion.ps1`](../build/ReleaseVersion.ps1) | Tag parse and four-part version |
+| [`build/ReleasePipeline.cs`](../build/ReleasePipeline.cs) | Staging, ingest, validation |
+| [`build/ReleaseTargets.cs`](../build/ReleaseTargets.cs) | NUKE entry points |
+| [`build/New-PartnerSubmissionInf.ps1`](../build/New-PartnerSubmissionInf.ps1) | Dual-arch INF for the submission CAB |
+| [`DsHidMini_combined.ddf`](../DsHidMini_combined.ddf) | Partner CAB layout (`dshidmini/` not at CAB root; includes PDBs) |
+| [`setup/InstallScript.cs`](../setup/InstallScript.cs) | WixSharp MSI contents |
+
+Local verification without publishing:
+
+```powershell
+.\build.cmd TestReleasePipeline
+```

--- a/driver/README.md
+++ b/driver/README.md
@@ -37,10 +37,9 @@ Designed for **Windows 10** version 1809 or newer (**x64**, **ARM64**). Dependen
 
 ### Prerequisites
 
-- [Visual Studio 2022](https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk#download-icon-step-1-install-visual-studio-2022)
-- [Windows 11 22H2 SDK](https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk#download-icon-step-2-install-windows-11-version-22h2-sdk)
-- [Windows 11 22H2 WDK](https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk#download-icon-step-3-install-windows-11-version-22h2-wdk)
-- [Driver Module Framework (DMF)](https://github.com/microsoft/DMF) **v1.1.83** or newer, cloned as a sibling of the DsHidMini repo and built (e.g. build `DmfU` for Release/Debug, x64 and Win32 as needed)
+- Visual Studio 2026 (MSBuild 18). CI uses the `windows-2025-vs2026` image
+- Windows SDK and WDK **10.0.28000** (the pair installed by the Build workflow)
+- [Driver Module Framework (DMF)](https://github.com/microsoft/DMF) via the `DMF/` submodule (`nefarius` branch). `.\build.cmd Compile` builds `DmfU` automatically
 
 ### Building
 
@@ -48,7 +47,7 @@ Open the solution (e.g. `dshidmini.sln` in the repo root) in Visual Studio and b
 
 ## Installation
 
-Pre-built binaries and installation steps are on the [releases page](https://github.com/nefarius/DsHidMini/releases) and in the [main README](../../README.md#installation). Do not install a self-built driver unless you are testing or developing; use signed builds from the project.
+Pre-built binaries and installation steps are on the [releases page](https://github.com/nefarius/DsHidMini/releases) and in the [main README](../../README.md#installation). Do not install a self-built driver unless you are testing or developing; use signed builds from the project. Maintainers producing those builds: [docs/RELEASE.md](../docs/RELEASE.md).
 
 ## Documentation
 

--- a/setup/DsHidMini.Installer.csproj
+++ b/setup/DsHidMini.Installer.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,7 +15,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SetupVersion Condition="'$(SetupVersion)' == ''">3.0.0</SetupVersion>
+    <SetupVersion Condition="'$(SetupVersion)' == ''"></SetupVersion>
+    <GenerateMsi Condition="'$(GenerateMsi)' == ''">false</GenerateMsi>
   </PropertyGroup>
 
   <Target Name="GenerateBuildVariableFile" BeforeTargets="BeforeBuild">
@@ -51,7 +52,8 @@
         <PackageReference Include="WixSharp-wix4.WPF" Version="2.4.0.1" />
     </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(GenerateMsi)' == 'true'">
+    <Error Condition="'$(SetupVersion)' == ''" Text="SetupVersion is required when GenerateMsi=true (use .\build.cmd BuildSetup --setup-version X.Y.Z)." />
     <Exec Command="cd .\&#xD;&#xA;set ide=true&#xD;&#xA;&quot;$(TargetPath)&quot;" />
   </Target>
 </Project>

--- a/setup/InstallScript.cs
+++ b/setup/InstallScript.cs
@@ -46,7 +46,15 @@ internal class InstallScript
     /// </remarks>
     private static void Main()
     {
+        RequireStagedInputs();
+
         // grab main app version
+        if (string.IsNullOrWhiteSpace(BuildVariables.SetupVersion))
+        {
+            throw new InvalidOperationException(
+                "SetupVersion is empty. Build the MSI with .\\build.cmd BuildSetup --setup-version X.Y.Z.");
+        }
+
         Version version = Version.Parse(BuildVariables.SetupVersion);
         const string driverPath = @"..\artifacts\drivers\x64\dshidmini.dll";
         Version driverVersion = Version.Parse(FileVersionInfo.GetVersionInfo(driverPath).FileVersion);
@@ -208,6 +216,39 @@ internal class InstallScript
         project.ResolveWildCards();
 
         project.BuildMsi();
+    }
+
+    /// <summary>
+    /// Fails with an actionable list when the release-staging contract is incomplete.
+    /// </summary>
+    private static void RequireStagedInputs()
+    {
+        string[] required =
+        [
+            @"..\artifacts\drivers\dshidmini.inf",
+            @"..\artifacts\drivers\dshidmini.cat",
+            @"..\artifacts\drivers\x64\dshidmini.dll",
+            @"..\artifacts\drivers\ARM64\dshidmini.dll",
+            @"..\artifacts\igfilter\nssmkig_x64\igfilter.inf",
+            @"..\artifacts\igfilter\nssmkig_x64\nssmkig.sys",
+            @"..\artifacts\igfilter\nssmkig_ARM64\igfilter.inf",
+            @"..\artifacts\igfilter\nssmkig_ARM64\nssmkig.sys",
+            @"..\artifacts\bin\ControlApp.exe",
+            @"nefcon\x64\nefconc.exe",
+            @"nefcon\ARM64\nefconc.exe",
+            @"nefarius_DsHidMini_Updater.exe"
+        ];
+
+        string[] missing = required.Where(path => !System.IO.File.Exists(path)).ToArray();
+        if (missing.Length == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "MSI inputs are missing. Stage a tagged release with DownloadCiArtifacts, " +
+            "IngestMicrosoftPackage, and StageIgfilter before BuildSetup." + Environment.NewLine +
+            string.Join(Environment.NewLine, missing.Select(path => "Missing: " + path)));
     }
 
     /// <summary>

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,44 +1,8 @@
 # DsHidMini setup
 
-This project generates an MSI package containing x64 and ARM64 driver editions using [WixSharp](https://github.com/oleg-shilo/wixsharp).
+WixSharp MSI that installs the dual-architecture DsHidMini driver, `igfilter`, ControlApp, nefcon, and the vicius-based updater.
 
-## Create a production release
-
-Commands/scripts are to be run from solution root directory.
-
-- Tag a release and let it build on CI (the "Build" GitHub Actions workflow)
-- Authenticate the GitHub CLI once with `gh auth login` (needs `repo` scope)
-- Use  
-  ```PowerShell
-  nuke download-ci-artifacts -buildversion "<workflow-run-id>"
-  ```  
-  to download the tagged release (the run ID is the numeric ID in the workflow run URL)
-- Submit the partner CAB (`dshidmini-partner-submission` artifact) to MS Partner Portal for signing. Tick both x64 and ARM64; the CAB is one dual-arch package
-- Extract the signed package. Copy the contents of the `dshidmini` folder (not the folder itself) into `.\artifacts\drivers` so the layout is:
-
-  ```text
-  artifacts/drivers/
-    dshidmini.inf
-    dshidmini.cat
-    x64/dshidmini.dll
-    ARM64/dshidmini.dll
-  ```
-
-  The catalog is bound to the dual-arch INF. Do not split it back into per-arch INFs.
-- Run  
-  ```PowerShell
-  nuke sign-production-binaries
-  ```  
-  to add EV signatures to binaries
-- Run  
-  ```PowerShell
-  nuke build-setup -setupversion "3.6.0"
-  ```   
-  to build and sign an MSI with the given version
-- Make public GitHub release
-  - Create tag for setup `setup-v3.6.0`
-- ???
-- Profit!
+Production releases are **not** built from this folder in Visual Studio. Follow [docs/RELEASE.md](../docs/RELEASE.md): tag `vMAJOR.MINOR.PATCH`, submit the partner CAB to Microsoft, ingest the signed package, then run `.\build.cmd BuildSetup`.
 
 ## Components
 
@@ -48,7 +12,21 @@ Software auto-updater. Custom build of [vicius](https://github.com/nefarius/vici
 
 ### `nefcon\...`
 
-[Driver installation helper utility](https://github.com/nefarius/nefcon).
+[Driver installation helper](https://github.com/nefarius/nefcon) used to install `igfilter`.
+
+## Staged inputs
+
+`BuildSetup` / `InstallScript` require this layout (created by the release targets, gitignored):
+
+```text
+artifacts/drivers/{dshidmini.inf,dshidmini.cat,x64/dshidmini.dll,ARM64/dshidmini.dll}
+artifacts/igfilter/nssmkig_{x64,ARM64}/{igfilter.inf,nssmkig.sys}
+artifacts/bin/ControlApp.exe
+```
+
+`igfilter` is a maintainer-supplied external payload. It is not produced by this repository.
+
+Building `DsHidMini.Installer.csproj` without `GenerateMsi=true` only compiles the generator. MSI emission is gated on `.\build.cmd BuildSetup`.
 
 ## 3rd party credits
 


### PR DESCRIPTION
Stamp driver versions from the tag plus run number, EV-sign DLLs before the partner CAB, and replace the ad-hoc MSI steps with validated ingest/setup targets and a runbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Process**
  - Automated release versioning, artifact staging, package validation, and MSI signing.
  - Added release metadata and hash artifacts for improved traceability.
  - Release automation now runs only for release references; manual workflow dispatch is no longer available.
  - Added checks for required setup inputs, package versions, signatures, and staged files.

- **Bug Fixes**
  - Invalid or incomplete release versions and missing setup inputs now produce actionable errors.

- **Documentation**
  - Added a production release runbook and updated setup, driver, build, and installation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->