### PR TITLE
Fix Partner submission state detection and add an offline signing dry run

### DIFF
--- a/.github/workflows/partner-signing.yml
+++ b/.github/workflows/partner-signing.yml
@@ -7,11 +7,27 @@ on:
         description: 'Build workflow run ID that produced the EV-signed partner CAB'
         required: true
         type: string
+      product-id:
+        description: 'Resume this existing Partner Center product instead of creating a new one'
+        required: false
+        type: string
+      submission-id:
+        description: 'Resume this existing submission (requires product-id)'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       source-run-id:
         description: 'Build workflow run ID that produced the EV-signed partner CAB'
         required: true
+        type: string
+      product-id:
+        description: 'Resume this existing Partner Center product instead of creating a new one'
+        required: false
+        type: string
+      submission-id:
+        description: 'Resume this existing submission (requires product-id)'
+        required: false
         type: string
 
 concurrency:
@@ -32,7 +48,7 @@ env:
 
 jobs:
   create:
-    name: 'Create Partner product'
+    name: 'Create or resume Partner product'
     runs-on: windows-2022
     outputs:
       product-id: ${{ steps.create.outputs.product-id }}
@@ -66,9 +82,12 @@ jobs:
 
       - uses: ./.github/actions/setup-sdcm
 
-      - name: 'Create product and submission'
+      - name: 'Create or resume product and submission'
         id: create
         shell: pwsh
+        env:
+          RESUME_PRODUCT_ID: ${{ inputs.product-id }}
+          RESUME_SUBMISSION_ID: ${{ inputs.submission-id }}
         run: |
           $ErrorActionPreference = 'Stop'
           . .\build\PartnerSigning.ps1
@@ -82,16 +101,45 @@ jobs:
           }
 
           $productName = "DsHidMini $($metadata.setupVersion) $($metadata.driverVersion)"
-          $announcement = (Get-Date).ToUniversalTime().ToString('s')
-          $productPath = Join-Path $pwd 'partner-product.json'
-          $submissionPath = Join-Path $pwd 'partner-submission.json'
-          Write-Utf8NoBomJson (New-PartnerProductPayload -ProductName $productName -AnnouncementDate $announcement) $productPath
-          Write-Utf8NoBomJson (New-PartnerSubmissionPayload -Name "$($productName) submission") $submissionPath
+          $resumeProductId = "$($env:RESUME_PRODUCT_ID)".Trim()
+          $resumeSubmissionId = "$($env:RESUME_SUBMISSION_ID)".Trim()
+          if ([bool]$resumeProductId -ne [bool]$resumeSubmissionId) {
+            throw 'product-id and submission-id must be supplied together to resume an existing submission.'
+          }
 
-          $productJson = Invoke-Sdcm product create --input $productPath
-          $productId = Get-SdcmEntityId -Json ($productJson | Out-String)
-          $submissionJson = Invoke-Sdcm submission create --product-id $productId --input $submissionPath
-          $submissionId = Get-SdcmEntityId -Json ($submissionJson | Out-String)
+          if ($resumeProductId) {
+            if ($resumeProductId -notmatch '^\d+$') { throw "product-id must be numeric. Got: '$resumeProductId'." }
+            if ($resumeSubmissionId -notmatch '^\d+$') { throw "submission-id must be numeric. Got: '$resumeSubmissionId'." }
+            $productId = $resumeProductId
+            $submissionId = $resumeSubmissionId
+
+            $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
+            $submission = ConvertFrom-SdcmJson -Json $listed
+            if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
+            $resumedId = Get-SdcmEntityId -Json $listed
+            if ($resumedId -ne $submissionId) {
+              throw "Partner Center returned submission $resumedId for requested submission $submissionId."
+            }
+            Write-Output "Resuming Partner Center product $productId submission $submissionId"
+            Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
+            if ((Get-PartnerSubmissionProgress -Submission $submission) -eq 'Failed') {
+              throw "Submission $submissionId already failed. Dispatch without product-id/submission-id to create a new product."
+            }
+          }
+          else {
+            $announcement = (Get-Date).ToUniversalTime().ToString('s')
+            $productPath = Join-Path $pwd 'partner-product.json'
+            $submissionPath = Join-Path $pwd 'partner-submission.json'
+            Write-Utf8NoBomJson (New-PartnerProductPayload -ProductName $productName -AnnouncementDate $announcement) $productPath
+            Write-Utf8NoBomJson (New-PartnerSubmissionPayload -Name "$($productName) submission") $submissionPath
+
+            $productJson = Invoke-Sdcm product create --input $productPath
+            $productId = Get-SdcmEntityId -Json $productJson
+            $submissionJson = Invoke-Sdcm submission create --product-id $productId --input $submissionPath
+            $submissionId = Get-SdcmEntityId -Json $submissionJson
+            Write-Output "Created Partner Center product $productId submission $submissionId"
+          }
+
           $portalUrl = Get-PartnerPortalUrl -ProductId $productId
 
           $checkpoint = [ordered]@{
@@ -105,6 +153,7 @@ jobs:
             submissionId = $submissionId
             portalUrl = $portalUrl
             productName = $productName
+            resumed = [bool]$resumeProductId
           }
           Write-Utf8NoBomJson $checkpoint 'partner-signing-checkpoint.json'
 
@@ -114,8 +163,9 @@ jobs:
           'driver-version=' + $metadata.driverVersion >> $env:GITHUB_OUTPUT
           'tag=' + $metadata.tag >> $env:GITHUB_OUTPUT
 
