### PR TITLE
Consume sdcm 1.0.0-pre004 status, get, and overwrite

### DIFF
--- a/.github/actions/setup-sdcm/action.yml
+++ b/.github/actions/setup-sdcm/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        dotnet tool install -g Nefarius.Tools.SDCM --version 1.0.0-pre003
+        dotnet tool install -g Nefarius.Tools.SDCM --version 1.0.0-pre004
         $tools = Join-Path $env:USERPROFILE '.dotnet\tools'
         echo $tools >> $env:GITHUB_PATH
-        Write-Output "Installed Nefarius.Tools.SDCM 1.0.0-pre003"
+        Write-Output "Installed Nefarius.Tools.SDCM 1.0.0-pre004"

--- a/.github/workflows/partner-signing.yml
+++ b/.github/workflows/partner-signing.yml
@@ -113,16 +113,15 @@ jobs:
             $productId = $resumeProductId
             $submissionId = $resumeSubmissionId
 
-            $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
-            $submission = ConvertFrom-SdcmJson -Json $listed
-            if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
-            $resumedId = Get-SdcmEntityId -Json $listed
+            $got = Invoke-Sdcm submission get --product-id $productId --submission-id $submissionId
+            $resumedId = Get-SdcmEntityId -Json $got
             if ($resumedId -ne $submissionId) {
               throw "Partner Center returned submission $resumedId for requested submission $submissionId."
             }
+            $status = Get-SdcmSubmissionStatus -ProductId $productId -SubmissionId $submissionId
             Write-Output "Resuming Partner Center product $productId submission $submissionId"
-            Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
-            if ((Get-PartnerSubmissionProgress -Submission $submission) -eq 'Failed') {
+            Write-Output (Get-SdcmSubmissionProgressSummary -Status $status)
+            if ((Get-SdcmSubmissionProgress -Status $status) -eq 'failed') {
               throw "Submission $submissionId already failed. Dispatch without product-id/submission-id to create a new product."
             }
           }
@@ -228,17 +227,15 @@ jobs:
             Select-Object -First 1
           if (-not $cab) { throw 'EV-signed partner CAB was not downloaded from the source run.' }
 
-          $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
-          $submission = ConvertFrom-SdcmJson -Json $listed
-          if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
-          $progress = Get-PartnerSubmissionProgress -Submission $submission
-          Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
+          $status = Get-SdcmSubmissionStatus -ProductId $productId -SubmissionId $submissionId
+          $progress = Get-SdcmSubmissionProgress -Status $status
+          Write-Output (Get-SdcmSubmissionProgressSummary -Status $status)
 
