### PR TITLE
Automate Partner Center attestation on tagged release builds.

### DIFF
--- a/.github/actions/download-artifact-with-retry/action.yml
+++ b/.github/actions/download-artifact-with-retry/action.yml
@@ -12,6 +12,10 @@ inputs:
   github-token:
     description: 'Token with actions:read permission'
     required: true
+  run-id:
+    description: 'Workflow run that owns the artifact. Defaults to the current run.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -25,7 +29,7 @@ runs:
         path: ${{ inputs.path }}
         github-token: ${{ inputs.github-token }}
         repository: ${{ github.repository }}
-        run-id: ${{ github.run_id }}
+        run-id: ${{ inputs.run-id != '' && inputs.run-id || github.run_id }}
 
     - name: 'Wait before attempt 2'
       if: steps.attempt-1.outcome == 'failure'
@@ -42,7 +46,7 @@ runs:
         path: ${{ inputs.path }}
         github-token: ${{ inputs.github-token }}
         repository: ${{ github.repository }}
-        run-id: ${{ github.run_id }}
+        run-id: ${{ inputs.run-id != '' && inputs.run-id || github.run_id }}
 
     - name: 'Wait before attempt 3'
       if: steps.attempt-2.outcome == 'failure'
@@ -57,4 +61,4 @@ runs:
         path: ${{ inputs.path }}
         github-token: ${{ inputs.github-token }}
         repository: ${{ github.repository }}
-        run-id: ${{ github.run_id }}
+        run-id: ${{ inputs.run-id != '' && inputs.run-id || github.run_id }}

--- a/.github/actions/setup-sdcm/action.yml
+++ b/.github/actions/setup-sdcm/action.yml
@@ -1,0 +1,19 @@
+name: 'Setup SDCM'
+description: 'Install .NET 10 and pin Nefarius.Tools.SDCM for Partner Center automation'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup .NET'
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: 'Install SDCM'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        dotnet tool install -g Nefarius.Tools.SDCM --version 1.0.0-pre003
+        $tools = Join-Path $env:USERPROFILE '.dotnet\tools'
+        echo $tools >> $env:GITHUB_PATH
+        Write-Output "Installed Nefarius.Tools.SDCM 1.0.0-pre003"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -679,3 +679,15 @@ jobs:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-name: dshidmini-partner-submission
+
+  partner-signing:
+    name: 'Partner Center signing'
+    needs: [version, partner-cab]
+    if: needs.version.outputs.is-release == 'true'
+    permissions:
+      contents: read
+      actions: read
+    secrets: inherit
+    uses: ./.github/workflows/partner-signing.yml
+    with:
+      source-run-id: ${{ github.run_id }}