+          $verb = if ($resumeProductId) { 'Resumed' } else { 'Created' }
           $summary = @(
-            "Created Partner Center product ``$productName``"
+            "$verb Partner Center product ``$productName``"
             "- Product ID: ``$productId``"
             "- Submission ID: ``$submissionId``"
             "- Portal: $portalUrl"
@@ -128,6 +178,7 @@ jobs:
         with:
           name: partner-signing-checkpoint
           if-no-files-found: error
+          overwrite: true
           path: partner-signing-checkpoint.json
 
   upload:
@@ -184,7 +235,7 @@ jobs:
           Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
 
           if ($progress -eq 'Failed') {
-            throw "Partner Center already failed product $productId submission $submissionId. Dispatch this workflow against the same source run to create a new product."
+            throw "Partner Center already failed product $productId submission $submissionId. Dispatch this workflow against the same source run, without product-id/submission-id, to create a new product."
           }
 
           if (Test-PartnerSubmissionNeedsUpload -Submission $submission) {
@@ -255,7 +306,7 @@ jobs:
           if ($progress -eq 'Created') {
             $preview = ConvertTo-SdcmJsonText -Json $listed
             if ($preview.Length -gt 1500) { $preview = $preview.Substring(0, 1500) + '...' }
-            throw "Submission is not committed. Re-run the upload job before waiting.`n$preview"
+            throw "Submission $submissionId is still commitPending, so Hardware Dev Center has nothing to process. Re-run the upload job before waiting.`n$preview"
           }
           if ($progress -ne 'Completed') {
             Invoke-Sdcm submission wait --product-id $productId --submission-id $submissionId --wait-timeout 3600
@@ -265,6 +316,8 @@ jobs:
           }
 
           $downloadZip = Join-Path $pwd 'hdc-download.zip'
+          # sdcm refuses to overwrite an existing destination file.
+          if (Test-Path -LiteralPath $downloadZip) { Remove-Item -LiteralPath $downloadZip -Force }
           Invoke-Sdcm submission download --product-id $productId --submission-id $submissionId --output-file $downloadZip
           $extractDir = Join-Path $pwd 'hdc-extracted'
           New-Item -ItemType Directory -Force -Path $extractDir | Out-Null

--- a/.github/workflows/partner-signing.yml
+++ b/.github/workflows/partner-signing.yml
@@ -178,10 +178,10 @@ jobs:
           if (-not $cab) { throw 'EV-signed partner CAB was not downloaded from the source run.' }
 
           $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
-          $submission = ConvertFrom-SdcmJson -Json ($listed | Out-String)
+          $submission = ConvertFrom-SdcmJson -Json $listed
           if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
           $progress = Get-PartnerSubmissionProgress -Submission $submission
-          Write-Output "Submission progress: $progress"
+          Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
 
           if ($progress -eq 'Failed') {
             throw "Partner Center already failed product $productId submission $submissionId. Dispatch this workflow against the same source run to create a new product."
@@ -196,8 +196,9 @@ jobs:
           }
 
           $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
-          $submission = ConvertFrom-SdcmJson -Json ($listed | Out-String)
+          $submission = ConvertFrom-SdcmJson -Json $listed
           if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
+          Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
           if (Test-PartnerSubmissionNeedsCommit -Submission $submission) {
             Write-Output 'Committing submission'
             Invoke-Sdcm submission commit --product-id $productId --submission-id $submissionId
@@ -243,16 +244,18 @@ jobs:
           if (-not $submissionId) { $submissionId = [string]$checkpoint.submissionId }
 
           $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
-          $submission = ConvertFrom-SdcmJson -Json ($listed | Out-String)
+          $submission = ConvertFrom-SdcmJson -Json $listed
           if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
           $progress = Get-PartnerSubmissionProgress -Submission $submission
-          Write-Output "Submission progress: $progress"
+          Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
 
           if ($progress -eq 'Failed') {
             throw "Partner Center failed product $productId submission $submissionId."
           }
           if ($progress -eq 'Created') {
-            throw 'Submission is not committed. Re-run the upload job before waiting.'
+            $preview = ConvertTo-SdcmJsonText -Json $listed
+            if ($preview.Length -gt 1500) { $preview = $preview.Substring(0, 1500) + '...' }
+            throw "Submission is not committed. Re-run the upload job before waiting.`n$preview"
           }
           if ($progress -ne 'Completed') {
             Invoke-Sdcm submission wait --product-id $productId --submission-id $submissionId --wait-timeout 3600

--- a/build/PartnerSigning.DryRun.ps1
+++ b/build/PartnerSigning.DryRun.ps1
@@ -1,0 +1,488 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Runs the Partner Center signing workflow offline against a mock sdcm.
+
+.DESCRIPTION
+    Every attempt against the real Hardware Dev Center consumes a Partner Center
+    product and submission, so the workflow's create / upload / wait glue cannot
+    be debugged in CI. This harness extracts the literal `run:` bodies out of
+    .github/workflows/partner-signing.yml and executes them against a fake sdcm
+    that implements the documented Submission state machine, asserting which sdcm
+    verbs each stage invokes. It needs no credentials and no network.
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$workflowPath = Join-Path $repoRoot '.github/workflows/partner-signing.yml'
+$root = Join-Path ([IO.Path]::GetTempPath()) ('dshm-partner-dryrun-' + [guid]::NewGuid().ToString('N'))
+
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-Equal($Actual, $Expected, [string] $Name) {
+    if ([string]$Actual -ne [string]$Expected) {
+        $script:Failures.Add($Name)
+        Write-Host "FAIL ${Name}: expected '$Expected', got '$Actual'"
+        return
+    }
+    Write-Host "PASS $Name"
+}
+
+function Assert-True([bool] $Condition, [string] $Name) {
+    if (-not $Condition) {
+        $script:Failures.Add($Name)
+        Write-Host "FAIL $Name"
+        return
+    }
+    Write-Host "PASS $Name"
+}
+
+# Pull the literal `run: |` bodies out of the workflow so the dry run exercises
+# the same glue CI executes rather than a paraphrase of it.
+function Get-WorkflowPwshBlocks {
+    param([string] $Path)
+
+    $lines = [IO.File]::ReadAllLines($Path)
+    $blocks = New-Object System.Collections.Generic.List[string]
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -notmatch '^(\s+)run: \|\s*$') { continue }
+        $indent = $Matches[1].Length
+        $body = New-Object System.Collections.Generic.List[string]
+        $j = $i + 1
+        while ($j -lt $lines.Count) {
+            $line = $lines[$j]
+            if ([string]::IsNullOrWhiteSpace($line)) { $body.Add(''); $j++; continue }
+            $lineIndent = $line.Length - $line.TrimStart().Length
+            if ($lineIndent -le $indent) { break }
+            $body.Add($line.Substring($indent + 2))
+            $j++
+        }
+        $blocks.Add(($body -join "`n"))
+        $i = $j - 1
+    }
+
+    return $blocks
+}
+
+function Select-Block {
+    param(
+        [System.Collections.Generic.List[string]] $Blocks,
+        [string] $Signature
+    )
+
+    $matched = @($Blocks | Where-Object { $_ -like "*$Signature*" })
+    if ($matched.Count -ne 1) {
+        throw "Expected exactly one workflow run block containing '$Signature', found $($matched.Count)."
+    }
+
+    return $matched[0]
+}
+
+function Invoke-Block {
+    param(
+        [string] $Body,
+        [string] $WorkDir,
+        [hashtable] $Substitutions = @{},
+        [hashtable] $Variables = @{}
+    )
+
+    $text = $Body
+    foreach ($key in $Substitutions.Keys) {
+        $text = $text.Replace($key, [string]$Substitutions[$key])
+    }
+    if ($text -match '\$\{\{') {
+        throw "Unsubstituted workflow expression remains: $([regex]::Match($text, '\$\{\{[^}]*\}\}').Value)"
+    }
+
+    $scriptPath = Join-Path $WorkDir ('block-' + [guid]::NewGuid().ToString('N') + '.ps1')
+    [IO.File]::WriteAllText($scriptPath, $text, [Text.UTF8Encoding]::new($false))
+
+    foreach ($key in $Variables.Keys) {
+        Set-Item -Path "Env:$key" -Value ([string]$Variables[$key])
+    }
+
+    Push-Location $WorkDir
+    try {
+        $output = & pwsh -NoProfile -File $scriptPath 2>&1
+        $exit = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exit
+        Output   = ($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Mock sdcm: a state machine over the documented Submission resource. Ids come
+# back quoted, `submission list` wraps the entity in an array, and the verbs
+# reject out-of-order calls the way the real tool does.
+# ---------------------------------------------------------------------------
+$mockScript = @'
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$statePath = $env:SDCM_MOCK_STATE
+$logPath = $env:SDCM_MOCK_LOG
+$state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json -AsHashtable
+
+function Save-State { $state | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $statePath -Encoding utf8 }
+
+$cliArgs = @($args)
+function Read-Option([string] $Name) {
+    $idx = [array]::IndexOf($cliArgs, $Name)
+    if ($idx -lt 0 -or $idx + 1 -ge $cliArgs.Count) { return $null }
+    return $cliArgs[$idx + 1]
+}
+
+# Every option sdcm is invoked with here takes a value, so skipping the token
+# after each --option leaves just the noun/verb pair.
+$verbs = New-Object System.Collections.Generic.List[string]
+for ($i = 0; $i -lt $cliArgs.Count; $i++) {
+    if ($cliArgs[$i] -like '--*') { $i++; continue }
+    $verbs.Add($cliArgs[$i])
+}
+$noun = $verbs[0]
+$verb = $verbs[1]
+Add-Content -LiteralPath $logPath -Value "$noun $verb"
+
+function Write-SubmissionJson([switch] $AsArray) {
+    $downloads = @($state.downloads | ForEach-Object { @{ type = $_; url = "https://example.invalid/$_" } })
+    $submission = [ordered]@{
+        id             = $state.submissionId
+        productId      = $state.productId
+        name           = 'DsHidMini dry run submission'
+        type           = 'initial'
+        commitStatus   = $state.commitStatus
+        workflowStatus = [ordered]@{
+            currentStep = $state.step
+            state       = $state.state
+            messages    = @()
+        }
+        downloads      = [ordered]@{ items = $downloads; messages = @() }
+    }
+    if ($AsArray) { ConvertTo-Json @($submission) -Depth 8 } else { ConvertTo-Json $submission -Depth 8 }
+}
+
+switch ("$noun $verb") {
+    'product create' {
+        $state.productId = '14631253285588838'
+        Save-State
+        ConvertTo-Json ([ordered]@{
+            id              = $state.productId
+            sharedProductId = '1152921504607010608'
+            productName     = 'DsHidMini dry run'
+        }) -Depth 8
+        exit 0
+    }
+    'submission create' {
+        $state.submissionId = '1152921505701853745'
+        $state.commitStatus = 'CommitPending'
+        $state.state = 'notStarted'
+        $state.step = 'packageInfoValidation'
+        $state.downloads = @('initialPackage')
+        Save-State
+        Write-SubmissionJson
+        exit 0
+    }
+    'submission list' {
+        Write-SubmissionJson -AsArray
+        exit 0
+    }
+    'submission upload' {
+        if ($state.commitStatus -ne 'CommitPending') { Write-Error 'requestInvalidForCurrentState'; exit 6 }
+        $state.uploaded = $true
+        Save-State
+        exit 0
+    }
+    'submission commit' {
+        if (-not $state.uploaded) { Write-Error 'no package uploaded'; exit 6 }
+        if ($state.commitStatus -ne 'CommitPending') { Write-Error 'already committed'; exit 6 }
+        $state.commitStatus = 'commitComplete'
+        $state.state = 'started'
+        $state.step = 'preparation'
+        Save-State
+        exit 0
+    }
+    'submission wait' {
+        if ($state.commitStatus -eq 'CommitPending') { Write-Error 'wait timed out'; exit 9 }
+        $state.state = 'completed'
+        $state.step = 'finalizeIngestion'
+        $state.downloads = @('initialPackage', 'signedPackage', 'certificationReport')
+        Save-State
+        Write-SubmissionJson
+        exit 0
+    }
+    'submission download' {
+        if ($state.downloads -notcontains 'signedPackage') { Write-Error 'no signedPackage available'; exit 5 }
+        $target = Read-Option '--output-file'
+        if (Test-Path -LiteralPath $target) { Write-Error 'destination exists'; exit 4 }
+        $stage = Join-Path ([IO.Path]::GetTempPath()) ('sdcm-mock-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $stage | Out-Null
+        $pkg = $state.submissionId
+        Set-Content -LiteralPath (Join-Path $stage "Signed_$pkg.zip") -Value 'signed-package'
+        Set-Content -LiteralPath (Join-Path $stage "Initial_$pkg.cab") -Value 'initial-package'
+        Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $target
+        Remove-Item -LiteralPath $stage -Recurse -Force
+        exit 0
+    }
+    default {
+        Write-Error "mock sdcm does not implement '$noun $verb'"
+        exit 1
+    }
+}
+'@
+
+$mockBin = Join-Path $root 'bin'
+New-Item -ItemType Directory -Force -Path $mockBin | Out-Null
+[IO.File]::WriteAllText((Join-Path $mockBin 'sdcm-mock.ps1'), $mockScript, [Text.UTF8Encoding]::new($false))
+[IO.File]::WriteAllText(
+    (Join-Path $mockBin 'sdcm.cmd'),
+    "@echo off`r`npwsh -NoProfile -File `"%~dp0sdcm-mock.ps1`" %*`r`n",
+    [Text.UTF8Encoding]::new($false))
+$originalPath = $env:PATH
+$env:PATH = "$mockBin$([IO.Path]::PathSeparator)$env:PATH"
+
+# ---------------------------------------------------------------------------
+# Scenario driver
+# ---------------------------------------------------------------------------
+$blocks = Get-WorkflowPwshBlocks -Path $workflowPath
+$createBlock = Select-Block -Blocks $blocks -Signature 'RESUME_PRODUCT_ID'
+$uploadBlock = Select-Block -Blocks $blocks -Signature 'Test-PartnerSubmissionNeedsUpload'
+$waitBlock = Select-Block -Blocks $blocks -Signature 'partner-signing-result.json'
+
+function New-Sandbox([string] $Name) {
+    $dir = Join-Path $root $Name
+    New-Item -ItemType Directory -Force -Path (Join-Path $dir 'build') | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'build/PartnerSigning.ps1') -Destination (Join-Path $dir 'build/PartnerSigning.ps1')
+    New-Item -ItemType Directory -Force -Path (Join-Path $dir 'metadata') | Out-Null
+    @{ tag = 'v3.6.1.2202'; setupVersion = '3.6.1'; driverVersion = '3.6.1.2202' } |
+        ConvertTo-Json | Set-Content -LiteralPath (Join-Path $dir 'metadata/release-metadata.json') -Encoding utf8
+    New-Item -ItemType Directory -Force -Path (Join-Path $dir 'submission') | Out-Null
+    Set-Content -LiteralPath (Join-Path $dir 'submission/dshidmini_3.6.1.2202.cab') -Value 'ev-signed-cab'
+    Set-Content -LiteralPath (Join-Path $dir 'outputs.txt') -Value ''
+    Set-Content -LiteralPath (Join-Path $dir 'summary.md') -Value ''
+    return $dir
+}
+
+function New-ScenarioEnvironment {
+    param([string] $Sandbox, [hashtable] $SeedState, [hashtable] $Overrides = @{})
+
+    $statePath = Join-Path $Sandbox 'sdcm-state.json'
+    $logPath = Join-Path $Sandbox 'sdcm-calls.log'
+    $SeedState | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $statePath -Encoding utf8
+    Set-Content -LiteralPath $logPath -Value ''
+
+    $variables = @{
+        SOURCE_RUN_ID        = '34446000000'
+        GITHUB_OUTPUT        = (Join-Path $Sandbox 'outputs.txt')
+        GITHUB_STEP_SUMMARY  = (Join-Path $Sandbox 'summary.md')
+        SDCM_MOCK_STATE      = $statePath
+        SDCM_MOCK_LOG        = $logPath
+        RESUME_PRODUCT_ID    = ''
+        RESUME_SUBMISSION_ID = ''
+    }
+    foreach ($key in $Overrides.Keys) { $variables[$key] = $Overrides[$key] }
+
+    return $variables
+}
+
+function Get-StepOutput([string] $Sandbox, [string] $Key) {
+    $line = Get-Content -LiteralPath (Join-Path $Sandbox 'outputs.txt') |
+        Where-Object { $_ -like "$Key=*" } | Select-Object -First 1
+    if (-not $line) { return '' }
+    return ($line -split '=', 2)[1]
+}
+
+function Get-SdcmCalls([string] $Sandbox) {
+    # A list rather than an array so an empty call log survives being stored on
+    # a pscustomobject property instead of collapsing to $null.
+    $calls = New-Object System.Collections.Generic.List[string]
+    Get-Content -LiteralPath (Join-Path $Sandbox 'sdcm-calls.log') |
+        Where-Object { $_ } | ForEach-Object { $calls.Add($_) }
+    return , $calls
+}
+
+function Measure-Call([string[]] $Calls, [string] $Call) {
+    return @($Calls | Where-Object { $_ -eq $Call }).Count
+}
+
+function Invoke-Pipeline {
+    param([string] $Name, [hashtable] $SeedState, [hashtable] $Overrides = @{})
+
+    Write-Host ''
+    Write-Host "=== $Name ==="
+    $sandbox = New-Sandbox ($Name -replace '[^A-Za-z0-9]', '-')
+    $variables = New-ScenarioEnvironment -Sandbox $sandbox -SeedState $SeedState -Overrides $Overrides
+
+    $create = Invoke-Block -Body $createBlock -WorkDir $sandbox -Variables $variables `
+        -Substitutions @{ '${{ github.run_id }}' = '99999999' }
+    Assert-Equal $create.ExitCode 0 "${Name}: create step succeeds"
+    if ($create.ExitCode -ne 0) { Write-Host $create.Output }
+
+    $productId = Get-StepOutput $sandbox 'product-id'
+    $submissionId = Get-StepOutput $sandbox 'submission-id'
+    Assert-True ($productId -match '^\d+$') "${Name}: create emits a numeric product-id"
+    Assert-True ($submissionId -match '^\d+$') "${Name}: create emits a numeric submission-id"
+
+    New-Item -ItemType Directory -Force -Path (Join-Path $sandbox 'checkpoint') | Out-Null
+    Copy-Item -LiteralPath (Join-Path $sandbox 'partner-signing-checkpoint.json') `
+        -Destination (Join-Path $sandbox 'checkpoint/partner-signing-checkpoint.json') -Force
+
+    $substitutions = @{
+        '${{ github.run_id }}'                      = '99999999'
+        '${{ needs.create.outputs.product-id }}'    = $productId
+        '${{ needs.create.outputs.submission-id }}' = $submissionId
+    }
+
+    $upload = Invoke-Block -Body $uploadBlock -WorkDir $sandbox -Variables $variables -Substitutions $substitutions
+    Assert-Equal $upload.ExitCode 0 "${Name}: upload step succeeds"
+    if ($upload.ExitCode -ne 0) { Write-Host $upload.Output }
+
+    $wait = Invoke-Block -Body $waitBlock -WorkDir $sandbox -Variables $variables -Substitutions $substitutions
+    Assert-Equal $wait.ExitCode 0 "${Name}: wait step succeeds"
+    if ($wait.ExitCode -ne 0) { Write-Host $wait.Output }
+
+    $calls = Get-SdcmCalls $sandbox
+    Write-Host "sdcm calls: $($calls -join ' | ')"
+
+    return [pscustomobject]@{
+        Sandbox      = $sandbox
+        Calls        = $calls
+        ProductId    = $productId
+        SubmissionId = $submissionId
+        UploadOutput = $upload.Output
+        WaitOutput   = $wait.Output
+    }
+}
+
+function Invoke-CreateOnly {
+    param([string] $Name, [hashtable] $SeedState, [hashtable] $Overrides = @{})
+
+    Write-Host ''
+    Write-Host "=== $Name ==="
+    $sandbox = New-Sandbox ($Name -replace '[^A-Za-z0-9]', '-')
+    $variables = New-ScenarioEnvironment -Sandbox $sandbox -SeedState $SeedState -Overrides $Overrides
+    $create = Invoke-Block -Body $createBlock -WorkDir $sandbox -Variables $variables `
+        -Substitutions @{ '${{ github.run_id }}' = '99999999' }
+
+    return [pscustomobject]@{
+        Sandbox  = $sandbox
+        ExitCode = $create.ExitCode
+        Output   = $create.Output
+        Calls    = (Get-SdcmCalls $sandbox)
+    }
+}
+
+try {
+    # A normal release run: create a product, upload, commit, wait, download.
+    $fresh = Invoke-Pipeline -Name 'fresh product' -SeedState @{
+        productId = ''; submissionId = ''; commitStatus = 'CommitPending'
+        state = 'notStarted'; step = ''; downloads = @(); uploaded = $false
+    }
+    Assert-Equal (Measure-Call $fresh.Calls 'product create') 1 'fresh: product created once'
+    Assert-Equal (Measure-Call $fresh.Calls 'submission create') 1 'fresh: submission created once'
+    Assert-Equal (Measure-Call $fresh.Calls 'submission upload') 1 'fresh: package uploaded exactly once'
+    Assert-Equal (Measure-Call $fresh.Calls 'submission commit') 1 'fresh: submission committed exactly once'
+    Assert-Equal (Measure-Call $fresh.Calls 'submission wait') 1 'fresh: waited once'
+    Assert-Equal (Measure-Call $fresh.Calls 'submission download') 1 'fresh: downloaded once'
+    $result = Get-Content -LiteralPath (Join-Path $fresh.Sandbox 'partner-signing-result.json') -Raw | ConvertFrom-Json
+    Assert-Equal $result.productId $fresh.ProductId 'fresh: result records the product id'
+    Assert-Equal $result.submissionId $fresh.SubmissionId 'fresh: result records the submission id'
+    Assert-Equal $result.signedZip "Signed_$($fresh.SubmissionId).zip" 'fresh: result records the signed zip'
+    Assert-Equal $result.tag 'v3.6.1.2202' 'fresh: result records the tag'
+    Assert-True (Test-Path -LiteralPath (Join-Path $fresh.Sandbox "partner-signed/Signed_$($fresh.SubmissionId).zip")) 'fresh: signed zip staged'
+    Assert-True (Test-Path -LiteralPath (Join-Path $fresh.Sandbox "partner-signed/Initial_$($fresh.SubmissionId).cab")) 'fresh: initial cab staged'
+
+    # Resuming a submission Hardware Dev Center is already processing must not
+    # open a second product, and must not upload or commit again.
+    $processing = Invoke-Pipeline -Name 'resume processing' -Overrides @{
+        RESUME_PRODUCT_ID = '13872423721100346'; RESUME_SUBMISSION_ID = '1152921505701853745'
+    } -SeedState @{
+        productId = '13872423721100346'; submissionId = '1152921505701853745'; commitStatus = 'commitComplete'
+        state = 'started'; step = 'scanning'; downloads = @('initialPackage'); uploaded = $true
+    }
+    Assert-Equal (Measure-Call $processing.Calls 'product create') 0 'processing: no new product created'
+    Assert-Equal (Measure-Call $processing.Calls 'submission create') 0 'processing: no new submission created'
+    Assert-Equal (Measure-Call $processing.Calls 'submission upload') 0 'processing: upload skipped'
+    Assert-Equal (Measure-Call $processing.Calls 'submission commit') 0 'processing: commit skipped'
+    Assert-Equal (Measure-Call $processing.Calls 'submission wait') 1 'processing: waited once'
+    Assert-Equal $processing.ProductId '13872423721100346' 'processing: keeps the requested product id'
+    Assert-Equal $processing.SubmissionId '1152921505701853745' 'processing: keeps the requested submission id'
+
+    # Resuming a product whose submission was created but never committed, which
+    # is what an orphaned product from a failed early step looks like.
+    $uncommitted = Invoke-Pipeline -Name 'resume uncommitted' -Overrides @{
+        RESUME_PRODUCT_ID = '13872423721100347'; RESUME_SUBMISSION_ID = '1152921505701853746'
+    } -SeedState @{
+        productId = '13872423721100347'; submissionId = '1152921505701853746'; commitStatus = 'CommitPending'
+        state = 'notStarted'; step = 'packageInfoValidation'; downloads = @('initialPackage'); uploaded = $false
+    }
+    Assert-Equal (Measure-Call $uncommitted.Calls 'product create') 0 'uncommitted: no new product created'
+    Assert-Equal (Measure-Call $uncommitted.Calls 'submission upload') 1 'uncommitted: package uploaded once'
+    Assert-Equal (Measure-Call $uncommitted.Calls 'submission commit') 1 'uncommitted: submission committed once'
+    Assert-Equal (Measure-Call $uncommitted.Calls 'submission wait') 1 'uncommitted: waited once'
+
+    # An already finished submission must skip the wait and go straight to the
+    # download.
+    $completed = Invoke-Pipeline -Name 'resume completed' -Overrides @{
+        RESUME_PRODUCT_ID = '13872423721100348'; RESUME_SUBMISSION_ID = '1152921505701853747'
+    } -SeedState @{
+        productId = '13872423721100348'; submissionId = '1152921505701853747'; commitStatus = 'commitComplete'
+        state = 'completed'; step = 'finalizeIngestion'
+        downloads = @('initialPackage', 'signedPackage'); uploaded = $true
+    }
+    Assert-Equal (Measure-Call $completed.Calls 'submission wait') 0 'completed: wait skipped'
+    Assert-Equal (Measure-Call $completed.Calls 'submission download') 1 'completed: downloaded once'
+    Assert-True ($completed.WaitOutput -like '*already completed*') 'completed: skip is reported'
+
+    # A failed submission must be refused up front instead of burning the rest
+    # of the pipeline.
+    $failed = Invoke-CreateOnly -Name 'resume failed' -Overrides @{
+        RESUME_PRODUCT_ID = '13872423721100349'; RESUME_SUBMISSION_ID = '1152921505701853748'
+    } -SeedState @{
+        productId = '13872423721100349'; submissionId = '1152921505701853748'; commitStatus = 'commitComplete'
+        state = 'failed'; step = 'validation'; downloads = @('initialPackage'); uploaded = $true
+    }
+    Assert-True ($failed.ExitCode -ne 0) 'failed: create refuses a failed submission'
+    Assert-True ($failed.Output -like '*already failed*') 'failed: refusal explains why'
+
+    # Half-specified resume inputs are a mistake worth catching before any API
+    # call happens.
+    $halfResume = Invoke-CreateOnly -Name 'partial resume inputs' -Overrides @{
+        RESUME_PRODUCT_ID = '13872423721100346'
+    } -SeedState @{
+        productId = ''; submissionId = ''; commitStatus = 'CommitPending'
+        state = 'notStarted'; step = ''; downloads = @(); uploaded = $false
+    }
+    Assert-True ($halfResume.ExitCode -ne 0) 'partial resume: create fails'
+    Assert-Equal $halfResume.Calls.Count 0 'partial resume: no sdcm call made'
+    Assert-True ($halfResume.Output -like '*must be supplied together*') 'partial resume: message names both inputs'
+
+    # A non-numeric id must never reach the API.
+    $badId = Invoke-CreateOnly -Name 'non numeric resume id' -Overrides @{
+        RESUME_PRODUCT_ID = 'not-an-id'; RESUME_SUBMISSION_ID = '1152921505701853745'
+    } -SeedState @{
+        productId = ''; submissionId = ''; commitStatus = 'CommitPending'
+        state = 'notStarted'; step = ''; downloads = @(); uploaded = $false
+    }
+    Assert-True ($badId.ExitCode -ne 0) 'bad id: create fails'
+    Assert-Equal $badId.Calls.Count 0 'bad id: no sdcm call made'
+}
+finally {
+    $env:PATH = $originalPath
+    if (Test-Path -LiteralPath $root) {
+        Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Output ''
+if ($script:Failures.Count -gt 0) {
+    throw "PartnerSigning dry run failed $($script:Failures.Count) assertion(s): $($script:Failures -join '; ')"
+}
+Write-Output 'PartnerSigning dry run passed'

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -43,6 +43,7 @@ Assert-Equal $product.requestedSignatures[0] 'WINDOWS_v100_X64_RS5_FULL' 'x64 RS
 Assert-Equal $product.requestedSignatures[1] 'WINDOWS_v100_ARM64_RS5_FULL' 'ARM64 RS5 signature'
 
 Assert-Equal (Get-SdcmEntityId -Json '{"id": 1152921505701840714, "name": "x"}') '1152921505701840714' 'entity id stays a string'
+Assert-Equal (Get-SdcmEntityId -Json '{"id": "1152921505701840714", "name": "x"}') '1152921505701840714' 'quoted entity id stays a string'
 
 $submission = New-PartnerSubmissionPayload -Name 'DsHidMini 3.6.0.2145'
 Assert-Equal $submission.type 'initial' 'submission type'

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -34,6 +34,46 @@ function Assert-Throws([scriptblock] $Action, [string] $Name) {
     Write-Output "PASS $Name"
 }
 
+# Builds a submission shaped like the Hardware Dashboard API's Submission
+# resource, so the state table below is exercised against real field names and
+# real documented values rather than invented ones.
+function New-TestSubmission {
+    [CmdletBinding()]
+    param(
+        [string] $CommitStatus = '',
+        [string] $State = '',
+        [string] $Step = '',
+        [string[]] $DownloadTypes = @()
+    )
+
+    $submission = [ordered]@{
+        id        = '1152921505701853745'
+        productId = '13872423721100346'
+        name      = 'DsHidMini 3.6.1 3.6.1.2202 submission'
+        type      = 'initial'
+    }
+    if ($CommitStatus) {
+        $submission['commitStatus'] = $CommitStatus
+    }
+    if ($State -or $Step) {
+        $submission['workflowStatus'] = [pscustomobject]@{
+            currentStep = $Step
+            state       = $State
+            messages    = @()
+        }
+    }
+    if ($DownloadTypes.Count -gt 0) {
+        $submission['downloads'] = [pscustomobject]@{
+            items    = @($DownloadTypes | ForEach-Object {
+                [pscustomobject]@{ type = $_; url = "https://example.invalid/$_" }
+            })
+            messages = @()
+        }
+    }
+
+    return [pscustomobject]$submission
+}
+
 $product = New-PartnerProductPayload -ProductName 'DsHidMini 3.6.0 3.6.0.2145' -AnnouncementDate '2026-09-09T00:00:00'
 Assert-Equal $product.testHarness 'Attestation' 'product harness'
 Assert-Equal $product.deviceType 'external' 'product device type'
@@ -42,68 +82,117 @@ Assert-Equal $product.requestedSignatures.Count 2 'signature count'
 Assert-Equal $product.requestedSignatures[0] 'WINDOWS_v100_X64_RS5_FULL' 'x64 RS5 signature'
 Assert-Equal $product.requestedSignatures[1] 'WINDOWS_v100_ARM64_RS5_FULL' 'ARM64 RS5 signature'
 
-Assert-Equal (Get-SdcmEntityId -Json '{"id": 1152921505701840714, "name": "x"}') '1152921505701840714' 'entity id stays a string'
-Assert-Equal (Get-SdcmEntityId -Json '{"id": "1152921505701840714", "name": "x"}') '1152921505701840714' 'quoted entity id stays a string'
-
 $submission = New-PartnerSubmissionPayload -Name 'DsHidMini 3.6.0.2145'
 Assert-Equal $submission.type 'initial' 'submission type'
 Assert-Equal (Get-PartnerPortalUrl -ProductId '123') 'https://partner.microsoft.com/dashboard/hardware/driver/123' 'portal url'
 
-$created = [pscustomobject]@{ commitStatus = 'commitPending' }
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $created) 'Created' 'created progress'
-Assert-True (Test-PartnerSubmissionNeedsUpload -Submission $created) 'created needs upload'
-Assert-True (Test-PartnerSubmissionNeedsCommit -Submission $created) 'created needs commit'
+# The raw API returns ids as numbers; sdcm re-serializes them as quoted strings.
+Assert-Equal (Get-SdcmEntityId -Json '{"id": 1152921505701840714, "name": "x"}') '1152921505701840714' 'entity id stays a string'
+Assert-Equal (Get-SdcmEntityId -Json '{"id": "1152921505701840714", "name": "x"}') '1152921505701840714' 'quoted entity id stays a string'
+Assert-Equal (Get-SdcmEntityId -Json '{"sharedProductId": "1152921504607010608", "id": "14631253285588838"}') '14631253285588838' 'sharedProductId is not mistaken for id'
+Assert-Equal (Get-SdcmEntityId -Json '{"productId": "13872423721100346", "id": "1152921505701853745"}') '1152921505701853745' 'productId is not mistaken for id'
+Assert-Equal (Get-SdcmEntityId -Json @('[', '  { "id": "42" }', ']')) '42' 'single-element array output unwraps'
+Assert-Throws { Get-SdcmEntityId -Json '{"name": "x"}' } 'missing id throws'
+Assert-Throws { Get-SdcmEntityId -Json '' } 'empty sdcm output throws'
 
-$idle = [pscustomobject]@{
-    commitStatus   = 'commitPending'
-    workflowStatus = [pscustomobject]@{ state = 'notStarted'; currentStep = '' }
+# workflowStatus.state is the state of workflowStatus.currentStep, not of the
+# submission as a whole, so every step/state combination has to be classified
+# explicitly. Documented states: notStarted, started, failed, completed.
+# Documented steps: packageInfoValidation, preparation, scanning, validation,
+# catalogCreation, manualReview, signing, finalizeIngestion.
+$progressCases = @(
+    @{ Name = 'fresh submission is Created'; Commit = 'CommitPending'; State = 'notStarted'; Step = 'packageInfoValidation'; Downloads = @('initialPackage'); Expected = 'Created' }
+    @{ Name = 'commitPending without workflow is Created'; Commit = 'commitPending'; State = ''; Step = ''; Downloads = @(); Expected = 'Created' }
+    @{ Name = 'submission with no status at all is Created'; Commit = ''; State = ''; Step = ''; Downloads = @(); Expected = 'Created' }
+    @{ Name = 'initialPackage alone is not completion'; Commit = 'CommitPending'; State = 'notStarted'; Step = ''; Downloads = @('initialPackage'); Expected = 'Created' }
+    @{ Name = 'committed but not yet started is Submitted'; Commit = 'commitComplete'; State = 'notStarted'; Step = 'packageInfoValidation'; Downloads = @('initialPackage'); Expected = 'Submitted' }
+    @{ Name = 'scanning in progress is Submitted'; Commit = 'commitComplete'; State = 'started'; Step = 'scanning'; Downloads = @('initialPackage'); Expected = 'Submitted' }
+    @{ Name = 'completed intermediate step is still Submitted'; Commit = 'commitComplete'; State = 'completed'; Step = 'scanning'; Downloads = @('initialPackage'); Expected = 'Submitted' }
+    @{ Name = 'manual review is Submitted'; Commit = 'commitComplete'; State = 'started'; Step = 'manualReview'; Downloads = @('initialPackage'); Expected = 'Submitted' }
+    @{ Name = 'signing is Submitted'; Commit = 'commitComplete'; State = 'started'; Step = 'signing'; Downloads = @('initialPackage'); Expected = 'Submitted' }
+    @{ Name = 'undocumented in-flight commit status is Submitted'; Commit = 'commitInProgress'; State = 'notStarted'; Step = ''; Downloads = @(); Expected = 'Submitted' }
+    @{ Name = 'started workflow without commitStatus is Submitted'; Commit = ''; State = 'started'; Step = 'validation'; Downloads = @(); Expected = 'Submitted' }
+    @{ Name = 'completed final step is Completed'; Commit = 'commitComplete'; State = 'completed'; Step = 'finalizeIngestion'; Downloads = @(); Expected = 'Completed' }
+    @{ Name = 'signedPackage download is Completed'; Commit = 'commitComplete'; State = 'started'; Step = 'signing'; Downloads = @('initialPackage', 'signedPackage'); Expected = 'Completed' }
+    @{ Name = 'failed workflow state is Failed'; Commit = 'commitComplete'; State = 'failed'; Step = 'validation'; Downloads = @('initialPackage'); Expected = 'Failed' }
+    @{ Name = 'commitFailed is Failed'; Commit = 'commitFailed'; State = 'notStarted'; Step = 'preparation'; Downloads = @(); Expected = 'Failed' }
+    @{ Name = 'failure wins over a signed package'; Commit = 'commitFailed'; State = 'failed'; Step = 'signing'; Downloads = @('signedPackage'); Expected = 'Failed' }
+)
+
+foreach ($case in $progressCases) {
+    $candidate = New-TestSubmission -CommitStatus $case.Commit -State $case.State -Step $case.Step -DownloadTypes $case.Downloads
+    Assert-Equal (Get-PartnerSubmissionProgress -Submission $candidate) $case.Expected $case.Name
 }
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $idle) 'Created' 'notStarted stays created'
 
-$submitted = [pscustomobject]@{
-    commitStatus    = 'commitSucceeded'
-    workflowStatus  = [pscustomobject]@{ state = 'inProgress'; currentStep = 'finalizeIngestion' }
-}
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $submitted) 'Submitted' 'submitted progress'
-Assert-True (-not (Test-PartnerSubmissionNeedsUpload -Submission $submitted)) 'submitted skips upload'
-Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $submitted)) 'submitted skips commit'
+# Upload and commit must fire exactly once, for a submission that is still ours.
+$fresh = New-TestSubmission -CommitStatus 'CommitPending' -State 'notStarted' -Step 'packageInfoValidation' -DownloadTypes @('initialPackage')
+Assert-True (Test-PartnerSubmissionNeedsUpload -Submission $fresh) 'fresh submission needs upload'
+Assert-True (Test-PartnerSubmissionNeedsCommit -Submission $fresh) 'fresh submission needs commit'
 
-$processing = [pscustomobject]@{
-    commitStatus   = 'commitComplete'
-    workflowStatus = [pscustomobject]@{ state = 'notStarted'; currentStep = 'Processing' }
-}
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $processing) 'Submitted' 'portal Processing is submitted'
-Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $processing)) 'processing skips commit'
+$committed = New-TestSubmission -CommitStatus 'commitComplete' -State 'notStarted' -Step 'packageInfoValidation' -DownloadTypes @('initialPackage')
+Assert-True (-not (Test-PartnerSubmissionNeedsUpload -Submission $committed)) 'committed submission skips upload'
+Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $committed)) 'committed submission skips commit'
 