-          if ($progress -eq 'Failed') {
+          if ($progress -eq 'failed') {
             throw "Partner Center already failed product $productId submission $submissionId. Dispatch this workflow against the same source run, without product-id/submission-id, to create a new product."
           }
 
-          if (Test-PartnerSubmissionNeedsUpload -Submission $submission) {
+          if (Test-SdcmSubmissionNeedsUpload -Status $status) {
             Write-Output "Uploading $($cab.FullName)"
             Invoke-Sdcm submission upload --product-id $productId --submission-id $submissionId --package $cab.FullName
           }
@@ -246,11 +243,9 @@ jobs:
             Write-Output 'Upload skipped; submission has already advanced past package upload.'
           }
 
-          $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
-          $submission = ConvertFrom-SdcmJson -Json $listed
-          if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
-          Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
-          if (Test-PartnerSubmissionNeedsCommit -Submission $submission) {
+          $status = Get-SdcmSubmissionStatus -ProductId $productId -SubmissionId $submissionId
+          Write-Output (Get-SdcmSubmissionProgressSummary -Status $status)
+          if (Test-SdcmSubmissionNeedsCommit -Status $status) {
             Write-Output 'Committing submission'
             Invoke-Sdcm submission commit --product-id $productId --submission-id $submissionId
           }
@@ -294,21 +289,19 @@ jobs:
           if (-not $productId) { $productId = [string]$checkpoint.productId }
           if (-not $submissionId) { $submissionId = [string]$checkpoint.submissionId }
 
-          $listed = Invoke-Sdcm submission list --product-id $productId --submission-id $submissionId
-          $submission = ConvertFrom-SdcmJson -Json $listed
-          if ($submission -is [System.Array]) { $submission = $submission | Select-Object -First 1 }
-          $progress = Get-PartnerSubmissionProgress -Submission $submission
-          Write-Output (Get-PartnerSubmissionProgressSummary -Submission $submission)
+          $status = Get-SdcmSubmissionStatus -ProductId $productId -SubmissionId $submissionId
+          $progress = Get-SdcmSubmissionProgress -Status $status
+          Write-Output (Get-SdcmSubmissionProgressSummary -Status $status)
 
-          if ($progress -eq 'Failed') {
+          if ($progress -eq 'failed') {
             throw "Partner Center failed product $productId submission $submissionId."
           }
-          if ($progress -eq 'Created') {
-            $preview = ConvertTo-SdcmJsonText -Json $listed
+          if ($progress -eq 'created') {
+            $preview = ConvertTo-SdcmJsonText -Json $status
             if ($preview.Length -gt 1500) { $preview = $preview.Substring(0, 1500) + '...' }
-            throw "Submission $submissionId is still commitPending, so Hardware Dev Center has nothing to process. Re-run the upload job before waiting.`n$preview"
+            throw "Submission $submissionId is still created (commitPending), so Hardware Dev Center has nothing to process. Re-run the upload job before waiting.`n$preview"
           }
-          if ($progress -ne 'Completed') {
+          if ($progress -ne 'completed') {
             Invoke-Sdcm submission wait --product-id $productId --submission-id $submissionId --wait-timeout 3600
           }
           else {
@@ -316,9 +309,7 @@ jobs:
           }
 
           $downloadZip = Join-Path $pwd 'hdc-download.zip'
-          # sdcm refuses to overwrite an existing destination file.
-          if (Test-Path -LiteralPath $downloadZip) { Remove-Item -LiteralPath $downloadZip -Force }
-          Invoke-Sdcm submission download --product-id $productId --submission-id $submissionId --output-file $downloadZip
+          Invoke-Sdcm submission download --product-id $productId --submission-id $submissionId --output-file $downloadZip --overwrite
           $extractDir = Join-Path $pwd 'hdc-extracted'
           New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
           Expand-Archive -LiteralPath $downloadZip -DestinationPath $extractDir -Force

--- a/.github/workflows/partner-signing.yml
+++ b/.github/workflows/partner-signing.yml
@@ -303,9 +303,19 @@ jobs:
           }
           if ($progress -ne 'completed') {
             Invoke-Sdcm submission wait --product-id $productId --submission-id $submissionId --wait-timeout 3600
+            $status = Get-SdcmSubmissionStatus -ProductId $productId -SubmissionId $submissionId
+            $progress = Get-SdcmSubmissionProgress -Status $status
+            Write-Output (Get-SdcmSubmissionProgressSummary -Status $status)
+            if ($progress -eq 'failed') {
+              throw "Partner Center failed product $productId submission $submissionId."
+            }
           }
           else {
             Write-Output 'Submission already completed; downloading without waiting.'
+          }
+
+          if ($progress -ne 'completed' -or -not (Test-SdcmSubmissionHasSignedPackage -Status $status)) {
+            throw "Submission $submissionId is not ready to download (progress=$progress). Hardware Dev Center has not published a signed package yet."
           }
 
           $downloadZip = Join-Path $pwd 'hdc-download.zip'

--- a/build/PartnerSigning.DryRun.ps1
+++ b/build/PartnerSigning.DryRun.ps1
@@ -341,7 +341,7 @@ function Measure-Call([string[]] $Calls, [string] $Call) {
 }
 
 function Invoke-Pipeline {
-    param([string] $Name, [hashtable] $SeedState, [hashtable] $Overrides = @{})
+    param([string] $Name, [hashtable] $SeedState, [hashtable] $Overrides = @{}, [int] $ExpectedWaitExitCode = 0)
 
     Write-Host ''
     Write-Host "=== $Name ==="
@@ -373,8 +373,8 @@ function Invoke-Pipeline {
     if ($upload.ExitCode -ne 0) { Write-Host $upload.Output }
 
     $wait = Invoke-Block -Body $waitBlock -WorkDir $sandbox -Variables $variables -Substitutions $substitutions
-    Assert-Equal $wait.ExitCode 0 "${Name}: wait step succeeds"
-    if ($wait.ExitCode -ne 0) { Write-Host $wait.Output }
+    Assert-Equal $wait.ExitCode $ExpectedWaitExitCode "${Name}: wait step exit $ExpectedWaitExitCode"
+    if ($wait.ExitCode -ne $ExpectedWaitExitCode) { Write-Host $wait.Output }
 
     $calls = Get-SdcmCalls $sandbox
     Write-Host "sdcm calls: $($calls -join ' | ')"
@@ -472,6 +472,18 @@ try {
     Assert-Equal (Measure-Call $completed.Calls 'submission wait') 0 'completed: wait skipped'
     Assert-Equal (Measure-Call $completed.Calls 'submission download') 1 'completed: downloaded once'
     Assert-True ($completed.WaitOutput -like '*already completed*') 'completed: skip is reported'
+
+    # progress=completed is not enough; download only when a signed package exists.
+    $completedNoSigned = Invoke-Pipeline -Name 'completed without signed package' -ExpectedWaitExitCode 1 -Overrides @{
+        RESUME_PRODUCT_ID = '13872423721100350'; RESUME_SUBMISSION_ID = '1152921505701853749'
+    } -SeedState @{
+        productId = '13872423721100350'; submissionId = '1152921505701853749'; commitStatus = 'commitComplete'
+        state = 'completed'; step = 'finalizeIngestion'
+        downloads = @('initialPackage'); uploaded = $true
+    }
+    Assert-Equal (Measure-Call $completedNoSigned.Calls 'submission wait') 0 'completed-no-signed: wait skipped'
+    Assert-Equal (Measure-Call $completedNoSigned.Calls 'submission download') 0 'completed-no-signed: download not attempted'
+    Assert-True ($completedNoSigned.WaitOutput -like '*not ready to download*') 'completed-no-signed: refusal names the missing package'
 
     # A failed submission must be refused up front instead of burning the rest
     # of the pipeline.

--- a/build/PartnerSigning.DryRun.ps1
+++ b/build/PartnerSigning.DryRun.ps1
@@ -119,8 +119,9 @@ function Invoke-Block {
 
 # ---------------------------------------------------------------------------
 # Mock sdcm: a state machine over the documented Submission resource. Ids come
-# back quoted, `submission list` wraps the entity in an array, and the verbs
-# reject out-of-order calls the way the real tool does.
+# back quoted. `submission get` returns one object; `submission status` returns
+# the normalized progress document. Verbs reject out-of-order calls the way
+# the real tool does.
 # ---------------------------------------------------------------------------
 $mockScript = @'
 #Requires -Version 7.0
@@ -140,11 +141,13 @@ function Read-Option([string] $Name) {
     return $cliArgs[$idx + 1]
 }
 
-# Every option sdcm is invoked with here takes a value, so skipping the token
-# after each --option leaves just the noun/verb pair.
+$flags = @('--overwrite', '--wait-metadata', '--verbose', '-v')
 $verbs = New-Object System.Collections.Generic.List[string]
 for ($i = 0; $i -lt $cliArgs.Count; $i++) {
-    if ($cliArgs[$i] -like '--*') { $i++; continue }
+    if ($cliArgs[$i] -like '--*' -or $cliArgs[$i] -eq '-v') {
+        if ($flags -notcontains $cliArgs[$i]) { $i++ }
+        continue
+    }
     $verbs.Add($cliArgs[$i])
 }
 $noun = $verbs[0]
@@ -167,6 +170,21 @@ function Write-SubmissionJson([switch] $AsArray) {
         downloads      = [ordered]@{ items = $downloads; messages = @() }
     }
     if ($AsArray) { ConvertTo-Json @($submission) -Depth 8 } else { ConvertTo-Json $submission -Depth 8 }
+}
+
+function Write-StatusJson {
+    $failed = ($state.state -eq 'failed') -or ($state.commitStatus -eq 'commitFailed')
+    $signed = $state.downloads -contains 'signedPackage'
+    $ready = $signed -or ($state.state -eq 'completed' -and $state.step -eq 'finalizeIngestion')
+    $progress = if ($failed) { 'failed' } elseif ($ready) { 'completed' } elseif ($state.commitStatus -eq 'CommitPending') { 'created' } else { 'processing' }
+    ConvertTo-Json ([ordered]@{
+        progress         = $progress
+        commitStatus     = $state.commitStatus
+        state            = $state.state
+        currentStep      = $state.step
+        hasSignedPackage = [bool]$signed
+    }) -Depth 8
+    if ($failed) { exit 7 }
 }
 
 switch ("$noun $verb") {
@@ -192,6 +210,14 @@ switch ("$noun $verb") {
     }
     'submission list' {
         Write-SubmissionJson -AsArray
+        exit 0
+    }
+    'submission get' {
+        Write-SubmissionJson
+        exit 0
+    }
+    'submission status' {
+        Write-StatusJson
         exit 0
     }
     'submission upload' {
@@ -221,7 +247,9 @@ switch ("$noun $verb") {
     'submission download' {
         if ($state.downloads -notcontains 'signedPackage') { Write-Error 'no signedPackage available'; exit 5 }
         $target = Read-Option '--output-file'
-        if (Test-Path -LiteralPath $target) { Write-Error 'destination exists'; exit 4 }
+        $overwrite = $cliArgs -contains '--overwrite'
+        if ((Test-Path -LiteralPath $target) -and -not $overwrite) { Write-Error 'destination exists'; exit 4 }
+        if (Test-Path -LiteralPath $target) { Remove-Item -LiteralPath $target -Force }
         $stage = Join-Path ([IO.Path]::GetTempPath()) ('sdcm-mock-' + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $stage | Out-Null
         $pkg = $state.submissionId
@@ -253,7 +281,7 @@ $env:PATH = "$mockBin$([IO.Path]::PathSeparator)$env:PATH"
 # ---------------------------------------------------------------------------
 $blocks = Get-WorkflowPwshBlocks -Path $workflowPath
 $createBlock = Select-Block -Blocks $blocks -Signature 'RESUME_PRODUCT_ID'
-$uploadBlock = Select-Block -Blocks $blocks -Signature 'Test-PartnerSubmissionNeedsUpload'
+$uploadBlock = Select-Block -Blocks $blocks -Signature 'Test-SdcmSubmissionNeedsUpload'
 $waitBlock = Select-Block -Blocks $blocks -Signature 'partner-signing-result.json'
 
 function New-Sandbox([string] $Name) {
@@ -391,6 +419,8 @@ try {
     Assert-Equal (Measure-Call $fresh.Calls 'submission commit') 1 'fresh: submission committed exactly once'
     Assert-Equal (Measure-Call $fresh.Calls 'submission wait') 1 'fresh: waited once'
     Assert-Equal (Measure-Call $fresh.Calls 'submission download') 1 'fresh: downloaded once'
+    Assert-Equal (Measure-Call $fresh.Calls 'submission list') 0 'fresh: does not use deprecated list'
+    Assert-True ((Measure-Call $fresh.Calls 'submission status') -ge 2) 'fresh: status is the progress source'
     $result = Get-Content -LiteralPath (Join-Path $fresh.Sandbox 'partner-signing-result.json') -Raw | ConvertFrom-Json
     Assert-Equal $result.productId $fresh.ProductId 'fresh: result records the product id'
     Assert-Equal $result.submissionId $fresh.SubmissionId 'fresh: result records the submission id'
@@ -412,6 +442,8 @@ try {
     Assert-Equal (Measure-Call $processing.Calls 'submission upload') 0 'processing: upload skipped'
     Assert-Equal (Measure-Call $processing.Calls 'submission commit') 0 'processing: commit skipped'
     Assert-Equal (Measure-Call $processing.Calls 'submission wait') 1 'processing: waited once'
+    Assert-Equal (Measure-Call $processing.Calls 'submission get') 1 'processing: get used to resume'
+    Assert-Equal (Measure-Call $processing.Calls 'submission list') 0 'processing: does not use deprecated list'
     Assert-Equal $processing.ProductId '13872423721100346' 'processing: keeps the requested product id'
     Assert-Equal $processing.SubmissionId '1152921505701853745' 'processing: keeps the requested submission id'
 

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -89,6 +89,12 @@ Assert-True (-not (Test-SdcmSubmissionNeedsUpload -Status $completed)) 'complete
 
 $failed = New-TestStatus -Progress 'failed' -CommitStatus 'commitFailed' -State 'failed' -Step 'validation'
 Assert-Equal (Get-SdcmSubmissionProgress -Status $failed) 'failed' 'failed progress'
+Assert-Equal (Get-SdcmSubmissionProgress -Status (New-TestStatus -Progress 'Completed')) 'completed' 'progress is case-insensitive'
+Assert-True (Test-SdcmSubmissionHasSignedPackage -Status $completed) 'completed reports a signed package'
+Assert-True (-not (Test-SdcmSubmissionHasSignedPackage -Status $processing)) 'processing has no signed package'
+Assert-Throws { Get-SdcmSubmissionProgress -Status ([pscustomobject]@{ commitStatus = 'CommitPending' }) } 'missing progress throws'
+Assert-Throws { Get-SdcmSubmissionProgress -Status (New-TestStatus -Progress '') } 'empty progress throws'
+Assert-Throws { Get-SdcmSubmissionProgress -Status (New-TestStatus -Progress 'unknown') } 'unknown progress throws'
 
 $statusJson = @'
 {

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -34,44 +34,23 @@ function Assert-Throws([scriptblock] $Action, [string] $Name) {
     Write-Output "PASS $Name"
 }
 
-# Builds a submission shaped like the Hardware Dashboard API's Submission
-# resource, so the state table below is exercised against real field names and
-# real documented values rather than invented ones.
-function New-TestSubmission {
+function New-TestStatus {
     [CmdletBinding()]
     param(
+        [string] $Progress,
         [string] $CommitStatus = '',
         [string] $State = '',
         [string] $Step = '',
-        [string[]] $DownloadTypes = @()
+        [bool] $HasSignedPackage = $false
     )
 
-    $submission = [ordered]@{
-        id        = '1152921505701853745'
-        productId = '13872423721100346'
-        name      = 'DsHidMini 3.6.1 3.6.1.2202 submission'
-        type      = 'initial'
+    return [pscustomobject]@{
+        progress         = $Progress
+        commitStatus     = $CommitStatus
+        state            = $State
+        currentStep      = $Step
+        hasSignedPackage = $HasSignedPackage
     }
-    if ($CommitStatus) {
-        $submission['commitStatus'] = $CommitStatus
-    }
-    if ($State -or $Step) {
-        $submission['workflowStatus'] = [pscustomobject]@{
-            currentStep = $Step
-            state       = $State
-            messages    = @()
-        }
-    }
-    if ($DownloadTypes.Count -gt 0) {
-        $submission['downloads'] = [pscustomobject]@{
-            items    = @($DownloadTypes | ForEach-Object {
-                [pscustomobject]@{ type = $_; url = "https://example.invalid/$_" }
-            })
-            messages = @()
-        }
-    }
-
-    return [pscustomobject]$submission
 }
 
 $product = New-PartnerProductPayload -ProductName 'DsHidMini 3.6.0 3.6.0.2145' -AnnouncementDate '2026-09-09T00:00:00'
@@ -86,115 +65,58 @@ $submission = New-PartnerSubmissionPayload -Name 'DsHidMini 3.6.0.2145'
 Assert-Equal $submission.type 'initial' 'submission type'
 Assert-Equal (Get-PartnerPortalUrl -ProductId '123') 'https://partner.microsoft.com/dashboard/hardware/driver/123' 'portal url'
 
-# The raw API returns ids as numbers; sdcm re-serializes them as quoted strings.
 Assert-Equal (Get-SdcmEntityId -Json '{"id": 1152921505701840714, "name": "x"}') '1152921505701840714' 'entity id stays a string'
 Assert-Equal (Get-SdcmEntityId -Json '{"id": "1152921505701840714", "name": "x"}') '1152921505701840714' 'quoted entity id stays a string'
 Assert-Equal (Get-SdcmEntityId -Json '{"sharedProductId": "1152921504607010608", "id": "14631253285588838"}') '14631253285588838' 'sharedProductId is not mistaken for id'
 Assert-Equal (Get-SdcmEntityId -Json '{"productId": "13872423721100346", "id": "1152921505701853745"}') '1152921505701853745' 'productId is not mistaken for id'
-Assert-Equal (Get-SdcmEntityId -Json @('[', '  { "id": "42" }', ']')) '42' 'single-element array output unwraps'
 Assert-Equal (Get-SdcmEntityId -Json ([pscustomobject]@{ id = '1152921505701840714'; name = 'x' })) '1152921505701840714' 'PSCustomObject entity id'
 Assert-Throws { Get-SdcmEntityId -Json '{"name": "x"}' } 'missing id throws'
 Assert-Throws { Get-SdcmEntityId -Json '' } 'empty sdcm output throws'
 
-# workflowStatus.state is the state of workflowStatus.currentStep, not of the
-# submission as a whole, so every step/state combination has to be classified
-# explicitly. Documented states: notStarted, started, failed, completed.
-# Documented steps: packageInfoValidation, preparation, scanning, validation,
-# catalogCreation, manualReview, signing, finalizeIngestion.
-$progressCases = @(
-    @{ Name = 'fresh submission is Created'; Commit = 'CommitPending'; State = 'notStarted'; Step = 'packageInfoValidation'; Downloads = @('initialPackage'); Expected = 'Created' }
-    @{ Name = 'commitPending without workflow is Created'; Commit = 'commitPending'; State = ''; Step = ''; Downloads = @(); Expected = 'Created' }
-    @{ Name = 'submission with no status at all is Created'; Commit = ''; State = ''; Step = ''; Downloads = @(); Expected = 'Created' }
-    @{ Name = 'initialPackage alone is not completion'; Commit = 'CommitPending'; State = 'notStarted'; Step = ''; Downloads = @('initialPackage'); Expected = 'Created' }
-    @{ Name = 'committed but not yet started is Submitted'; Commit = 'commitComplete'; State = 'notStarted'; Step = 'packageInfoValidation'; Downloads = @('initialPackage'); Expected = 'Submitted' }
-    @{ Name = 'scanning in progress is Submitted'; Commit = 'commitComplete'; State = 'started'; Step = 'scanning'; Downloads = @('initialPackage'); Expected = 'Submitted' }
-    @{ Name = 'completed intermediate step is still Submitted'; Commit = 'commitComplete'; State = 'completed'; Step = 'scanning'; Downloads = @('initialPackage'); Expected = 'Submitted' }
-    @{ Name = 'manual review is Submitted'; Commit = 'commitComplete'; State = 'started'; Step = 'manualReview'; Downloads = @('initialPackage'); Expected = 'Submitted' }
-    @{ Name = 'signing is Submitted'; Commit = 'commitComplete'; State = 'started'; Step = 'signing'; Downloads = @('initialPackage'); Expected = 'Submitted' }
-    @{ Name = 'undocumented in-flight commit status is Submitted'; Commit = 'commitInProgress'; State = 'notStarted'; Step = ''; Downloads = @(); Expected = 'Submitted' }
-    @{ Name = 'started workflow without commitStatus is Submitted'; Commit = ''; State = 'started'; Step = 'validation'; Downloads = @(); Expected = 'Submitted' }
-    @{ Name = 'completed final step is Completed'; Commit = 'commitComplete'; State = 'completed'; Step = 'finalizeIngestion'; Downloads = @(); Expected = 'Completed' }
-    @{ Name = 'signedPackage download is Completed'; Commit = 'commitComplete'; State = 'started'; Step = 'signing'; Downloads = @('initialPackage', 'signedPackage'); Expected = 'Completed' }
-    @{ Name = 'failed workflow state is Failed'; Commit = 'commitComplete'; State = 'failed'; Step = 'validation'; Downloads = @('initialPackage'); Expected = 'Failed' }
-    @{ Name = 'commitFailed is Failed'; Commit = 'commitFailed'; State = 'notStarted'; Step = 'preparation'; Downloads = @(); Expected = 'Failed' }
-    @{ Name = 'failure wins over a signed package'; Commit = 'commitFailed'; State = 'failed'; Step = 'signing'; Downloads = @('signedPackage'); Expected = 'Failed' }
-)
+$created = New-TestStatus -Progress 'created' -CommitStatus 'CommitPending' -State 'notStarted' -Step 'packageInfoValidation'
+Assert-Equal (Get-SdcmSubmissionProgress -Status $created) 'created' 'created progress'
+Assert-True (Test-SdcmSubmissionNeedsUpload -Status $created) 'created needs upload'
+Assert-True (Test-SdcmSubmissionNeedsCommit -Status $created) 'created needs commit'
 
-foreach ($case in $progressCases) {
-    $candidate = New-TestSubmission -CommitStatus $case.Commit -State $case.State -Step $case.Step -DownloadTypes $case.Downloads
-    Assert-Equal (Get-PartnerSubmissionProgress -Submission $candidate) $case.Expected $case.Name
+$processing = New-TestStatus -Progress 'processing' -CommitStatus 'commitComplete' -State 'started' -Step 'scanning'
+Assert-Equal (Get-SdcmSubmissionProgress -Status $processing) 'processing' 'processing progress'
+Assert-True (-not (Test-SdcmSubmissionNeedsUpload -Status $processing)) 'processing skips upload'
+Assert-True (-not (Test-SdcmSubmissionNeedsCommit -Status $processing)) 'processing skips commit'
+
+$completed = New-TestStatus -Progress 'completed' -CommitStatus 'commitComplete' -State 'completed' -Step 'finalizeIngestion' -HasSignedPackage $true
+Assert-Equal (Get-SdcmSubmissionProgress -Status $completed) 'completed' 'completed progress'
+Assert-True (-not (Test-SdcmSubmissionNeedsUpload -Status $completed)) 'completed skips upload'
+
+$failed = New-TestStatus -Progress 'failed' -CommitStatus 'commitFailed' -State 'failed' -Step 'validation'
+Assert-Equal (Get-SdcmSubmissionProgress -Status $failed) 'failed' 'failed progress'
+
+$statusJson = @'
+{
+  "progress": "processing",
+  "commitStatus": "commitComplete",
+  "state": "started",
+  "currentStep": "scanning",
+  "hasSignedPackage": false
 }
-
-# Upload and commit must fire exactly once, for a submission that is still ours.
-$fresh = New-TestSubmission -CommitStatus 'CommitPending' -State 'notStarted' -Step 'packageInfoValidation' -DownloadTypes @('initialPackage')
-Assert-True (Test-PartnerSubmissionNeedsUpload -Submission $fresh) 'fresh submission needs upload'
-Assert-True (Test-PartnerSubmissionNeedsCommit -Submission $fresh) 'fresh submission needs commit'
-
-$committed = New-TestSubmission -CommitStatus 'commitComplete' -State 'notStarted' -Step 'packageInfoValidation' -DownloadTypes @('initialPackage')
-Assert-True (-not (Test-PartnerSubmissionNeedsUpload -Submission $committed)) 'committed submission skips upload'
-Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $committed)) 'committed submission skips commit'
-
-$processing = New-TestSubmission -CommitStatus 'commitComplete' -State 'started' -Step 'scanning' -DownloadTypes @('initialPackage')
-Assert-True (-not (Test-PartnerSubmissionNeedsUpload -Submission $processing)) 'processing submission skips upload'
-Assert-True (-not (Test-PartnerSubmissionNeedsCommit -Submission $processing)) 'processing submission skips commit'
-
-# `sdcm submission list --submission-id` wraps the entity in an array and quotes
-# every id, which is what the workflow actually has to parse.
-$sdcmListJson = @'
-[
-  {
-    "id": "1152921505701853745",
-    "productId": "13872423721100346",
-    "name": "DsHidMini 3.6.1 3.6.1.2202 submission",
-    "type": "initial",
-    "commitStatus": "commitComplete",
-    "workflowStatus": {
-      "currentStep": "scanning",
-      "state": "started",
-      "messages": []
-    },
-    "downloads": {
-      "items": [
-        { "type": "initialPackage", "url": "https://example.invalid/initial" }
-      ],
-      "messages": []
-    }
-  }
-]
 '@
-$fromSdcm = ConvertFrom-SdcmJson -Json $sdcmListJson
-Assert-True ($fromSdcm.id -is [string]) 'list array id is a string'
-Assert-Equal $fromSdcm.id '1152921505701853745' 'list array unwraps quoted id'
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $fromSdcm) 'Submitted' 'sdcm list JSON is Submitted'
-Assert-True ((Get-PartnerSubmissionProgressSummary -Submission $fromSdcm) -like '*Submitted*') 'progress summary includes Submitted'
-Assert-True ((Get-PartnerSubmissionProgressSummary -Submission $fromSdcm) -like '*currentStep=scanning*') 'progress summary includes the current step'
+$fromStatus = ConvertFrom-SdcmJson -Json $statusJson
+Assert-Equal (Get-SdcmSubmissionProgress -Status $fromStatus) 'processing' 'status JSON is processing'
+Assert-True ((Get-SdcmSubmissionProgressSummary -Status $fromStatus) -like '*processing*') 'status summary includes processing'
+Assert-True ((Get-SdcmSubmissionProgressSummary -Status $fromStatus) -like '*currentStep=scanning*') 'status summary includes the current step'
 
-$sdcmCompletedJson = @'
-[
-  {
-    "id": "1152921505701853745",
-    "productId": "13872423721100346",
-    "commitStatus": "commitComplete",
-    "workflowStatus": {
-      "currentStep": "finalizeIngestion",
-      "state": "completed",
-      "messages": []
-    },
-    "downloads": {
-      "items": [
-        { "type": "initialPackage", "url": "https://example.invalid/initial" },
-        { "type": "signedPackage", "url": "https://example.invalid/signed" },
-        { "type": "certificationReport", "url": "https://example.invalid/report" }
-      ],
-      "messages": []
-    }
-  }
-]
+$getJson = @'
+{
+  "id": "1152921505701853745",
+  "productId": "13872423721100346",
+  "name": "DsHidMini 3.6.1 3.6.1.2202 submission",
+  "type": "initial",
+  "commitStatus": "commitComplete"
+}
 '@
-$completedFromSdcm = ConvertFrom-SdcmJson -Json $sdcmCompletedJson
-Assert-Equal (Get-PartnerSubmissionProgress -Submission $completedFromSdcm) 'Completed' 'sdcm completed JSON is Completed'
-Assert-True (Test-PartnerSubmissionHasSignedPackage -Submission $completedFromSdcm) 'signed package detected'
-Assert-True (-not (Test-PartnerSubmissionHasSignedPackage -Submission $fromSdcm)) 'no signed package while processing'
+$fromGet = ConvertFrom-SdcmJson -Json $getJson
+Assert-True ($fromGet.id -is [string]) 'get id is a string'
+Assert-Equal $fromGet.id '1152921505701853745' 'get JSON keeps quoted id'
+Assert-Equal (Get-SdcmEntityId -Json $getJson) '1152921505701853745' 'get JSON entity id'
 
 $temp = Join-Path ([IO.Path]::GetTempPath()) ("dshm-partner-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $temp | Out-Null

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -86,6 +86,7 @@ Assert-True (-not (Test-SdcmSubmissionNeedsCommit -Status $processing)) 'process
 $completed = New-TestStatus -Progress 'completed' -CommitStatus 'commitComplete' -State 'completed' -Step 'finalizeIngestion' -HasSignedPackage $true
 Assert-Equal (Get-SdcmSubmissionProgress -Status $completed) 'completed' 'completed progress'
 Assert-True (-not (Test-SdcmSubmissionNeedsUpload -Status $completed)) 'completed skips upload'
+Assert-True (-not (Test-SdcmSubmissionNeedsCommit -Status $completed)) 'completed skips commit'
 
 $failed = New-TestStatus -Progress 'failed' -CommitStatus 'commitFailed' -State 'failed' -Step 'validation'
 Assert-Equal (Get-SdcmSubmissionProgress -Status $failed) 'failed' 'failed progress'

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -4,17 +4,12 @@ Set-StrictMode -Version Latest
 $script:PartnerSignedNamePattern = '^Signed_(\d+)\.zip$'
 $script:PartnerInitialNamePattern = '^Initial_(\d+)\.cab$'
 
-# Hardware Dev Center submission vocabulary. commitStatus is documented as
-# commitPending / commitComplete / commitFailed, but the API reference shows
-# 'CommitPending' while the service returns 'commitPending', so every comparison
-# below is case-insensitive. workflowStatus.state is one of notStarted, started,
-# failed, completed and describes *the current step only*; currentStep walks
-# packageInfoValidation, preparation, scanning, validation, catalogCreation,
-# manualReview, signing, finalizeIngestion.
-$script:PartnerCommitPending = 'commitPending'
-$script:PartnerCommitFailed = 'commitFailed'
-$script:PartnerWorkflowFinalStep = 'finalizeIngestion'
-$script:PartnerSignedPackageType = 'signedPackage'
+# sdcm 1.0.0-pre004 owns the Hardware Dev Center state machine. progress is
+# created | processing | completed | failed. state describes currentStep only.
+$script:SdcmProgressCreated = 'created'
+$script:SdcmProgressProcessing = 'processing'
+$script:SdcmProgressCompleted = 'completed'
+$script:SdcmProgressFailed = 'failed'
 
 function Invoke-Sdcm {
     [CmdletBinding()]
@@ -119,141 +114,49 @@ function Get-PartnerSubmissionProperty {
     return $null
 }
 
-function Test-PartnerValueEquals {
+function Get-SdcmSubmissionStatus {
     [CmdletBinding()]
     param(
-        [string] $Value,
         [Parameter(Mandatory = $true)]
-        [string] $Expected
+        [string] $ProductId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $SubmissionId
     )
 
-    if ([string]::IsNullOrWhiteSpace($Value)) {
-        return $false
+    # Failed submissions still emit the status document, then exit 7.
+    $json = & sdcm --output json --auth client-secret submission status --product-id $ProductId --submission-id $SubmissionId
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -notin 0, 7) {
+        throw "sdcm submission status --product-id $ProductId --submission-id $SubmissionId failed with exit code $exitCode"
     }
-
-    return [string]::Equals($Value.Trim(), $Expected, [StringComparison]::OrdinalIgnoreCase)
+    return ConvertFrom-SdcmJson -Json $json
 }
 
-function Get-PartnerSubmissionWorkflow {
+function Get-SdcmSubmissionProgress {
     [CmdletBinding()]
-    param($Submission)
+    param($Status)
 
-    if ($null -eq $Submission -or -not $Submission.PSObject.Properties['workflowStatus']) {
-        return $null
+    $progress = Get-PartnerSubmissionProperty -Object $Status -Names @('progress')
+    if (-not $progress) {
+        return $script:SdcmProgressCreated
     }
 
-    return $Submission.workflowStatus
+    return $progress.Trim().ToLowerInvariant()
 }
 
-function Get-PartnerSubmissionWorkflowState {
+function Get-SdcmSubmissionProgressSummary {
     [CmdletBinding()]
-    param($Submission)
+    param($Status)
 
-    $workflow = Get-PartnerSubmissionWorkflow -Submission $Submission
-    if ($null -eq $workflow) {
-        return $null
+    $progress = Get-SdcmSubmissionProgress -Status $Status
+    $commit = Get-PartnerSubmissionProperty -Object $Status -Names @('commitStatus')
+    $state = Get-PartnerSubmissionProperty -Object $Status -Names @('state')
+    $step = Get-PartnerSubmissionProperty -Object $Status -Names @('currentStep')
+    $signed = $false
+    if ($Status -and $Status.PSObject.Properties['hasSignedPackage'] -and $null -ne $Status.hasSignedPackage) {
+        $signed = [bool]$Status.hasSignedPackage
     }
-    if ($workflow -is [string]) {
-        return $workflow
-    }
-
-    return Get-PartnerSubmissionProperty -Object $workflow -Names @('state', 'currentState', 'status')
-}
-
-function Get-PartnerSubmissionWorkflowStep {
-    [CmdletBinding()]
-    param($Submission)
-
-    $workflow = Get-PartnerSubmissionWorkflow -Submission $Submission
-    if ($null -eq $workflow -or $workflow -is [string]) {
-        return $null
-    }
-
-    return Get-PartnerSubmissionProperty -Object $workflow -Names @('currentStep')
-}
-
-function Get-PartnerSubmissionCommitStatus {
-    [CmdletBinding()]
-    param($Submission)
-
-    return Get-PartnerSubmissionProperty -Object $Submission -Names @('commitStatus')
-}
-
-function Test-PartnerSubmissionHasSignedPackage {
-    [CmdletBinding()]
-    param($Submission)
-
-    if ($null -eq $Submission -or -not $Submission.PSObject.Properties['downloads']) {
-        return $false
-    }
-
-    $downloads = $Submission.downloads
-    if ($null -eq $downloads -or -not $downloads.PSObject.Properties['items'] -or -not $downloads.items) {
-        return $false
-    }
-
-    foreach ($item in @($downloads.items)) {
-        if ($null -eq $item -or -not $item.PSObject.Properties['type']) {
-            continue
-        }
-        if (Test-PartnerValueEquals -Value ([string]$item.type) -Expected $script:PartnerSignedPackageType) {
-            return $true
-        }
-    }
-
-    return $false
-}
-
-function Get-PartnerSubmissionProgress {
-    [CmdletBinding()]
-    param($Submission)
-
-    $commit = Get-PartnerSubmissionCommitStatus -Submission $Submission
-    $state = Get-PartnerSubmissionWorkflowState -Submission $Submission
-    $step = Get-PartnerSubmissionWorkflowStep -Submission $Submission
-
-    if ((Test-PartnerValueEquals -Value $commit -Expected $script:PartnerCommitFailed) -or
-        (Test-PartnerValueEquals -Value $state -Expected 'failed')) {
-        return 'Failed'
-    }
-
-    # A downloadable signedPackage is the only unambiguous completion signal.
-    # state applies to currentStep, so 'completed' on an intermediate step such
-    # as scanning must not be read as the whole submission being done.
-    if (Test-PartnerSubmissionHasSignedPackage -Submission $Submission) {
-        return 'Completed'
-    }
-    if ((Test-PartnerValueEquals -Value $state -Expected 'completed') -and
-        (Test-PartnerValueEquals -Value $step -Expected $script:PartnerWorkflowFinalStep)) {
-        return 'Completed'
-    }
-
-    # Anything other than commitPending means the submission already belongs to
-    # Hardware Dev Center and must not be uploaded or committed again. Treating
-    # unrecognised values as committed keeps an undocumented in-flight status
-    # from triggering a second upload.
-    if ($commit -and -not (Test-PartnerValueEquals -Value $commit -Expected $script:PartnerCommitPending)) {
-        return 'Submitted'
-    }
-    # Fallback for a submission that reports no commitStatus at all: the
-    # workflow only leaves notStarted once Hardware Dev Center owns the package.
-    if ((Test-PartnerValueEquals -Value $state -Expected 'started') -or
-        (Test-PartnerValueEquals -Value $state -Expected 'completed')) {
-        return 'Submitted'
-    }
-
-    return 'Created'
-}
-
-function Get-PartnerSubmissionProgressSummary {
-    [CmdletBinding()]
-    param($Submission)
-
-    $progress = Get-PartnerSubmissionProgress -Submission $Submission
-    $commit = Get-PartnerSubmissionCommitStatus -Submission $Submission
-    $state = Get-PartnerSubmissionWorkflowState -Submission $Submission
-    $step = Get-PartnerSubmissionWorkflowStep -Submission $Submission
-    $signed = Test-PartnerSubmissionHasSignedPackage -Submission $Submission
     if (-not $commit) { $commit = '-' }
     if (-not $state) { $state = '-' }
     if (-not $step) { $step = '-' }
@@ -261,20 +164,18 @@ function Get-PartnerSubmissionProgressSummary {
     return "Submission progress: $progress (commitStatus=$commit; state=$state; currentStep=$step; signedPackage=$signed)"
 }
 
-function Test-PartnerSubmissionNeedsUpload {
+function Test-SdcmSubmissionNeedsUpload {
     [CmdletBinding()]
-    param($Submission)
+    param($Status)
 
-    $progress = Get-PartnerSubmissionProgress -Submission $Submission
-    return $progress -eq 'Created'
+    return (Get-SdcmSubmissionProgress -Status $Status) -eq $script:SdcmProgressCreated
 }
 
-function Test-PartnerSubmissionNeedsCommit {
+function Test-SdcmSubmissionNeedsCommit {
     [CmdletBinding()]
-    param($Submission)
+    param($Status)
 
-    $progress = Get-PartnerSubmissionProgress -Submission $Submission
-    return $progress -eq 'Created'
+    return (Get-SdcmSubmissionProgress -Status $Status) -eq $script:SdcmProgressCreated
 }
 
 function Find-PartnerSignedPackagePair {
@@ -333,10 +234,6 @@ function Get-SdcmEntityId {
         $Json
     )
 
-    # sdcm --output json re-serializes Hardware Dev Center ids as quoted strings
-    # via LongToStringJsonConverter, while the raw API uses unquoted numbers.
-    # Parse the document instead of pattern matching so a nested id can never be
-    # mistaken for the entity's own id.
     $entity = ConvertFrom-SdcmJson -Json $Json
     if ($entity -is [System.Collections.IList] -and $entity -isnot [string]) {
         $entity = @($entity) | Select-Object -First 1
@@ -363,8 +260,6 @@ function ConvertTo-SdcmJsonText {
         return $Json
     }
 
-    # String arrays are already JSON text (sdcm / command output). Join them.
-    # PSCustomObject and hashtable values must be serialized, not display-stringed.
     $items = @($Json)
     $allStrings = $true
     foreach ($item in $items) {

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -139,10 +139,32 @@ function Get-SdcmSubmissionProgress {
 
     $progress = Get-PartnerSubmissionProperty -Object $Status -Names @('progress')
     if (-not $progress) {
-        return $script:SdcmProgressCreated
+        throw 'sdcm submission status is missing progress.'
     }
 
-    return $progress.Trim().ToLowerInvariant()
+    $normalized = $progress.Trim().ToLowerInvariant()
+    $allowed = @(
+        $script:SdcmProgressCreated
+        $script:SdcmProgressProcessing
+        $script:SdcmProgressCompleted
+        $script:SdcmProgressFailed
+    )
+    if ($normalized -notin $allowed) {
+        throw "sdcm submission status reported unexpected progress '$progress'."
+    }
+
+    return $normalized
+}
+
+function Test-SdcmSubmissionHasSignedPackage {
+    [CmdletBinding()]
+    param($Status)
+
+    if (-not $Status -or -not $Status.PSObject.Properties['hasSignedPackage'] -or $null -eq $Status.hasSignedPackage) {
+        return $false
+    }
+
+    return [bool]$Status.hasSignedPackage
 }
 
 function Get-SdcmSubmissionProgressSummary {

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -143,7 +143,7 @@ Retry without rebuilding. Every fresh run opens another Partner Center product, 
 - **workflow_dispatch** with the original Build run ID plus `product-id` and `submission-id` resumes that existing submission using the current branch's scripts. This is how a script fix reaches a submission Hardware Dev Center is already processing, without opening another product.
 - **workflow_dispatch** with the original Build run ID and no `product-id` / `submission-id` creates a fresh product and submission from the already-built CAB. Use this only once Hardware Dev Center has rejected or failed a submission.
 
-Before changing that automation, run `.\build.cmd TestReleasePipeline`. It runs the workflow's own `create` / `upload` / `wait` scripts against a mock `sdcm` and asserts which sdcm verbs each stage calls, so submission-state bugs surface locally instead of consuming a product.
+Before changing that automation, run `.\build.cmd TestReleasePipeline`. It runs the workflow's own `create` / `upload` / `wait` scripts against a mock `sdcm` 1.0.0-pre004 (`submission get` / `status` / `--overwrite`) and asserts which verbs each stage calls, so submission-state bugs surface locally instead of consuming a product.
 
 This project's verified behavior: Microsoft **adds** its signature to the already EV-signed DLLs and replaces the catalog. If a returned DLL has only a Microsoft signer, stop and investigate; do not continue to MSI.
 
@@ -241,7 +241,7 @@ gh release create setup-v3.6.0 `
 | [`build/ReleaseVersion.ps1`](../build/ReleaseVersion.ps1) | Tag parse and four-part version |
 | [`build/ReleasePipeline.cs`](../build/ReleasePipeline.cs) | Staging, ingest, validation |
 | [`build/ReleaseTargets.cs`](../build/ReleaseTargets.cs) | NUKE entry points |
-| [`build/PartnerSigning.ps1`](../build/PartnerSigning.ps1) | SDCM payloads, submission progress, Signed_/Initial_ pair checks |
+| [`build/PartnerSigning.ps1`](../build/PartnerSigning.ps1) | SDCM payloads, `submission status` wrappers, Signed_/Initial_ pair checks |
 | [`build/PartnerSigning.DryRun.ps1`](../build/PartnerSigning.DryRun.ps1) | Offline dry run of the signing workflow against a mock sdcm |
 | [`.github/workflows/partner-signing.yml`](../.github/workflows/partner-signing.yml) | Retryable Partner Center submit / wait / ingest |
 | [`build/New-PartnerSubmissionInf.ps1`](../build/New-PartnerSubmissionInf.ps1) | Dual-arch INF for the submission CAB |


### PR DESCRIPTION
The tool now owns submission progress and download overwrite, so Partner signing no longer reconstructs that state machine from list JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Partner signing workflows now refresh submission status after waiting and report updated progress.
  * Failed, incomplete, or unpublished submissions are rejected before download.
  * Downloads can overwrite existing files automatically.
  * Updated tooling and release validation use SDCM version 1.0.0-pre004.
* **Tests**
  * Expanded coverage for progress states, failure handling, signed-package detection, and upload/download decisions.
* **Documentation**
  * Updated the release runbook with the latest signing workflow validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->