--- a/.github/workflows/partner-signing.yml
+++ b/.github/workflows/partner-signing.yml
@@ -1,0 +1,393 @@
+name: 'Partner Center signing'
+
+on:
+  workflow_call:
+    inputs:
+      source-run-id:
+        description: 'Build workflow run ID that produced the EV-signed partner CAB'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      source-run-id:
+        description: 'Build workflow run ID that produced the EV-signed partner CAB'
+        required: true
+        type: string
+
+concurrency:
+  group: partner-signing-${{ inputs.source-run-id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+  DOTNET_NOLOGO: 'true'
+  SOURCE_RUN_ID: ${{ inputs.source-run-id }}
+  SDCM_PROFILES__DEFAULT__TENANTID: ${{ secrets.SDCM_PROFILES__DEFAULT__TENANTID }}
+  SDCM_PROFILES__DEFAULT__CLIENTID: ${{ secrets.SDCM_PROFILES__DEFAULT__CLIENTID }}
+  SDCM_PROFILES__DEFAULT__KEY: ${{ secrets.SDCM_PROFILES__DEFAULT__KEY }}
+
+jobs:
+  create:
+    name: 'Create Partner product'
+    runs-on: windows-2022
+    outputs:
+      product-id: ${{ steps.create.outputs.product-id }}
+      submission-id: ${{ steps.create.outputs.submission-id }}
+      setup-version: ${{ steps.create.outputs.setup-version }}
+      driver-version: ${{ steps.create.outputs.driver-version }}
+      tag: ${{ steps.create.outputs.tag }}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 'Require Partner Center credentials'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not $env:SOURCE_RUN_ID) { throw 'source-run-id is required.' }
+          if ($env:SOURCE_RUN_ID -notmatch '^\d+$') { throw "source-run-id must be a numeric run ID. Got: '$env:SOURCE_RUN_ID'." }
+          if (-not $env:SDCM_PROFILES__DEFAULT__TENANTID) { throw 'Repository secret SDCM_PROFILES__DEFAULT__TENANTID is not set.' }
+          if (-not $env:SDCM_PROFILES__DEFAULT__CLIENTID) { throw 'Repository secret SDCM_PROFILES__DEFAULT__CLIENTID is not set.' }
+          if (-not $env:SDCM_PROFILES__DEFAULT__KEY) { throw 'Repository secret SDCM_PROFILES__DEFAULT__KEY is not set.' }
+
+      - name: 'Download release metadata'
+        uses: ./.github/actions/download-artifact-with-retry
+        with:
+          name: release-metadata
+          path: metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ env.SOURCE_RUN_ID }}
+
+      - uses: ./.github/actions/setup-sdcm
+
+      - name: 'Create product and submission'
+        id: create
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . .\build\PartnerSigning.ps1
+
+          $metadataPath = Get-ChildItem -LiteralPath metadata -Recurse -Filter 'release-metadata.json' |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $metadataPath) { throw 'release-metadata.json was not downloaded from the source run.' }
+          $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+          if (-not $metadata.setupVersion -or -not $metadata.driverVersion -or -not $metadata.tag) {
+            throw 'release-metadata.json is missing tag, setupVersion, or driverVersion.'
+          }
+
+          $productName = "DsHidMini $($metadata.setupVersion) $($metadata.driverVersion)"
+          $announcement = (Get-Date).ToUniversalTime().ToString('s')
+          $productPath = Join-Path $pwd 'partner-product.json'
+          $submissionPath = Join-Path $pwd 'partner-submission.json'
+          Write-Utf8NoBomJson (New-PartnerProductPayload -ProductName $productName -AnnouncementDate $announcement) $productPath
+          Write-Utf8NoBomJson (New-PartnerSubmissionPayload -Name "$($productName) submission") $submissionPath
+
+          $productJson = Invoke-Sdcm product create --input $productPath
+          $productId = Get-SdcmEntityId -Json ($productJson | Out-String)
+          $submissionJson = Invoke-Sdcm submission create --product-id $productId --input $submissionPath
+          $submissionId = Get-SdcmEntityId -Json ($submissionJson | Out-String)
+          $portalUrl = Get-PartnerPortalUrl -ProductId $productId
+
+          $checkpoint = [ordered]@{
+            schemaVersion = 1
+            sourceRunId = [int64]$env:SOURCE_RUN_ID
+            signingRunId = [int64]'${{ github.run_id }}'
+            tag = [string]$metadata.tag
+            setupVersion = [string]$metadata.setupVersion
+            driverVersion = [string]$metadata.driverVersion
+            productId = $productId
+            submissionId = $submissionId
+            portalUrl = $portalUrl
+            productName = $productName
+          }
+          Write-Utf8NoBomJson $checkpoint 'partner-signing-checkpoint.json'
+
+          'product-id=' + $productId >> $env:GITHUB_OUTPUT
+          'submission-id=' + $submissionId >> $env:GITHUB_OUTPUT
+          'setup-version=' + $metadata.setupVersion >> $env:GITHUB_OUTPUT
+          'driver-version=' + $metadata.driverVersion >> $env:GITHUB_OUTPUT
+          'tag=' + $metadata.tag >> $env:GITHUB_OUTPUT
+
+          $summary = @(
+            "Created Partner Center product ``$productName``"
+            "- Product ID: ``$productId``"
+            "- Submission ID: ``$submissionId``"
+            "- Portal: $portalUrl"
+          ) -join [Environment]::NewLine
+          $summary >> $env:GITHUB_STEP_SUMMARY
+          Write-Output $summary
+
+      - name: 'Upload checkpoint'
+        uses: actions/upload-artifact@v7
+        with:
+          name: partner-signing-checkpoint
+          if-no-files-found: error
+          path: partner-signing-checkpoint.json
+
+  upload:
+    name: 'Upload and commit'
+    needs: create
+    runs-on: windows-2022
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 'Download checkpoint'
+        uses: ./.github/actions/download-artifact-with-retry
+        with:
+          name: partner-signing-checkpoint
+          path: checkpoint
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Download partner CAB'
+        uses: ./.github/actions/download-artifact-with-retry
+        with:
+          name: dshidmini-partner-submission
+          path: submission
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ env.SOURCE_RUN_ID }}
+
+      - uses: ./.github/actions/setup-sdcm
+
+      - name: 'Upload and commit when needed'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . .\build\PartnerSigning.ps1
+
+          $checkpointPath = Get-ChildItem -LiteralPath checkpoint -Recurse -Filter 'partner-signing-checkpoint.json' |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $checkpointPath) { throw 'partner-signing-checkpoint.json is missing.' }
+          $checkpoint = Get-Content -LiteralPath $checkpointPath -Raw | ConvertFrom-Json
+          $productId = '${{ needs.create.outputs.product-id }}'
+          $submissionId = '${{ needs.create.outputs.submission-id }}'
+          if (-not $productId) { $productId = [string]$checkpoint.productId }
+          if (-not $submissionId) { $submissionId = [string]$checkpoint.submissionId }
+          if (-not $productId -or -not $submissionId) { throw 'Product or submission ID is missing.' }
+
+          $cab = Get-ChildItem -LiteralPath submission -Recurse -File -Filter 'dshidmini_*.cab' |
+            Select-Object -First 1
+          if (-not $cab) { throw 'EV-signed partner CAB was not downloaded from the source run.' }
+
+          $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
+          $submission = ConvertFrom-SdcmJson -Json ($listed | Out-String)
+          if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
+          $progress = Get-PartnerSubmissionProgress -Submission $submission
+          Write-Output "Submission progress: $progress"
+
+          if ($progress -eq 'Failed') {
+            throw "Partner Center already failed product $productId submission $submissionId. Dispatch this workflow against the same source run to create a new product."
+          }
+
+          if (Test-PartnerSubmissionNeedsUpload -Submission $submission) {
+            Write-Output "Uploading $($cab.FullName)"
+            Invoke-Sdcm submission upload --product-id $productId --submission-id $submissionId --package $cab.FullName
+          }
+          else {
+            Write-Output 'Upload skipped; submission has already advanced past package upload.'
+          }
+
+          $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
+          $submission = ConvertFrom-SdcmJson -Json ($listed | Out-String)
+          if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
+          if (Test-PartnerSubmissionNeedsCommit -Submission $submission) {
+            Write-Output 'Committing submission'
+            Invoke-Sdcm submission commit --product-id $productId --submission-id $submissionId
+          }
+          else {
+            Write-Output 'Commit skipped; submission is already committed or in progress.'
+          }
+
+          "Portal: $(Get-PartnerPortalUrl -ProductId $productId)" >> $env:GITHUB_STEP_SUMMARY
+
+  wait:
+    name: 'Wait and download'
+    needs: [create, upload]
+    runs-on: windows-2022
+    timeout-minutes: 90
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 'Download checkpoint'
+        uses: ./.github/actions/download-artifact-with-retry
+        with:
+          name: partner-signing-checkpoint
+          path: checkpoint
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/setup-sdcm
+
+      - name: 'Wait, download, and extract signed files'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . .\build\PartnerSigning.ps1
+
+          $checkpointPath = Get-ChildItem -LiteralPath checkpoint -Recurse -Filter 'partner-signing-checkpoint.json' |
+            Select-Object -First 1 -ExpandProperty FullName
+          $checkpoint = Get-Content -LiteralPath $checkpointPath -Raw | ConvertFrom-Json
+          $productId = '${{ needs.create.outputs.product-id }}'
+          $submissionId = '${{ needs.create.outputs.submission-id }}'
+          if (-not $productId) { $productId = [string]$checkpoint.productId }
+          if (-not $submissionId) { $submissionId = [string]$checkpoint.submissionId }
+
+          $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
+          $submission = ConvertFrom-SdcmJson -Json ($listed | Out-String)
+          if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
+          $progress = Get-PartnerSubmissionProgress -Submission $submission
+          Write-Output "Submission progress: $progress"
+
+          if ($progress -eq 'Failed') {
+            throw "Partner Center failed product $productId submission $submissionId."
+          }
+          if ($progress -eq 'Created') {
+            throw 'Submission is not committed. Re-run the upload job before waiting.'
+          }
+          if ($progress -ne 'Completed') {
+            Invoke-Sdcm submission wait --product-id $productId --submission-id $submissionId --wait-timeout 3600
+          }
+          else {
+            Write-Output 'Submission already completed; downloading without waiting.'
+          }
+
+          $downloadZip = Join-Path $pwd 'hdc-download.zip'
+          Invoke-Sdcm submission download --product-id $productId --submission-id $submissionId --output-file $downloadZip
+          $extractDir = Join-Path $pwd 'hdc-extracted'
+          New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+          Expand-Archive -LiteralPath $downloadZip -DestinationPath $extractDir -Force
+
+          $pair = Find-PartnerSignedPackagePair -Root $extractDir
+
+          $stage = Join-Path $pwd 'partner-signed'
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item -LiteralPath $pair.SignedZip -Destination (Join-Path $stage $pair.SignedName)
+          Copy-Item -LiteralPath $pair.InitialCab -Destination (Join-Path $stage $pair.InitialName)
+
+          $result = [ordered]@{
+            schemaVersion = 1
+            sourceRunId = [int64]$env:SOURCE_RUN_ID
+            signingRunId = [int64]'${{ github.run_id }}'
+            tag = [string]$checkpoint.tag
+            setupVersion = [string]$checkpoint.setupVersion
+            driverVersion = [string]$checkpoint.driverVersion
+            productId = $productId
+            submissionId = $submissionId
+            portalUrl = Get-PartnerPortalUrl -ProductId $productId
+            signedZip = $pair.SignedName
+            initialCab = $pair.InitialName
+            packageId = $pair.Id
+          }
+          Write-Utf8NoBomJson $result 'partner-signing-result.json'
+
+          $summary = @(
+            "Downloaded Partner Center signed files for $($checkpoint.tag)"
+            "- $($pair.SignedName)"
+            "- $($pair.InitialName)"
+            "- Portal: $($result.portalUrl)"
+          ) -join [Environment]::NewLine
+          $summary >> $env:GITHUB_STEP_SUMMARY
+          Write-Output $summary
+
+      - name: 'Upload signed Partner files'
+        uses: actions/upload-artifact@v7
+        with:
+          name: dshidmini-partner-signed
+          if-no-files-found: error
+          path: partner-signed/*
+
+      - name: 'Upload signing result'
+        uses: actions/upload-artifact@v7
+        with:
+          name: partner-signing-result
+          if-no-files-found: error
+          path: partner-signing-result.json
+
+      - name: 'Mirror signed Partner files'
+        uses: nefarius/AppVeyorArtifactsReceiver@master
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-name: dshidmini-partner-signed
+
+  ingest:
+    name: 'Validate Microsoft package'
+    needs: [create, wait]
+    runs-on: windows-2022
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 'Download signed Partner files'
+        uses: ./.github/actions/download-artifact-with-retry
+        with:
+          name: dshidmini-partner-signed
+          path: partner-signed
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Download release metadata'
+        uses: ./.github/actions/download-artifact-with-retry
+        with:
+          name: release-metadata
+          path: metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ env.SOURCE_RUN_ID }}
+
+      - name: 'Setup .NET'
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: 'Restore local .NET tools'
+        run: dotnet tool restore
+
+      - name: 'Ingest and validate attested drivers'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . .\build\PartnerSigning.ps1
+
+          $pair = Find-PartnerSignedPackagePair -Root (Join-Path $pwd 'partner-signed')
+          $metadataPath = Get-ChildItem -LiteralPath metadata -Recurse -Filter 'release-metadata.json' |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $metadataPath) { throw 'release-metadata.json was not downloaded from the source run.' }
+
+          $artifacts = Join-Path $pwd 'artifacts'
+          New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
+          Copy-Item -LiteralPath $metadataPath -Destination (Join-Path $artifacts 'release-metadata.json') -Force
+
+          & .\build.cmd IngestMicrosoftPackage --microsoft-package-path $pair.SignedZip --artifacts-path $artifacts
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+          if (-not (Test-Path -LiteralPath (Join-Path $artifacts 'drivers\dshidmini.inf'))) {
+            throw 'IngestMicrosoftPackage did not produce artifacts/drivers/dshidmini.inf.'
+          }
+
+          "Ingested $($pair.SignedName) into artifacts/drivers" >> $env:GITHUB_STEP_SUMMARY
+
+      - name: 'Upload attested drivers'
+        uses: actions/upload-artifact@v7
+        with:
+          name: dshidmini-microsoft-drivers
+          if-no-files-found: error
+          path: artifacts/drivers/**
+
+      - name: 'Upload release metadata for retry runs'
+        if: github.run_id != inputs.source-run-id
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-metadata
+          if-no-files-found: error
+          path: artifacts/release-metadata.json

--- a/.github/workflows/partner-signing.yml
+++ b/.github/workflows/partner-signing.yml
@@ -304,6 +304,7 @@ jobs:
         with:
           name: dshidmini-partner-signed
           if-no-files-found: error
+          overwrite: true
           path: partner-signed/*
 
       - name: 'Upload signing result'
@@ -311,6 +312,7 @@ jobs:
         with:
           name: partner-signing-result
           if-no-files-found: error
+          overwrite: true
           path: partner-signing-result.json
 
       - name: 'Mirror signed Partner files'
@@ -382,6 +384,7 @@ jobs:
         with:
           name: dshidmini-microsoft-drivers
           if-no-files-found: error
+          overwrite: true
           path: artifacts/drivers/**
 
       - name: 'Upload release metadata for retry runs'
@@ -390,4 +393,5 @@ jobs:
         with:
           name: release-metadata
           if-no-files-found: error
+          overwrite: true
           path: artifacts/release-metadata.json

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -1,0 +1,107 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $here 'PartnerSigning.ps1')
+
+function Assert-Equal($Actual, $Expected, [string] $Name) {
+    if ($Actual -cne $Expected) {
+        throw "FAIL ${Name}: expected '$Expected', got '$Actual'."
+    }
+    Write-Output "PASS $Name"
+}
+
+function Assert-True([bool] $Condition, [string] $Name) {
+    if (-not $Condition) {
+        throw "FAIL $Name"
+    }
+    Write-Output "PASS $Name"
+}
+
+function Assert-Throws([scriptblock] $Action, [string] $Name) {
+    $threw = $false
+    try {
+        & $Action
+    }
+    catch {
+        $threw = $true
+    }
+
+    if (-not $threw) {
+        throw "FAIL ${Name}: expected an exception"
+    }
+
+    Write-Output "PASS $Name"
+}
+
+$product = New-PartnerProductPayload -ProductName 'DsHidMini 3.6.0 3.6.0.2145' -AnnouncementDate '2026-09-09T00:00:00'
+Assert-Equal $product.testHarness 'Attestation' 'product harness'
+Assert-Equal $product.deviceType 'external' 'product device type'
+Assert-Equal $product.selectedProductTypes.windows_v100_RS5 'Unclassified' 'product type RS5'
+Assert-Equal $product.requestedSignatures.Count 2 'signature count'
+Assert-Equal $product.requestedSignatures[0] 'WINDOWS_v100_X64_RS5_FULL' 'x64 RS5 signature'
+Assert-Equal $product.requestedSignatures[1] 'WINDOWS_v100_ARM64_RS5_FULL' 'ARM64 RS5 signature'
+
+Assert-Equal (Get-SdcmEntityId -Json '{"id": 1152921505701840714, "name": "x"}') '1152921505701840714' 'entity id stays a string'
+
+$submission = New-PartnerSubmissionPayload -Name 'DsHidMini 3.6.0.2145'
+Assert-Equal $submission.type 'initial' 'submission type'
+Assert-Equal (Get-PartnerPortalUrl -ProductId '123') 'https://partner.microsoft.com/dashboard/hardware/driver/123' 'portal url'
+
+$created = [pscustomobject]@{ commitStatus = 'commitPending' }
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $created) 'Created' 'created progress'
+Assert-True (Test-PartnerSubmissionNeedsUpload -Submission $created) 'created needs upload'
+Assert-True (Test-PartnerSubmissionNeedsCommit -Submission $created) 'created needs commit'
+
+$submitted = [pscustomobject]@{
+    commitStatus    = 'commitSucceeded'
+    workflowStatus  = [pscustomobject]@{ state = 'inProgress'; currentStep = 'finalizeIngestion' }
+}
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $submitted) 'Submitted' 'submitted progress'
+Assert-True (-not (Test-PartnerSubmissionNeedsUpload -Submission $submitted)) 'submitted skips upload'
+Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $submitted)) 'submitted skips commit'
+
+$completed = [pscustomobject]@{
+    workflowStatus = [pscustomobject]@{ state = 'completed' }
+    downloads      = [pscustomobject]@{
+        items = @(
+            [pscustomobject]@{ type = 'signedPackage' }
+        )
+    }
+}
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $completed) 'Completed' 'completed progress'
+
+$failed = [pscustomobject]@{ workflowStatus = [pscustomobject]@{ state = 'failed' } }
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $failed) 'Failed' 'failed progress'
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) ("dshm-partner-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $temp | Out-Null
+try {
+    $id = '1152921505701840714'
+    Set-Content -LiteralPath (Join-Path $temp "Signed_$id.zip") -Value 'signed'
+    Set-Content -LiteralPath (Join-Path $temp "Initial_$id.cab") -Value 'initial'
+    $pair = Find-PartnerSignedPackagePair -Root $temp
+    Assert-Equal $pair.Id $id 'pair id'
+    Assert-Equal $pair.SignedName "Signed_$id.zip" 'signed name'
+    Assert-Equal $pair.InitialName "Initial_$id.cab" 'initial name'
+
+    Set-Content -LiteralPath (Join-Path $temp 'Signed_999.zip') -Value 'other'
+    $stillPaired = Find-PartnerSignedPackagePair -Root $temp
+    Assert-Equal $stillPaired.Id $id 'unmatched extra signed zip still pairs one id'
+
+    Remove-Item -LiteralPath (Join-Path $temp "Initial_$id.cab")
+    Assert-Throws { Find-PartnerSignedPackagePair -Root $temp } 'missing initial cab'
+
+    $nested = Join-Path $temp 'nested'
+    New-Item -ItemType Directory -Path $nested | Out-Null
+    Set-Content -LiteralPath (Join-Path $nested "Signed_$id.zip") -Value 'signed'
+    Set-Content -LiteralPath (Join-Path $nested "Initial_$id.cab") -Value 'initial'
+    Set-Content -LiteralPath (Join-Path $temp "Signed_42.zip") -Value 'signed'
+    Set-Content -LiteralPath (Join-Path $temp "Initial_42.cab") -Value 'initial'
+    Assert-Throws { Find-PartnerSignedPackagePair -Root $temp } 'multiple pairs rejected'
+}
+finally {
+    Remove-Item -LiteralPath $temp -Recurse -Force
+}
+
+Write-Output 'PartnerSigning tests passed'

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -1,0 +1,270 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+
+$script:PartnerSignedNamePattern = '^Signed_(\d+)\.zip$'
+$script:PartnerInitialNamePattern = '^Initial_(\d+)\.cab$'
+
+function Invoke-Sdcm {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]] $SdcmArgs
+    )
+
+    & sdcm --output json --auth client-secret @SdcmArgs
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "sdcm $($SdcmArgs -join ' ') failed with exit code $exitCode"
+    }
+}
+
+function Write-Utf8NoBomJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Object,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Path
+    )
+
+    $directory = Split-Path -Parent $Path
+    if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    $json = $Object | ConvertTo-Json -Depth 8
+    [IO.File]::WriteAllText($Path, $json, [Text.UTF8Encoding]::new($false))
+}
+
+function New-PartnerProductPayload {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ProductName,
+
+        [Parameter(Mandatory = $true)]
+        [string] $AnnouncementDate
+    )
+
+    [ordered]@{
+        productName           = $ProductName
+        testHarness           = 'Attestation'
+        announcementDate      = $AnnouncementDate
+        firmwareVersion       = '0'
+        deviceType            = 'external'
+        isTestSign            = $false
+        isFlightSign          = $false
+        selectedProductTypes  = @{ windows_v100_RS5 = 'Unclassified' }
+        requestedSignatures   = @(
+            'WINDOWS_v100_X64_RS5_FULL'
+            'WINDOWS_v100_ARM64_RS5_FULL'
+        )
+    }
+}
+
+function New-PartnerSubmissionPayload {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    [ordered]@{
+        name = $Name
+        type = 'initial'
+    }
+}
+
+function Get-PartnerPortalUrl {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ProductId
+    )
+
+    "https://partner.microsoft.com/dashboard/hardware/driver/$ProductId"
+}
+
+function Get-PartnerSubmissionWorkflowState {
+    [CmdletBinding()]
+    param($Submission)
+
+    if ($null -eq $Submission) {
+        return $null
+    }
+
+    if (-not $Submission.PSObject.Properties['workflowStatus']) {
+        return $null
+    }
+
+    $workflow = $Submission.workflowStatus
+    if ($null -eq $workflow) {
+        return $null
+    }
+
+    if ($workflow -is [string]) {
+        return $workflow
+    }
+
+    foreach ($name in @('state', 'currentState', 'status')) {
+        if ($workflow.PSObject.Properties[$name] -and $workflow.$name) {
+            return [string]$workflow.$name
+        }
+    }
+
+    return $null
+}
+
+function Get-PartnerSubmissionProgress {
+    [CmdletBinding()]
+    param($Submission)
+
+    $workflow = Get-PartnerSubmissionWorkflowState -Submission $Submission
+    $commit = $null
+    if ($Submission -and $Submission.PSObject.Properties['commitStatus'] -and $Submission.commitStatus) {
+        $commit = [string]$Submission.commitStatus
+    }
+
+    $downloadTypes = @()
+    if ($Submission -and $Submission.PSObject.Properties['downloads'] -and $Submission.downloads -and
+        $Submission.downloads.PSObject.Properties['items'] -and $Submission.downloads.items) {
+        $downloadTypes = @(
+            $Submission.downloads.items |
+                ForEach-Object { $_.type } |
+                Where-Object { $_ }
+        )
+    }
+
+    $failed = @(
+        'failed', 'failure', 'cancelled', 'canceled', 'commitFailed'
+    )
+    if ($workflow -and ($failed -contains $workflow)) {
+        return 'Failed'
+    }
+    if ($commit -and ($failed -contains $commit)) {
+        return 'Failed'
+    }
+
+    $completed = @('completed', 'complete', 'succeeded', 'success')
+    if ($workflow -and ($completed -contains $workflow)) {
+        return 'Completed'
+    }
+    if ($downloadTypes -contains 'signedPackage') {
+        return 'Completed'
+    }
+
+    $submitted = @(
+        'inProgress', 'inprogress', 'commitSucceeded', 'commitInProgress', 'finalizeIngestion'
+    )
+    if ($commit -and ($submitted -contains $commit)) {
+        return 'Submitted'
+    }
+    if ($workflow -and ($submitted -contains $workflow)) {
+        return 'Submitted'
+    }
+
+    return 'Created'
+}
+
+function Test-PartnerSubmissionNeedsUpload {
+    [CmdletBinding()]
+    param($Submission)
+
+    $progress = Get-PartnerSubmissionProgress -Submission $Submission
+    return $progress -eq 'Created'
+}
+
+function Test-PartnerSubmissionNeedsCommit {
+    [CmdletBinding()]
+    param($Submission)
+
+    $progress = Get-PartnerSubmissionProgress -Submission $Submission
+    return $progress -eq 'Created'
+}
+
+function Find-PartnerSignedPackagePair {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Root
+    )
+
+    if (-not (Test-Path -LiteralPath $Root)) {
+        throw "Partner download directory not found: $Root"
+    }
+
+    $signed = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Filter 'Signed_*.zip' |
+        Where-Object { $_.Name -match $script:PartnerSignedNamePattern })
+    $initial = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Filter 'Initial_*.cab' |
+        Where-Object { $_.Name -match $script:PartnerInitialNamePattern })
+
+    if ($signed.Count -eq 0 -or $initial.Count -eq 0) {
+        throw "Partner download is missing Signed_<id>.zip and/or Initial_<id>.cab under $Root."
+    }
+
+    $pairs = foreach ($zip in $signed) {
+        if ($zip.Name -notmatch $script:PartnerSignedNamePattern) {
+            continue
+        }
+        $id = $Matches[1]
+        $cab = $initial | Where-Object { $_.Name -eq "Initial_$id.cab" } | Select-Object -First 1
+        if ($cab) {
+            [pscustomobject]@{
+                Id           = $id
+                SignedZip    = $zip.FullName
+                InitialCab   = $cab.FullName
+                SignedName   = $zip.Name
+                InitialName  = $cab.Name
+            }
+        }
+    }
+
+    $pairs = @($pairs)
+    if ($pairs.Count -eq 0) {
+        throw "Partner download has Signed_*.zip and Initial_*.cab files, but no matching numeric id pair under $Root."
+    }
+    if ($pairs.Count -gt 1) {
+        $names = ($pairs | ForEach-Object { $_.SignedName }) -join ', '
+        throw "Partner download has multiple Signed_/Initial_ pairs ($names). Point at a single submission download."
+    }
+
+    return $pairs[0]
+}
+
+function Get-SdcmEntityId {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Json
+    )
+
+    $match = [regex]::Match($Json, '"id"\s*:\s*(\d+)')
+    if (-not $match.Success) {
+        throw 'sdcm JSON is missing an id field.'
+    }
+
+    return $match.Groups[1].Value
+}
+
+function ConvertFrom-SdcmJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Json
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Json)) {
+        throw 'sdcm returned empty JSON.'
+    }
+
+    $parsed = $Json | ConvertFrom-Json
+    if ($parsed -is [System.Array]) {
+        if ($parsed.Count -eq 1) {
+            return $parsed[0]
+        }
+        return $parsed
+    }
+
+    return $parsed
+}

--- a/build/ReleasePipeline.cs
+++ b/build/ReleasePipeline.cs
@@ -160,6 +160,59 @@ static class ReleaseStaging
         }
     }
 
+    public static bool TryStageMicrosoftDrivers(string downloadDir, string artifactsRoot)
+    {
+        IReadOnlyList<string> packages = FindStagedMicrosoftDriverPackages(downloadDir);
+        if (packages.Count == 0)
+        {
+            return false;
+        }
+
+        if (packages.Count > 1)
+        {
+            throw new InvalidOperationException(
+                "Multiple dshidmini driver packages were found; refusing to guess. Packages:" +
+                Environment.NewLine + string.Join(Environment.NewLine, packages));
+        }
+
+        string destination = DriversDirectory(artifactsRoot);
+        if (Directory.Exists(destination))
+        {
+            Directory.Delete(destination, recursive: true);
+        }
+
+        CopyDirectory(packages[0], destination);
+        RequireDriverLayout(destination);
+        return true;
+    }
+
+    static IReadOnlyList<string> FindStagedMicrosoftDriverPackages(string root)
+    {
+        if (!Directory.Exists(root))
+        {
+            return [];
+        }
+
+        string preferred = Path.Combine(root, "dshidmini-microsoft-drivers");
+        if (File.Exists(Path.Combine(preferred, "dshidmini.inf")))
+        {
+            return [Path.GetFullPath(preferred)];
+        }
+
+        IReadOnlyList<string> named = FindDriverPackages(root);
+        if (named.Count > 0)
+        {
+            return named;
+        }
+
+        return Directory.GetFiles(root, "dshidmini.inf", SearchOption.AllDirectories)
+            .Select(Path.GetDirectoryName)
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     public static IReadOnlyList<string> FindDriverPackages(string root)
     {
         if (!Directory.Exists(root))

--- a/build/ReleasePipeline.cs
+++ b/build/ReleasePipeline.cs
@@ -176,6 +176,8 @@ static class ReleaseStaging
         }
 
         string destination = DriversDirectory(artifactsRoot);
+        RequireDriverLayout(packages[0]);
+
         if (Directory.Exists(destination))
         {
             Directory.Delete(destination, recursive: true);

--- a/build/ReleasePipelineTests.cs
+++ b/build/ReleasePipelineTests.cs
@@ -10,6 +10,7 @@ static class ReleasePipelineTests
     {
         TestMetadataRoundTrip();
         TestArrangeDownloadedArtifacts();
+        TestStageMicrosoftDrivers();
         TestUniquePackageDetection();
         TestIngestFromDirectoryAndZip();
         TestIgfilterStaging();
@@ -61,6 +62,18 @@ static class ReleasePipelineTests
         metadata.Files.PartnerCab.Sha256 = new string('0', 64);
         ReleaseStaging.WriteMetadata(Path.Combine(download, "release-metadata", ReleaseStaging.MetadataFileName), metadata);
         AssertThrows(() => ReleaseStaging.ArrangeDownloadedArtifacts(download, artifacts), "hash mismatch");
+    }
+
+    static void TestStageMicrosoftDrivers()
+    {
+        using TempScope scope = new();
+        string download = Path.Combine(scope.Root, "download");
+        string artifacts = Path.Combine(scope.Root, "artifacts");
+        WriteDriverPackage(Path.Combine(download, "dshidmini-microsoft-drivers"));
+        AssertTrue(ReleaseStaging.TryStageMicrosoftDrivers(download, artifacts), "drivers staged");
+        AssertTrue(File.Exists(Path.Combine(artifacts, "drivers", "dshidmini.inf")), "inf staged");
+        AssertTrue(File.Exists(Path.Combine(artifacts, "drivers", "x64", "dshidmini.dll")), "x64 staged");
+        AssertTrue(!ReleaseStaging.TryStageMicrosoftDrivers(Path.Combine(scope.Root, "empty"), artifacts), "missing drivers");
     }
 
     static void TestUniquePackageDetection()

--- a/build/ReleasePipelineTests.cs
+++ b/build/ReleasePipelineTests.cs
@@ -74,6 +74,13 @@ static class ReleasePipelineTests
         AssertTrue(File.Exists(Path.Combine(artifacts, "drivers", "dshidmini.inf")), "inf staged");
         AssertTrue(File.Exists(Path.Combine(artifacts, "drivers", "x64", "dshidmini.dll")), "x64 staged");
         AssertTrue(!ReleaseStaging.TryStageMicrosoftDrivers(Path.Combine(scope.Root, "empty"), artifacts), "missing drivers");
+
+        string badDownload = Path.Combine(scope.Root, "bad-download");
+        Directory.CreateDirectory(Path.Combine(badDownload, "dshidmini-microsoft-drivers"));
+        File.WriteAllText(Path.Combine(badDownload, "dshidmini-microsoft-drivers", "dshidmini.inf"), "inf");
+        AssertThrows(() => ReleaseStaging.TryStageMicrosoftDrivers(badDownload, artifacts), "invalid source");
+        AssertTrue(File.Exists(Path.Combine(artifacts, "drivers", "dshidmini.inf")), "previous drivers kept");
+        AssertTrue(File.Exists(Path.Combine(artifacts, "drivers", "x64", "dshidmini.dll")), "previous x64 kept");
     }
 
     static void TestUniquePackageDetection()

--- a/build/ReleaseTargets.cs
+++ b/build/ReleaseTargets.cs
@@ -19,7 +19,8 @@ partial class Build
 
     /// <summary>
     /// Downloads the tagged-run artifacts needed to continue a release: signed ControlApp,
-    /// the EV-signed partner submission CAB, and release-metadata.json. Does not sign anything.
+    /// the EV-signed partner submission CAB, release-metadata.json, and the Microsoft-attested
+    /// driver package when Partner Center signing has finished. Does not sign anything.
     /// </summary>
     [UsedImplicitly]
     public Target DownloadCiArtifacts => _ => _
@@ -28,7 +29,7 @@ partial class Build
             if (string.IsNullOrWhiteSpace(RunId))
             {
                 throw new InvalidOperationException(
-                    "DownloadCiArtifacts requires RunId (the numeric GitHub Actions run ID from the Build workflow URL).");
+                    "DownloadCiArtifacts requires RunId (the numeric GitHub Actions run ID from the Build or Partner signing workflow URL).");
             }
 
             if (!long.TryParse(RunId, out long parsedRunId) || parsedRunId <= 0)
@@ -45,26 +46,51 @@ partial class Build
 
             Directory.CreateDirectory(downloadDir);
 
-            string[] patterns = ["release-metadata", "control-app", "dshidmini-partner-submission"];
-            foreach (string pattern in patterns)
+            DownloadRunArtifact(parsedRunId, downloadDir, "release-metadata", required: true);
+            string metadataFile = ReleaseStaging.FindExistingFile(downloadDir, ReleaseStaging.MetadataFileName)
+                                  ?? throw new InvalidOperationException(
+                                      "Downloaded artifacts are missing release-metadata.json. Use a tagged Build workflow run.");
+            ReleaseMetadata sourceMetadata = ReleaseStaging.ReadMetadata(metadataFile);
+            long sourceRunId = sourceMetadata.RunId;
+            if (sourceRunId != parsedRunId)
             {
-                ProcessTasks.StartProcess("gh",
-                        $"run download {RunId} --repo nefarius/DsHidMini --dir \"{downloadDir}\" --pattern \"{pattern}\"")
-                    .AssertZeroExitCode();
+                Log.Information(
+                    "Requested run {RunId} is a Partner signing retry; ControlApp and the partner CAB come from source run {SourceRunId}",
+                    parsedRunId, sourceRunId);
+            }
+
+            long payloadRunId = sourceRunId > 0 ? sourceRunId : parsedRunId;
+            DownloadRunArtifact(payloadRunId, downloadDir, "control-app", required: true);
+            DownloadRunArtifact(payloadRunId, downloadDir, "dshidmini-partner-submission", required: true);
+            DownloadRunArtifact(parsedRunId, downloadDir, "dshidmini-microsoft-drivers", required: false);
+            if (payloadRunId != parsedRunId)
+            {
+                DownloadRunArtifact(payloadRunId, downloadDir, "dshidmini-microsoft-drivers", required: false);
             }
 
             ReleaseStaging.ArrangeDownloadedArtifacts(downloadDir, artifactsDir);
             ReleaseMetadata metadata = ReleaseStaging.ReadMetadata(ReleaseStaging.MetadataPath(artifactsDir));
-            if (metadata.RunId != parsedRunId)
+            if (metadata.RunId != parsedRunId && metadata.RunId != sourceRunId)
             {
                 throw new InvalidOperationException(
-                    $"Downloaded metadata runId {metadata.RunId} does not match requested RunId {parsedRunId}.");
+                    $"Downloaded metadata runId {metadata.RunId} does not match requested RunId {parsedRunId} or source run {sourceRunId}.");
             }
 
+            bool stagedDrivers = ReleaseStaging.TryStageMicrosoftDrivers(downloadDir, artifactsDir);
             Log.Information("Staged release {Tag} / driver {DriverVersion} from run {RunId}",
                 metadata.Tag, metadata.DriverVersion, metadata.RunId);
             Log.Information("Partner CAB is in {Submission}", ReleaseStaging.SubmissionDirectory(artifactsDir));
-            Log.Information("Next: submit that CAB to Partner Center, then IngestMicrosoftPackage.");
+            if (stagedDrivers)
+            {
+                Log.Information("Microsoft-attested drivers are in {Drivers}",
+                    ReleaseStaging.DriversDirectory(artifactsDir));
+                Log.Information("Next: StageIgfilter, then ValidateSetupInputs / BuildSetup.");
+            }
+            else
+            {
+                Log.Information(
+                    "Microsoft-attested drivers are not on this run yet. Wait for Partner Center signing or ingest a downloaded Signed_*.zip.");
+            }
         });
 
     /// <summary>
@@ -189,17 +215,38 @@ partial class Build
     public Target TestReleasePipeline => _ => _
         .Executes(() =>
         {
-            AbsolutePath tests = RootDirectory / "build" / "ReleaseVersion.Tests.ps1";
             string shell = ToolPathResolver.TryGetEnvironmentExecutable("pwsh.exe")
                            ?? ToolPathResolver.TryGetEnvironmentExecutable("pwsh")
                            ?? TryGetPathExecutable("pwsh")
                            ?? "powershell";
-            ProcessTasks.StartProcess(shell, $"-NoProfile -File \"{tests}\"")
-                .AssertZeroExitCode();
+            foreach (string testFile in new[] { "ReleaseVersion.Tests.ps1", "PartnerSigning.Tests.ps1" })
+            {
+                AbsolutePath tests = RootDirectory / "build" / testFile;
+                ProcessTasks.StartProcess(shell, $"-NoProfile -File \"{tests}\"")
+                    .AssertZeroExitCode();
+            }
 
             ReleasePipelineTests.Run();
             Log.Information("Release pipeline tests passed");
         });
+
+    static void DownloadRunArtifact(long runId, string downloadDir, string pattern, bool required)
+    {
+            var process = ProcessTasks.StartProcess("gh",
+                $"run download {runId} --repo nefarius/DsHidMini --dir \"{downloadDir}\" --pattern \"{pattern}\"");
+            process.WaitForExit();
+            if (process.ExitCode == 0)
+            {
+                return;
+            }
+
+            if (required)
+            {
+                throw new InvalidOperationException($"Failed to download '{pattern}' from GitHub Actions run {runId}.");
+            }
+
+            Log.Information("Optional artifact {Pattern} is not on run {RunId}", pattern, runId);
+        }
 
     static string TryGetPathExecutable(string name)
     {

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # DsHidMini tagged driver release
 
-This is the maintainer and agent runbook for producing a production MSI. Partner Center upload and download is the only human gate. Every other step is a NUKE target invoked with `.\build.cmd` from the repository root.
+This is the maintainer and agent runbook for producing a production MSI. Tagged CI EV-signs the combined CAB, submits it to Partner Center, waits for attestation, and stages the Microsoft-signed drivers. The remaining local steps are igfilter staging, MSI construction, and the GitHub release. Every local step is a NUKE target invoked with `.\build.cmd` from the repository root.
 
 Do not use `nuke ...` directly, do not use Visual Studio to emit the MSI, and do not mix artifacts from different GitHub Actions runs.
 
@@ -34,6 +34,9 @@ GitHub Actions secrets/variables used by tagged runs:
 - `SIGN_RELAY_SERVER` (variable)
 - `SIGN_RELAY_CI_TOKEN` (secret)
 - `WEBHOOK_URL` (secret; artifact mirror)
+- `SDCM_PROFILES__DEFAULT__TENANTID` (secret; Partner Center Entra tenant)
+- `SDCM_PROFILES__DEFAULT__CLIENTID` (secret; Partner Center app)
+- `SDCM_PROFILES__DEFAULT__KEY` (secret; Partner Center API key)
 
 ## CI jobs and artifacts
 
@@ -44,6 +47,8 @@ version
   -> build (x64, ARM64, x86)          unsigned driver DLLs + per-arch CABs
   -> control-app                      EV-signs ControlApp.exe and XInput1_3.dll
   -> partner-cab                      EV-signs driver DLLs, packs dual-arch CAB, EV-signs CAB
+  -> partner-signing                  Partner Center attestation via [partner-signing.yml](../.github/workflows/partner-signing.yml)
+       create -> upload -> wait -> ingest
 ```
 
 `partner-cab` does not depend on `control-app`. The compile job must leave `dshidmini.dll` unsigned. Immediately before `makecab` of [`DsHidMini_combined.ddf`](../DsHidMini_combined.ddf), both architecture DLLs are EV-signed. Microsoft attestation **adds** its signature; it does not replace the publisher signature.
@@ -54,6 +59,10 @@ version
 | `control-app` | release tags only | EV-signed `bin/ControlApp.exe` and XInput DLLs |
 | `dshidmini-partner-submission` | release tags only | `dshidmini_{DriverVersion}.cab` (EV-signed) |
 | `release-metadata` | release tags only | `release-metadata.json` (tag, versions, run ID, CAB SHA-256) |
+| `partner-signing-checkpoint` | release tags only | Partner product/submission IDs (non-secret) |
+| `dshidmini-partner-signed` | release tags only | `Signed_<id>.zip` and `Initial_<id>.cab` from the portal, mirrored to buildbot |
+| `partner-signing-result` | release tags only | Portal URL, IDs, and signed file names |
+| `dshidmini-microsoft-drivers` | release tags only | Validated dual-arch `dshidmini.inf` / `.cat` / `x64` / `ARM64` tree |
 
 Per-architecture CABs (`dshidmini_x64.cab` / `dshidmini_ARM64.cab`) are CI archives only. Never submit them to Partner Center.
 
@@ -103,7 +112,7 @@ git tag v3.6.0
 git push origin v3.6.0
 ```
 
-Wait for the Build workflow to finish. Copy the numeric run ID from the run URL (`https://github.com/nefarius/DsHidMini/actions/runs/<run-id>`).
+Wait for the Build workflow, including Partner Center signing, to finish. Signing can take up to about an hour after the CAB is packed. Copy the numeric run ID from the run URL (`https://github.com/nefarius/DsHidMini/actions/runs/<run-id>`).
 
 Restart point: if the workflow failed, delete the tag only if you will recreate the same three-part version; otherwise use the next patch.
 
@@ -113,29 +122,36 @@ Restart point: if the workflow failed, delete the tag only if you will recreate 
 .\build.cmd DownloadCiArtifacts --run-id 123456789
 ```
 
-This target does **not** sign files. It requires `release-metadata`, `control-app`, and `dshidmini-partner-submission` from that exact run and checks the CAB SHA-256 against the metadata.
+This target does **not** sign files. It requires `release-metadata`, `control-app`, and `dshidmini-partner-submission`. After Partner Center signing finishes it also pulls `dshidmini-microsoft-drivers` into `artifacts/drivers`. It checks the CAB SHA-256 against the metadata.
 
-Restart point: rerun the same command; it replaces `artifacts/ci` and restages ControlApp, metadata, and the CAB.
+If you re-ran [`.github/workflows/partner-signing.yml`](../.github/workflows/partner-signing.yml) by hand, pass that signing run ID instead. ControlApp and the partner CAB are then fetched from the source Build run recorded in `release-metadata.json`.
 
-### 3. Submit the CAB (human gate)
+Restart point: rerun the same command; it replaces `artifacts/ci` and restages ControlApp, metadata, the CAB, and attested drivers when present.
 
-Microsoft documentation: [Attestation sign Windows drivers](https://learn.microsoft.com/en-us/windows-hardware/drivers/dashboard/code-signing-attestation).
+### 3. Partner Center signing (CI)
 
-1. Open the [Partner Center hardware dashboard](https://partner.microsoft.com/dashboard/hardware).
-2. Submit new hardware.
-3. Product name: `DsHidMini <setupVersion> <yyyy-MM-dd>` (searchable; not the file version).
-4. Upload `artifacts/submission/dshidmini_<driverVersion>.cab`.
-5. Leave both test-signing options **unchecked**.
-6. Requested signatures: **Windows 10/11 attestation for x64 and ARM64**.
-7. Submit and wait until the dashboard marks the submission complete.
-8. Download the signed driver package (zip).
+The `partner-signing` jobs create a new versioned Attestation product named `DsHidMini <setupVersion> <driverVersion>` and request exactly:
+
+- `WINDOWS_v100_X64_RS5_FULL` (Windows 10 Client version 1809 Client x64 (RS5))
+- `WINDOWS_v100_ARM64_RS5_FULL` (Windows 10 Client version 1809 Client ARM64 (RS5))
+
+They upload the EV-signed combined CAB, wait up to 60 minutes, download `Signed_<id>.zip` plus `Initial_<id>.cab`, mirror that pair to buildbot, then ingest and signature-check the signed zip.
+
+Retry without rebuilding:
+
+- **Re-run failed jobs** on the same workflow run resumes after the last successful job (`create` / `upload` / `wait` / `ingest`). Upload/commit is status-aware and will not blindly re-upload a submission that already advanced.
+- **workflow_dispatch** of `Partner Center signing` with the original Build run ID creates a fresh product/submission from the already-built CAB. Use this after Hardware Dev Center rejects or fails a submission.
 
 This project's verified behavior: Microsoft **adds** its signature to the already EV-signed DLLs and replaces the catalog. If a returned DLL has only a Microsoft signer, stop and investigate; do not continue to MSI.
 
-### 4. Ingest the signed package
+CI does **not** build or publish the MSI, create a GitHub release, or create a shipping label.
+
+### 4. Ingest the signed package (only if CI did not)
+
+Skip this when `DownloadCiArtifacts` already staged `artifacts/drivers`. Use it for a portal zip downloaded by hand:
 
 ```powershell
-.\build.cmd IngestMicrosoftPackage --microsoft-package-path "D:\inbox\DsHidMini-signed.zip"
+.\build.cmd IngestMicrosoftPackage --microsoft-package-path "D:\inbox\Signed_1152921505701840714.zip"
 ```
 
 Accepts a `.zip`, `.cab`, or an already extracted directory. It locates the unique `dshidmini` folder (the folder that contains `dshidmini.inf`, not the parent), copies its contents into `artifacts/drivers`, and requires:
@@ -191,7 +207,7 @@ gh release create setup-v3.6.0 `
 - Mix a CAB from run A with a Microsoft package from run B.
 - Split the returned dual-arch INF/CAT into x64-only and ARM64-only packages.
 - EV-sign driver DLLs again after Microsoft returns them.
-- Use `workflow_dispatch` (removed) or a four-part `v*` tag to start a release.
+- Use a four-part `v*` tag to start a release. `workflow_dispatch` on Partner Center signing is only for retrying attestation from an existing Build run.
 - Treat `artifacts/` as source-controlled input; it is gitignored staging.
 
 ## Troubleshooting
@@ -201,6 +217,10 @@ gh release create setup-v3.6.0 `
 | `version` job: tag must be `vMAJOR.MINOR.PATCH` | Four-part or prerelease tag |
 | `DownloadCiArtifacts` missing `release-metadata` | Run was not a three-part release tag |
 | Partner CAB hash mismatch | Incomplete download or wrong run ID |
+| `create` job auth exit 2 | `SDCM_PROFILES__DEFAULT__*` secrets missing or invalid |
+| `wait` job exit 7 | Hardware Dev Center rejected the submission; dispatch a new signing run |
+| `wait` job exit 9 | `--wait-timeout` 3600 elapsed; re-run failed jobs to resume the wait |
+| Missing `Signed_<id>.zip` / `Initial_<id>.cab` pair | Downloaded the wrapper or submission CAB instead of the portal pair |
 | Multiple `dshidmini` packages | Point `MicrosoftPackagePath` at the zip or the single package folder |
 | DLL missing Microsoft signer | Downloaded the submission CAB instead of the dashboard's signed package |
 | DLL missing publisher signer | Microsoft package is not from this pipeline's EV-signed CAB |
@@ -215,6 +235,8 @@ gh release create setup-v3.6.0 `
 | [`build/ReleaseVersion.ps1`](../build/ReleaseVersion.ps1) | Tag parse and four-part version |
 | [`build/ReleasePipeline.cs`](../build/ReleasePipeline.cs) | Staging, ingest, validation |
 | [`build/ReleaseTargets.cs`](../build/ReleaseTargets.cs) | NUKE entry points |
+| [`build/PartnerSigning.ps1`](../build/PartnerSigning.ps1) | SDCM payloads, submission progress, Signed_/Initial_ pair checks |
+| [`.github/workflows/partner-signing.yml`](../.github/workflows/partner-signing.yml) | Retryable Partner Center submit / wait / ingest |
 | [`build/New-PartnerSubmissionInf.ps1`](../build/New-PartnerSubmissionInf.ps1) | Dual-arch INF for the submission CAB |
 | [`DsHidMini_combined.ddf`](../DsHidMini_combined.ddf) | Partner CAB layout (`dshidmini/` not at CAB root; includes PDBs) |
 | [`setup/InstallScript.cs`](../setup/InstallScript.cs) | WixSharp MSI contents |


### PR DESCRIPTION
Submit the EV-signed CAB, wait for Microsoft signatures, and stage validated drivers so maintainers no longer upload through the portal by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated Partner Center signing for release packages, including submission tracking, signed-file retrieval, validation, and artifact publishing.
  - Added support for retrying signing runs using artifacts from a selected workflow run.
  - Added automatic staging and validation of Microsoft-attested driver packages.
  - Added release automation for installing and using the required signing tools.

- **Bug Fixes**
  - Prevented invalid driver packages from replacing previously staged drivers.
  - Improved handling of required and optional artifact download failures.

- **Documentation**
  - Updated the release runbook with automated signing procedures, retry guidance, validation steps, artifacts, and troubleshooting information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->