+$processing = New-TestSubmission -CommitStatus 'commitComplete' -State 'started' -Step 'scanning' -DownloadTypes @('initialPackage')
+Assert-True (-not (Test-PartnerSubmissionNeedsUpload -Submission $processing)) 'processing submission skips upload'
+Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $processing)) 'processing submission skips commit'
+
+# `sdcm submission list --submission-id` wraps the entity in an array and quotes
+# every id, which is what the workflow actually has to parse.
 $sdcmListJson = @'
 [
   {
     "id": "1152921505701853745",
+    "productId": "13872423721100346",
+    "name": "DsHidMini 3.6.1 3.6.1.2202 submission",
+    "type": "initial",
     "commitStatus": "commitComplete",
     "workflowStatus": {
-      "currentStep": "Processing",
-      "state": "notStarted"
+      "currentStep": "scanning",
+      "state": "started",
+      "messages": []
+    },
+    "downloads": {
+      "items": [
+        { "type": "initialPackage", "url": "https://example.invalid/initial" }
+      ],
+      "messages": []
     }
   }
 ]
 '@
 $fromSdcm = ConvertFrom-SdcmJson -Json $sdcmListJson
 Assert-Equal $fromSdcm.id '1152921505701853745' 'list array unwraps quoted id'
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $fromSdcm) 'Submitted' 'sdcm list JSON is submitted'
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $fromSdcm) 'Submitted' 'sdcm list JSON is Submitted'
 Assert-True ((Get-PartnerSubmissionProgressSummary -Submission $fromSdcm) -like '*Submitted*') 'progress summary includes Submitted'
+Assert-True ((Get-PartnerSubmissionProgressSummary -Submission $fromSdcm) -like '*currentStep=scanning*') 'progress summary includes the current step'
 
-$completed = [pscustomobject]@{
-    workflowStatus = [pscustomobject]@{ state = 'completed' }
-    downloads      = [pscustomobject]@{
-        items = @(
-            [pscustomobject]@{ type = 'signedPackage' }
-        )
+$sdcmCompletedJson = @'
+[
+  {
+    "id": "1152921505701853745",
+    "productId": "13872423721100346",
+    "commitStatus": "commitComplete",
+    "workflowStatus": {
+      "currentStep": "finalizeIngestion",
+      "state": "completed",
+      "messages": []
+    },
+    "downloads": {
+      "items": [
+        { "type": "initialPackage", "url": "https://example.invalid/initial" },
+        { "type": "signedPackage", "url": "https://example.invalid/signed" },
+        { "type": "certificationReport", "url": "https://example.invalid/report" }
+      ],
+      "messages": []
     }
-}
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $completed) 'Completed' 'completed progress'
-
-$failed = [pscustomobject]@{ workflowStatus = [pscustomobject]@{ state = 'failed' } }
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $failed) 'Failed' 'failed progress'
+  }
+]
+'@
+$completedFromSdcm = ConvertFrom-SdcmJson -Json $sdcmCompletedJson
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $completedFromSdcm) 'Completed' 'sdcm completed JSON is Completed'
+Assert-True (Test-PartnerSubmissionHasSignedPackage -Submission $completedFromSdcm) 'signed package detected'
+Assert-True (-not (Test-PartnerSubmissionHasSignedPackage -Submission $fromSdcm)) 'no signed package while processing'
 
 $temp = Join-Path ([IO.Path]::GetTempPath()) ("dshm-partner-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $temp | Out-Null

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -54,6 +54,12 @@ Assert-Equal (Get-PartnerSubmissionProgress -Submission $created) 'Created' 'cre
 Assert-True (Test-PartnerSubmissionNeedsUpload -Submission $created) 'created needs upload'
 Assert-True (Test-PartnerSubmissionNeedsCommit -Submission $created) 'created needs commit'
 
+$idle = [pscustomobject]@{
+    commitStatus   = 'commitPending'
+    workflowStatus = [pscustomobject]@{ state = 'notStarted'; currentStep = '' }
+}
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $idle) 'Created' 'notStarted stays created'
+
 $submitted = [pscustomobject]@{
     commitStatus    = 'commitSucceeded'
     workflowStatus  = [pscustomobject]@{ state = 'inProgress'; currentStep = 'finalizeIngestion' }
@@ -61,6 +67,30 @@ $submitted = [pscustomobject]@{
 Assert-Equal (Get-PartnerSubmissionProgress -Submission $submitted) 'Submitted' 'submitted progress'
 Assert-True (-not (Test-PartnerSubmissionNeedsUpload -Submission $submitted)) 'submitted skips upload'
 Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $submitted)) 'submitted skips commit'
+
+$processing = [pscustomobject]@{
+    commitStatus   = 'commitComplete'
+    workflowStatus = [pscustomobject]@{ state = 'notStarted'; currentStep = 'Processing' }
+}
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $processing) 'Submitted' 'portal Processing is submitted'
+Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $processing)) 'processing skips commit'
+
+$sdcmListJson = @'
+[
+  {
+    "id": "1152921505701853745",
+    "commitStatus": "commitComplete",
+    "workflowStatus": {
+      "currentStep": "Processing",
+      "state": "notStarted"
+    }
+  }
+]
+'@
+$fromSdcm = ConvertFrom-SdcmJson -Json $sdcmListJson
+Assert-Equal $fromSdcm.id '1152921505701853745' 'list array unwraps quoted id'
+Assert-Equal (Get-PartnerSubmissionProgress -Submission $fromSdcm) 'Submitted' 'sdcm list JSON is submitted'
+Assert-True ((Get-PartnerSubmissionProgressSummary -Submission $fromSdcm) -like '*Submitted*') 'progress summary includes Submitted'
 
 $completed = [pscustomobject]@{
     workflowStatus = [pscustomobject]@{ state = 'completed' }

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -92,6 +92,7 @@ Assert-Equal (Get-SdcmEntityId -Json '{"id": "1152921505701840714", "name": "x"}
 Assert-Equal (Get-SdcmEntityId -Json '{"sharedProductId": "1152921504607010608", "id": "14631253285588838"}') '14631253285588838' 'sharedProductId is not mistaken for id'
 Assert-Equal (Get-SdcmEntityId -Json '{"productId": "13872423721100346", "id": "1152921505701853745"}') '1152921505701853745' 'productId is not mistaken for id'
 Assert-Equal (Get-SdcmEntityId -Json @('[', '  { "id": "42" }', ']')) '42' 'single-element array output unwraps'
+Assert-Equal (Get-SdcmEntityId -Json ([pscustomobject]@{ id = '1152921505701840714'; name = 'x' })) '1152921505701840714' 'PSCustomObject entity id'
 Assert-Throws { Get-SdcmEntityId -Json '{"name": "x"}' } 'missing id throws'
 Assert-Throws { Get-SdcmEntityId -Json '' } 'empty sdcm output throws'
 
@@ -162,6 +163,7 @@ $sdcmListJson = @'
 ]
 '@
 $fromSdcm = ConvertFrom-SdcmJson -Json $sdcmListJson
+Assert-True ($fromSdcm.id -is [string]) 'list array id is a string'
 Assert-Equal $fromSdcm.id '1152921505701853745' 'list array unwraps quoted id'
 Assert-Equal (Get-PartnerSubmissionProgress -Submission $fromSdcm) 'Submitted' 'sdcm list JSON is Submitted'
 Assert-True ((Get-PartnerSubmissionProgressSummary -Submission $fromSdcm) -like '*Submitted*') 'progress summary includes Submitted'

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -363,7 +363,21 @@ function ConvertTo-SdcmJsonText {
         return $Json
     }
 
-    return (@($Json) | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    # String arrays are already JSON text (sdcm / command output). Join them.
+    # PSCustomObject and hashtable values must be serialized, not display-stringed.
+    $items = @($Json)
+    $allStrings = $true
+    foreach ($item in $items) {
+        if ($item -isnot [string]) {
+            $allStrings = $false
+            break
+        }
+    }
+    if ($allStrings) {
+        return $items -join [Environment]::NewLine
+    }
+
+    return ConvertTo-Json -InputObject $Json -Depth 8
 }
 
 function ConvertFrom-SdcmJson {

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -4,6 +4,18 @@ Set-StrictMode -Version Latest
 $script:PartnerSignedNamePattern = '^Signed_(\d+)\.zip$'
 $script:PartnerInitialNamePattern = '^Initial_(\d+)\.cab$'
 
+# Hardware Dev Center submission vocabulary. commitStatus is documented as
+# commitPending / commitComplete / commitFailed, but the API reference shows
+# 'CommitPending' while the service returns 'commitPending', so every comparison
+# below is case-insensitive. workflowStatus.state is one of notStarted, started,
+# failed, completed and describes *the current step only*; currentStep walks
+# packageInfoValidation, preparation, scanning, validation, catalogCreation,
+# manualReview, signing, finalizeIngestion.
+$script:PartnerCommitPending = 'commitPending'
+$script:PartnerCommitFailed = 'commitFailed'
+$script:PartnerWorkflowFinalStep = 'finalizeIngestion'
+$script:PartnerSignedPackageType = 'signedPackage'
+
 function Invoke-Sdcm {
     [CmdletBinding()]
     param(
@@ -107,31 +119,22 @@ function Get-PartnerSubmissionProperty {
     return $null
 }
 
-function Get-PartnerSubmissionWorkflowState {
+function Test-PartnerValueEquals {
     [CmdletBinding()]
-    param($Submission)
+    param(
+        [string] $Value,
+        [Parameter(Mandatory = $true)]
+        [string] $Expected
+    )
 
-    if ($null -eq $Submission) {
-        return $null
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
     }
 
-    if (-not $Submission.PSObject.Properties['workflowStatus']) {
-        return $null
-    }
-
-    $workflow = $Submission.workflowStatus
-    if ($null -eq $workflow) {
-        return $null
-    }
-
-    if ($workflow -is [string]) {
-        return $workflow
-    }
-
-    return Get-PartnerSubmissionProperty -Object $workflow -Names @('state', 'currentState', 'status', 'currentStep')
+    return [string]::Equals($Value.Trim(), $Expected, [StringComparison]::OrdinalIgnoreCase)
 }
 
-function Get-PartnerSubmissionWorkflowStep {
+function Get-PartnerSubmissionWorkflow {
     [CmdletBinding()]
     param($Submission)
 
@@ -139,7 +142,29 @@ function Get-PartnerSubmissionWorkflowStep {
         return $null
     }
 
-    $workflow = $Submission.workflowStatus
+    return $Submission.workflowStatus
+}
+
+function Get-PartnerSubmissionWorkflowState {
+    [CmdletBinding()]
+    param($Submission)
+
+    $workflow = Get-PartnerSubmissionWorkflow -Submission $Submission
+    if ($null -eq $workflow) {
+        return $null
+    }
+    if ($workflow -is [string]) {
+        return $workflow
+    }
+
+    return Get-PartnerSubmissionProperty -Object $workflow -Names @('state', 'currentState', 'status')
+}
+
+function Get-PartnerSubmissionWorkflowStep {
+    [CmdletBinding()]
+    param($Submission)
+
+    $workflow = Get-PartnerSubmissionWorkflow -Submission $Submission
     if ($null -eq $workflow -or $workflow -is [string]) {
         return $null
     }
@@ -154,64 +179,66 @@ function Get-PartnerSubmissionCommitStatus {
     return Get-PartnerSubmissionProperty -Object $Submission -Names @('commitStatus')
 }
 
+function Test-PartnerSubmissionHasSignedPackage {
+    [CmdletBinding()]
+    param($Submission)
+
+    if ($null -eq $Submission -or -not $Submission.PSObject.Properties['downloads']) {
+        return $false
+    }
+
+    $downloads = $Submission.downloads
+    if ($null -eq $downloads -or -not $downloads.PSObject.Properties['items'] -or -not $downloads.items) {
+        return $false
+    }
+
+    foreach ($item in @($downloads.items)) {
+        if ($null -eq $item -or -not $item.PSObject.Properties['type']) {
+            continue
+        }
+        if (Test-PartnerValueEquals -Value ([string]$item.type) -Expected $script:PartnerSignedPackageType) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function Get-PartnerSubmissionProgress {
     [CmdletBinding()]
     param($Submission)
 
-    $workflow = Get-PartnerSubmissionWorkflowState -Submission $Submission
-    $step = Get-PartnerSubmissionWorkflowStep -Submission $Submission
     $commit = Get-PartnerSubmissionCommitStatus -Submission $Submission
+    $state = Get-PartnerSubmissionWorkflowState -Submission $Submission
+    $step = Get-PartnerSubmissionWorkflowStep -Submission $Submission
 
-    $downloadTypes = @()
-    if ($Submission -and $Submission.PSObject.Properties['downloads'] -and $Submission.downloads -and
-        $Submission.downloads.PSObject.Properties['items'] -and $Submission.downloads.items) {
-        $downloadTypes = @(
-            $Submission.downloads.items |
-                ForEach-Object { $_.type } |
-                Where-Object { $_ }
-        )
+    if ((Test-PartnerValueEquals -Value $commit -Expected $script:PartnerCommitFailed) -or
+        (Test-PartnerValueEquals -Value $state -Expected 'failed')) {
+        return 'Failed'
     }
 
-    $signals = @($commit, $workflow, $step) | Where-Object { $_ }
-
-    $failed = @(
-        'failed', 'failure', 'cancelled', 'canceled', 'commitFailed'
-    )
-    foreach ($signal in $signals) {
-        if ($failed -contains $signal) {
-            return 'Failed'
-        }
-    }
-
-    $completed = @('completed', 'complete', 'succeeded', 'success', 'published')
-    if ($workflow -and ($completed -contains $workflow)) {
+    # A downloadable signedPackage is the only unambiguous completion signal.
+    # state applies to currentStep, so 'completed' on an intermediate step such
+    # as scanning must not be read as the whole submission being done.
+    if (Test-PartnerSubmissionHasSignedPackage -Submission $Submission) {
         return 'Completed'
     }
-    if ($step -and ($completed -contains $step)) {
-        return 'Completed'
-    }
-    if ($downloadTypes -contains 'signedPackage') {
+    if ((Test-PartnerValueEquals -Value $state -Expected 'completed') -and
+        (Test-PartnerValueEquals -Value $step -Expected $script:PartnerWorkflowFinalStep)) {
         return 'Completed'
     }
 
-    $pendingCommit = @('commitPending', 'pending')
-    $idleWorkflow = @('notStarted', 'notstarted', 'none', 'unknown')
-    $submitted = @(
-        'inProgress', 'inprogress', 'processing', 'started', 'running',
-        'commitSucceeded', 'commitInProgress', 'commitComplete', 'commitStarted',
-        'finalizeIngestion', 'preprocess', 'preProcess'
-    )
-
-    foreach ($signal in $signals) {
-        if ($submitted -contains $signal) {
-            return 'Submitted'
-        }
+    # Anything other than commitPending means the submission already belongs to
+    # Hardware Dev Center and must not be uploaded or committed again. Treating
+    # unrecognised values as committed keeps an undocumented in-flight status
+    # from triggering a second upload.
+    if ($commit -and -not (Test-PartnerValueEquals -Value $commit -Expected $script:PartnerCommitPending)) {
+        return 'Submitted'
     }
-
-    $commitIsActive = $commit -and -not ($pendingCommit -contains $commit)
-    $workflowIsActive = $workflow -and -not ($idleWorkflow -contains $workflow)
-    $stepIsActive = $step -and -not ($idleWorkflow -contains $step)
-    if ($commitIsActive -or $workflowIsActive -or $stepIsActive) {
+    # Fallback for a submission that reports no commitStatus at all: the
+    # workflow only leaves notStarted once Hardware Dev Center owns the package.
+    if ((Test-PartnerValueEquals -Value $state -Expected 'started') -or
+        (Test-PartnerValueEquals -Value $state -Expected 'completed')) {
         return 'Submitted'
     }
 
@@ -224,12 +251,14 @@ function Get-PartnerSubmissionProgressSummary {
 
     $progress = Get-PartnerSubmissionProgress -Submission $Submission
     $commit = Get-PartnerSubmissionCommitStatus -Submission $Submission
-    $workflow = Get-PartnerSubmissionWorkflowState -Submission $Submission
+    $state = Get-PartnerSubmissionWorkflowState -Submission $Submission
     $step = Get-PartnerSubmissionWorkflowStep -Submission $Submission
+    $signed = Test-PartnerSubmissionHasSignedPackage -Submission $Submission
     if (-not $commit) { $commit = '-' }
-    if (-not $workflow) { $workflow = '-' }
+    if (-not $state) { $state = '-' }
     if (-not $step) { $step = '-' }
-    return "Submission progress: $progress (commitStatus=$commit; state=$workflow; currentStep=$step)"
+
+    return "Submission progress: $progress (commitStatus=$commit; state=$state; currentStep=$step; signedPackage=$signed)"
 }
 
 function Test-PartnerSubmissionNeedsUpload {
@@ -301,19 +330,26 @@ function Get-SdcmEntityId {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string] $Json
+        $Json
     )
 
-    # sdcm --output json re-serializes Hardware Dev Center ids with
-    # LongToStringJsonConverter, so the value is a quoted string. The raw API
-    # uses an unquoted number. Accept both so the id stays a string.
-    $match = [regex]::Match($Json, '"id"\s*:\s*"?(\d+)"?')
-    if (-not $match.Success) {
-        $preview = if ($Json.Length -gt 500) { $Json.Substring(0, 500) + '...' } else { $Json }
-        throw "sdcm JSON is missing an id field.`n$preview"
+    # sdcm --output json re-serializes Hardware Dev Center ids as quoted strings
+    # via LongToStringJsonConverter, while the raw API uses unquoted numbers.
+    # Parse the document instead of pattern matching so a nested id can never be
+    # mistaken for the entity's own id.
+    $entity = ConvertFrom-SdcmJson -Json $Json
+    if ($entity -is [System.Collections.IList] -and $entity -isnot [string]) {
+        $entity = @($entity) | Select-Object -First 1
     }
 
-    return $match.Groups[1].Value
+    $id = Get-PartnerSubmissionProperty -Object $entity -Names @('id')
+    if (-not $id -or $id -notmatch '^\d+$') {
+        $preview = ConvertTo-SdcmJsonText -Json $Json
+        if ($preview.Length -gt 500) { $preview = $preview.Substring(0, 500) + '...' }
+        throw "sdcm JSON is missing a numeric id field.`n$preview"
+    }
+
+    return $id
 }
 
 function ConvertTo-SdcmJsonText {

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -239,9 +239,13 @@ function Get-SdcmEntityId {
         [string] $Json
     )
 
-    $match = [regex]::Match($Json, '"id"\s*:\s*(\d+)')
+    # sdcm --output json re-serializes Hardware Dev Center ids with
+    # LongToStringJsonConverter, so the value is a quoted string. The raw API
+    # uses an unquoted number. Accept both so the id stays a string.
+    $match = [regex]::Match($Json, '"id"\s*:\s*"?(\d+)"?')
     if (-not $match.Success) {
-        throw 'sdcm JSON is missing an id field.'
+        $preview = if ($Json.Length -gt 500) { $Json.Substring(0, 500) + '...' } else { $Json }
+        throw "sdcm JSON is missing an id field.`n$preview"
     }
 
     return $match.Groups[1].Value

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -86,6 +86,27 @@ function Get-PartnerPortalUrl {
     "https://partner.microsoft.com/dashboard/hardware/driver/$ProductId"
 }
 
+function Get-PartnerSubmissionProperty {
+    [CmdletBinding()]
+    param(
+        $Object,
+        [string[]] $Names
+    )
+
+    if ($null -eq $Object) {
+        return $null
+    }
+
+    foreach ($name in $Names) {
+        $property = $Object.PSObject.Properties[$name]
+        if ($property -and $null -ne $property.Value -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+            return [string]$property.Value
+        }
+    }
+
+    return $null
+}
+
 function Get-PartnerSubmissionWorkflowState {
     [CmdletBinding()]
     param($Submission)
@@ -107,13 +128,30 @@ function Get-PartnerSubmissionWorkflowState {
         return $workflow
     }
 
-    foreach ($name in @('state', 'currentState', 'status')) {
-        if ($workflow.PSObject.Properties[$name] -and $workflow.$name) {
-            return [string]$workflow.$name
-        }
+    return Get-PartnerSubmissionProperty -Object $workflow -Names @('state', 'currentState', 'status', 'currentStep')
+}
+
+function Get-PartnerSubmissionWorkflowStep {
+    [CmdletBinding()]
+    param($Submission)
+
+    if ($null -eq $Submission -or -not $Submission.PSObject.Properties['workflowStatus']) {
+        return $null
     }
 
-    return $null
+    $workflow = $Submission.workflowStatus
+    if ($null -eq $workflow -or $workflow -is [string]) {
+        return $null
+    }
+
+    return Get-PartnerSubmissionProperty -Object $workflow -Names @('currentStep')
+}
+
+function Get-PartnerSubmissionCommitStatus {
+    [CmdletBinding()]
+    param($Submission)
+
+    return Get-PartnerSubmissionProperty -Object $Submission -Names @('commitStatus')
 }
 
 function Get-PartnerSubmissionProgress {
@@ -121,10 +159,8 @@ function Get-PartnerSubmissionProgress {
     param($Submission)
 
     $workflow = Get-PartnerSubmissionWorkflowState -Submission $Submission
-    $commit = $null
-    if ($Submission -and $Submission.PSObject.Properties['commitStatus'] -and $Submission.commitStatus) {
-        $commit = [string]$Submission.commitStatus
-    }
+    $step = Get-PartnerSubmissionWorkflowStep -Submission $Submission
+    $commit = Get-PartnerSubmissionCommitStatus -Submission $Submission
 
     $downloadTypes = @()
     if ($Submission -and $Submission.PSObject.Properties['downloads'] -and $Submission.downloads -and
@@ -136,35 +172,64 @@ function Get-PartnerSubmissionProgress {
         )
     }
 
+    $signals = @($commit, $workflow, $step) | Where-Object { $_ }
+
     $failed = @(
         'failed', 'failure', 'cancelled', 'canceled', 'commitFailed'
     )
-    if ($workflow -and ($failed -contains $workflow)) {
-        return 'Failed'
-    }
-    if ($commit -and ($failed -contains $commit)) {
-        return 'Failed'
+    foreach ($signal in $signals) {
+        if ($failed -contains $signal) {
+            return 'Failed'
+        }
     }
 
-    $completed = @('completed', 'complete', 'succeeded', 'success')
+    $completed = @('completed', 'complete', 'succeeded', 'success', 'published')
     if ($workflow -and ($completed -contains $workflow)) {
+        return 'Completed'
+    }
+    if ($step -and ($completed -contains $step)) {
         return 'Completed'
     }
     if ($downloadTypes -contains 'signedPackage') {
         return 'Completed'
     }
 
+    $pendingCommit = @('commitPending', 'pending')
+    $idleWorkflow = @('notStarted', 'notstarted', 'none', 'unknown')
     $submitted = @(
-        'inProgress', 'inprogress', 'commitSucceeded', 'commitInProgress', 'finalizeIngestion'
+        'inProgress', 'inprogress', 'processing', 'started', 'running',
+        'commitSucceeded', 'commitInProgress', 'commitComplete', 'commitStarted',
+        'finalizeIngestion', 'preprocess', 'preProcess'
     )
-    if ($commit -and ($submitted -contains $commit)) {
-        return 'Submitted'
+
+    foreach ($signal in $signals) {
+        if ($submitted -contains $signal) {
+            return 'Submitted'
+        }
     }
-    if ($workflow -and ($submitted -contains $workflow)) {
+
+    $commitIsActive = $commit -and -not ($pendingCommit -contains $commit)
+    $workflowIsActive = $workflow -and -not ($idleWorkflow -contains $workflow)
+    $stepIsActive = $step -and -not ($idleWorkflow -contains $step)
+    if ($commitIsActive -or $workflowIsActive -or $stepIsActive) {
         return 'Submitted'
     }
 
     return 'Created'
+}
+
+function Get-PartnerSubmissionProgressSummary {
+    [CmdletBinding()]
+    param($Submission)
+
+    $progress = Get-PartnerSubmissionProgress -Submission $Submission
+    $commit = Get-PartnerSubmissionCommitStatus -Submission $Submission
+    $workflow = Get-PartnerSubmissionWorkflowState -Submission $Submission
+    $step = Get-PartnerSubmissionWorkflowStep -Submission $Submission
+    if (-not $commit) { $commit = '-' }
+    if (-not $workflow) { $workflow = '-' }
+    if (-not $step) { $step = '-' }
+    return "Submission progress: $progress (commitStatus=$commit; state=$workflow; currentStep=$step)"
 }
 
 function Test-PartnerSubmissionNeedsUpload {
@@ -251,23 +316,39 @@ function Get-SdcmEntityId {
     return $match.Groups[1].Value
 }
 
+function ConvertTo-SdcmJsonText {
+    [CmdletBinding()]
+    param($Json)
+
+    if ($null -eq $Json) {
+        return ''
+    }
+    if ($Json -is [string]) {
+        return $Json
+    }
+
+    return (@($Json) | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+}
+
 function ConvertFrom-SdcmJson {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string] $Json
+        $Json
     )
 
-    if ([string]::IsNullOrWhiteSpace($Json)) {
+    $text = ConvertTo-SdcmJsonText -Json $Json
+    if ([string]::IsNullOrWhiteSpace($text)) {
         throw 'sdcm returned empty JSON.'
     }
 
-    $parsed = $Json | ConvertFrom-Json
-    if ($parsed -is [System.Array]) {
-        if ($parsed.Count -eq 1) {
-            return $parsed[0]
+    $parsed = $text | ConvertFrom-Json
+    if ($parsed -is [System.Collections.IList] -and $parsed -isnot [string]) {
+        $items = @($parsed)
+        if ($items.Count -eq 1) {
+            return $items[0]
         }
-        return $parsed
+        return $items
     }
 
     return $parsed

--- a/build/ReleaseTargets.cs
+++ b/build/ReleaseTargets.cs
@@ -209,7 +209,8 @@ partial class Build
         });
 
     /// <summary>
-    /// Runs non-production release-pipeline unit checks (version parsing and staging fixtures).
+    /// Runs non-production release-pipeline checks: version parsing, staging fixtures, and the
+    /// offline Partner Center signing dry run against a mock sdcm.
     /// </summary>
     [UsedImplicitly]
     public Target TestReleasePipeline => _ => _
@@ -219,7 +220,11 @@ partial class Build
                            ?? ToolPathResolver.TryGetEnvironmentExecutable("pwsh")
                            ?? TryGetPathExecutable("pwsh")
                            ?? "powershell";
-            foreach (string testFile in new[] { "ReleaseVersion.Tests.ps1", "PartnerSigning.Tests.ps1" })
+            foreach (string testFile in new[]
+                     {
+                         "ReleaseVersion.Tests.ps1", "PartnerSigning.Tests.ps1",
+                         "PartnerSigning.DryRun.ps1"
+                     })
             {
                 AbsolutePath tests = RootDirectory / "build" / testFile;
                 ProcessTasks.StartProcess(shell, $"-NoProfile -File \"{tests}\"")

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -130,17 +130,20 @@ Restart point: rerun the same command; it replaces `artifacts/ci` and restages C
 
 ### 3. Partner Center signing (CI)
 
-The `partner-signing` jobs create a new versioned Attestation product named `DsHidMini <setupVersion> <driverVersion>` and request exactly:
+The `partner-signing` jobs create a new versioned Attestation product named `DsHidMini <setupVersion> <driverVersion>`, or resume one named by the `product-id` / `submission-id` inputs, and request exactly:
 
 - `WINDOWS_v100_X64_RS5_FULL` (Windows 10 Client version 1809 Client x64 (RS5))
 - `WINDOWS_v100_ARM64_RS5_FULL` (Windows 10 Client version 1809 Client ARM64 (RS5))
 
 They upload the EV-signed combined CAB, wait up to 60 minutes, download `Signed_<id>.zip` plus `Initial_<id>.cab`, mirror that pair to buildbot, then ingest and signature-check the signed zip.
 
-Retry without rebuilding:
+Retry without rebuilding. Every fresh run opens another Partner Center product, so prefer the resume path:
 
-- **Re-run failed jobs** on the same workflow run resumes after the last successful job (`create` / `upload` / `wait` / `ingest`). Upload/commit is status-aware and will not blindly re-upload a submission that already advanced.
-- **workflow_dispatch** of `Partner Center signing` with the original Build run ID creates a fresh product/submission from the already-built CAB. Use this after Hardware Dev Center rejects or fails a submission.
+- **Re-run failed jobs** on the same workflow run resumes after the last successful job (`create` / `upload` / `wait` / `ingest`). Upload/commit is status-aware and will not blindly re-upload a submission that already advanced. A re-run replays the commit the run started from, so a fix to `build/PartnerSigning.ps1` or to the workflow is **not** picked up; dispatch instead.
+- **workflow_dispatch** with the original Build run ID plus `product-id` and `submission-id` resumes that existing submission using the current branch's scripts. This is how a script fix reaches a submission Hardware Dev Center is already processing, without opening another product.
+- **workflow_dispatch** with the original Build run ID and no `product-id` / `submission-id` creates a fresh product and submission from the already-built CAB. Use this only once Hardware Dev Center has rejected or failed a submission.
+
+Before changing that automation, run `.\build.cmd TestReleasePipeline`. It runs the workflow's own `create` / `upload` / `wait` scripts against a mock `sdcm` and asserts which sdcm verbs each stage calls, so submission-state bugs surface locally instead of consuming a product.
 
 This project's verified behavior: Microsoft **adds** its signature to the already EV-signed DLLs and replaces the catalog. If a returned DLL has only a Microsoft signer, stop and investigate; do not continue to MSI.
 
@@ -208,6 +211,7 @@ gh release create setup-v3.6.0 `
 - Split the returned dual-arch INF/CAT into x64-only and ARM64-only packages.
 - EV-sign driver DLLs again after Microsoft returns them.
 - Use a four-part `v*` tag to start a release. `workflow_dispatch` on Partner Center signing is only for retrying attestation from an existing Build run.
+- Dispatch Partner Center signing to debug the automation. Each fresh run opens a Partner Center product; resume the existing submission or run `.\build.cmd TestReleasePipeline` instead.
 - Treat `artifacts/` as source-controlled input; it is gitignored staging.
 
 ## Troubleshooting
@@ -220,6 +224,8 @@ gh release create setup-v3.6.0 `
 | `create` job auth exit 2 | `SDCM_PROFILES__DEFAULT__*` secrets missing or invalid |
 | `wait` job exit 7 | Hardware Dev Center rejected the submission; dispatch a new signing run |
 | `wait` job exit 9 | `--wait-timeout` 3600 elapsed; re-run failed jobs to resume the wait |
+| `wait` job: submission is still commitPending | The commit never landed; re-run the `upload` job before the wait |
+| `create` job: product-id and submission-id must be supplied together | Resume needs both ids, or neither |
 | Missing `Signed_<id>.zip` / `Initial_<id>.cab` pair | Downloaded the wrapper or submission CAB instead of the portal pair |
 | Multiple `dshidmini` packages | Point `MicrosoftPackagePath` at the zip or the single package folder |
 | DLL missing Microsoft signer | Downloaded the submission CAB instead of the dashboard's signed package |
@@ -236,6 +242,7 @@ gh release create setup-v3.6.0 `
 | [`build/ReleasePipeline.cs`](../build/ReleasePipeline.cs) | Staging, ingest, validation |
 | [`build/ReleaseTargets.cs`](../build/ReleaseTargets.cs) | NUKE entry points |
 | [`build/PartnerSigning.ps1`](../build/PartnerSigning.ps1) | SDCM payloads, submission progress, Signed_/Initial_ pair checks |
+| [`build/PartnerSigning.DryRun.ps1`](../build/PartnerSigning.DryRun.ps1) | Offline dry run of the signing workflow against a mock sdcm |
 | [`.github/workflows/partner-signing.yml`](../.github/workflows/partner-signing.yml) | Retryable Partner Center submit / wait / ingest |
 | [`build/New-PartnerSubmissionInf.ps1`](../build/New-PartnerSubmissionInf.ps1) | Dual-arch INF for the submission CAB |
 | [`DsHidMini_combined.ddf`](../DsHidMini_combined.ddf) | Partner CAB layout (`dshidmini/` not at CAB root; includes PDBs) |


### PR DESCRIPTION
Audit of the Partner Center signing automation against the documented Hardware Dashboard API state machine, rather than one fix per failed CI run. Every experimental run consumes a real Partner Center product, so the goal was to find the remaining defects offline.

## Ground truth

`workflowStatus.state` is one of `notStarted`, `started`, `failed`, `completed`, and it describes **`currentStep` only**, not the submission. `currentStep` walks `packageInfoValidation`, `preparation`, `scanning`, `validation`, `catalogCreation`, `manualReview`, `signing`, `finalizeIngestion`. `commitStatus` is `commitPending` / `commitComplete` / `commitFailed`, with casing that differs between the API reference and the service. `sdcm --output json` re-serializes every id as a quoted string and wraps `submission list` in an array.

## Defects found

1. **`sdcm JSON is missing an id field.`** `Get-SdcmEntityId` matched `"id": <digits>` but sdcm emits `"id": "<digits>"`. Ids are now parsed out of the JSON document, so `productId` and `sharedProductId` can never be mistaken for the entity id either.
2. **A freshly created submission was classified `Submitted`.** Any non-idle `currentStep` counted as progress, so `commitPending` / `notStarted` / `packageInfoValidation` skipped **both** the upload and the commit. The wait job would then poll for its full hour against a submission Hardware Dev Center had never been asked to process, and the product would be wasted.
3. **A completed intermediate step was classified `Completed`.** `state: completed` on `scanning` skipped the wait and ran `submission download` before any `signedPackage` existed, which exits 5.
4. **No resume path.** The `create` job unconditionally opened a new product, so no retry could ever continue an in-flight submission.
5. `submission download` refuses to overwrite its destination, which the wait job did not account for.

## Changes

`Get-PartnerSubmissionProgress` now keys off `commitStatus`, treating anything other than `commitPending` as committed so an undocumented in-flight value cannot regress into a second upload. `Completed` requires a `signedPackage` download or `completed` on `finalizeIngestion`.

The workflow takes optional `product-id` and `submission-id` inputs. Supplied together, the `create` job resumes that submission instead of opening a product, verifies the id it got back, and refuses a submission that already failed.

## Verification

`build/PartnerSigning.DryRun.ps1` extracts the workflow's own `run:` bodies and executes them against a mock `sdcm` implementing the documented state machine, asserting which sdcm verbs each stage calls. It covers a fresh product, resuming a processing submission, resuming an uncommitted one, resuming a completed one, and the guard paths. It needs no credentials and no network, and runs as part of `build.cmd TestReleasePipeline`, which the x64 CI job already executes.

`build/PartnerSigning.Tests.ps1` grew a state table over the documented step/state combinations; the cases for defects 2 and 3 fail against the previous logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Partner Center signing runs can resume existing submissions using product and submission IDs.
  - Progress updates now show workflow and commit status, current steps, and completion details.
  - Completion detection recognizes signed-package downloads and requires the final workflow step.
  - SDCM input handling supports structured values and single-item arrays.

- **Bug Fixes**
  - Improved entity ID parsing, diagnostics, failure handling, retries, and workflow-state processing.

- **Tests**
  - Added offline coverage for fresh, resumed, completed, failed, and invalid signing scenarios.

- **Documentation**
  - Clarified resume, retry, troubleshooting, and local validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->