### PR TITLE
Keep signedPackage as Signed zip and download initialPackage separately.

### DIFF
--- a/.github/workflows/partner-signing.yml
+++ b/.github/workflows/partner-signing.yml
@@ -318,18 +318,8 @@ jobs:
             throw "Submission $submissionId is not ready to download (progress=$progress). Hardware Dev Center has not published a signed package yet."
           }
 
-          $downloadZip = Join-Path $pwd 'hdc-download.zip'
-          Invoke-Sdcm submission download --product-id $productId --submission-id $submissionId --output-file $downloadZip --overwrite
-          $extractDir = Join-Path $pwd 'hdc-extracted'
-          New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
-          Expand-Archive -LiteralPath $downloadZip -DestinationPath $extractDir -Force
-
-          $pair = Find-PartnerSignedPackagePair -Root $extractDir
-
           $stage = Join-Path $pwd 'partner-signed'
-          New-Item -ItemType Directory -Force -Path $stage | Out-Null
-          Copy-Item -LiteralPath $pair.SignedZip -Destination (Join-Path $stage $pair.SignedName)
-          Copy-Item -LiteralPath $pair.InitialCab -Destination (Join-Path $stage $pair.InitialName)
+          $pair = Save-SdcmSubmissionPackagePair -ProductId $productId -SubmissionId $submissionId -Destination $stage
 
           $result = [ordered]@{
             schemaVersion = 1

--- a/build/PartnerSigning.DryRun.ps1
+++ b/build/PartnerSigning.DryRun.ps1
@@ -155,7 +155,15 @@ $verb = $verbs[1]
 Add-Content -LiteralPath $logPath -Value "$noun $verb"
 
 function Write-SubmissionJson([switch] $AsArray) {
-    $downloads = @($state.downloads | ForEach-Object { @{ type = $_; url = "https://example.invalid/$_" } })
+    $downloads = @($state.downloads | ForEach-Object {
+        $url = "https://example.invalid/$_"
+        if ($_ -eq 'initialPackage') {
+            $cab = Join-Path (Split-Path -Parent $statePath) 'initial-package.cab'
+            if (-not (Test-Path -LiteralPath $cab)) { Set-Content -LiteralPath $cab -Value 'initial-package' }
+            $url = ([Uri]$cab).AbsoluteUri
+        }
+        @{ type = $_; url = $url }
+    })
     $submission = [ordered]@{
         id             = $state.submissionId
         productId      = $state.productId
@@ -252,9 +260,7 @@ switch ("$noun $verb") {
         if (Test-Path -LiteralPath $target) { Remove-Item -LiteralPath $target -Force }
         $stage = Join-Path ([IO.Path]::GetTempPath()) ('sdcm-mock-' + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $stage | Out-Null
-        $pkg = $state.submissionId
-        Set-Content -LiteralPath (Join-Path $stage "Signed_$pkg.zip") -Value 'signed-package'
-        Set-Content -LiteralPath (Join-Path $stage "Initial_$pkg.cab") -Value 'initial-package'
+        Set-Content -LiteralPath (Join-Path $stage 'dshidmini.sys') -Value 'signed-package'
         Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $target
         Remove-Item -LiteralPath $stage -Recurse -Force
         exit 0
@@ -428,6 +434,14 @@ try {
     Assert-Equal $result.tag 'v3.6.1.2202' 'fresh: result records the tag'
     Assert-True (Test-Path -LiteralPath (Join-Path $fresh.Sandbox "partner-signed/Signed_$($fresh.SubmissionId).zip")) 'fresh: signed zip staged'
     Assert-True (Test-Path -LiteralPath (Join-Path $fresh.Sandbox "partner-signed/Initial_$($fresh.SubmissionId).cab")) 'fresh: initial cab staged'
+    Assert-Equal (Measure-Call $fresh.Calls 'submission get') 1 'fresh: get used for the initialPackage url'
+    $unwrapped = Join-Path $fresh.Sandbox 'hdc-extracted'
+    New-Item -ItemType Directory -Force -Path $unwrapped | Out-Null
+    Expand-Archive -LiteralPath (Join-Path $fresh.Sandbox "partner-signed/Signed_$($fresh.SubmissionId).zip") -DestinationPath $unwrapped -Force
+    $unwrappedNames = @(Get-ChildItem -LiteralPath $unwrapped -Recurse -File | ForEach-Object { $_.Name })
+    Assert-True ($unwrappedNames -contains 'dshidmini.sys') 'fresh: signed zip contains driver files'
+    Assert-True ($unwrappedNames -notcontains "Signed_$($fresh.SubmissionId).zip") 'fresh: signed zip is not a wrapper'
+    Assert-True ($unwrappedNames -notcontains "Initial_$($fresh.SubmissionId).cab") 'fresh: signed zip has no initial cab'
 
     # Resuming a submission Hardware Dev Center is already processing must not
     # open a second product, and must not upload or commit again.
@@ -442,7 +456,7 @@ try {
     Assert-Equal (Measure-Call $processing.Calls 'submission upload') 0 'processing: upload skipped'
     Assert-Equal (Measure-Call $processing.Calls 'submission commit') 0 'processing: commit skipped'
     Assert-Equal (Measure-Call $processing.Calls 'submission wait') 1 'processing: waited once'
-    Assert-Equal (Measure-Call $processing.Calls 'submission get') 1 'processing: get used to resume'
+    Assert-Equal (Measure-Call $processing.Calls 'submission get') 2 'processing: get used to resume and to fetch initialPackage'
     Assert-Equal (Measure-Call $processing.Calls 'submission list') 0 'processing: does not use deprecated list'
     Assert-Equal $processing.ProductId '13872423721100346' 'processing: keeps the requested product id'
     Assert-Equal $processing.SubmissionId '1152921505701853745' 'processing: keeps the requested submission id'

--- a/build/PartnerSigning.Tests.ps1
+++ b/build/PartnerSigning.Tests.ps1
@@ -117,13 +117,23 @@ $getJson = @'
   "productId": "13872423721100346",
   "name": "DsHidMini 3.6.1 3.6.1.2202 submission",
   "type": "initial",
-  "commitStatus": "commitComplete"
+  "commitStatus": "commitComplete",
+  "downloads": {
+    "items": [
+      { "type": "initialPackage", "url": "https://example.invalid/initial.cab" },
+      { "type": "signedPackage", "url": "https://example.invalid/signed.zip" }
+    ],
+    "messages": []
+  }
 }
 '@
 $fromGet = ConvertFrom-SdcmJson -Json $getJson
 Assert-True ($fromGet.id -is [string]) 'get id is a string'
 Assert-Equal $fromGet.id '1152921505701853745' 'get JSON keeps quoted id'
 Assert-Equal (Get-SdcmEntityId -Json $getJson) '1152921505701853745' 'get JSON entity id'
+Assert-Equal (Get-SdcmSubmissionDownloadUrl -Submission $fromGet -Type 'initialPackage') 'https://example.invalid/initial.cab' 'get JSON initialPackage url'
+Assert-Equal (Get-SdcmSubmissionDownloadUrl -Submission $fromGet -Type 'signedPackage') 'https://example.invalid/signed.zip' 'get JSON signedPackage url'
+Assert-Equal (Get-SdcmSubmissionDownloadUrl -Submission $fromGet -Type 'certificationReport') $null 'missing download type is null'
 
 $temp = Join-Path ([IO.Path]::GetTempPath()) ("dshm-partner-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $temp | Out-Null
@@ -150,6 +160,12 @@ try {
     Set-Content -LiteralPath (Join-Path $temp "Signed_42.zip") -Value 'signed'
     Set-Content -LiteralPath (Join-Path $temp "Initial_42.cab") -Value 'initial'
     Assert-Throws { Find-PartnerSignedPackagePair -Root $temp } 'multiple pairs rejected'
+
+    $blobSrc = Join-Path $temp 'portal-initial.cab'
+    $blobDst = Join-Path $temp 'copied-initial.cab'
+    Set-Content -LiteralPath $blobSrc -Value 'portal-initial'
+    Save-SdcmBlob -Url ([Uri]$blobSrc).AbsoluteUri -Path $blobDst
+    Assert-Equal (Get-Content -LiteralPath $blobDst -Raw).Trim() 'portal-initial' 'file URI blob copy'
 }
 finally {
     Remove-Item -LiteralPath $temp -Recurse -Force

--- a/build/PartnerSigning.ps1
+++ b/build/PartnerSigning.ps1
@@ -217,7 +217,9 @@ function Find-PartnerSignedPackagePair {
         Where-Object { $_.Name -match $script:PartnerInitialNamePattern })
 
     if ($signed.Count -eq 0 -or $initial.Count -eq 0) {
-        throw "Partner download is missing Signed_<id>.zip and/or Initial_<id>.cab under $Root."
+        $found = @(Get-ChildItem -LiteralPath $Root -Recurse -File | ForEach-Object { $_.Name })
+        $preview = if ($found.Count -eq 0) { '(empty)' } else { $found -join ', ' }
+        throw "Partner download is missing Signed_<id>.zip and/or Initial_<id>.cab under $Root. Found: $preview"
     }
 
     $pairs = foreach ($zip in $signed) {
@@ -247,6 +249,98 @@ function Find-PartnerSignedPackagePair {
     }
 
     return $pairs[0]
+}
+
+function Get-SdcmSubmissionDownloadUrl {
+    [CmdletBinding()]
+    param(
+        $Submission,
+        [Parameter(Mandatory = $true)]
+        [string] $Type
+    )
+
+    if (-not $Submission -or -not $Submission.PSObject.Properties['downloads'] -or $null -eq $Submission.downloads) {
+        return $null
+    }
+
+    $downloads = $Submission.downloads
+    if (-not $downloads.PSObject.Properties['items'] -or $null -eq $downloads.items) {
+        return $null
+    }
+
+    foreach ($item in @($downloads.items)) {
+        $itemType = Get-PartnerSubmissionProperty -Object $item -Names @('type')
+        if ($itemType -and $itemType.Equals($Type, [StringComparison]::OrdinalIgnoreCase)) {
+            return Get-PartnerSubmissionProperty -Object $item -Names @('url')
+        }
+    }
+
+    return $null
+}
+
+function Save-SdcmBlob {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Url,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Path
+    )
+
+    $directory = Split-Path -Parent $Path
+    if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    $uri = [Uri]$Url
+    if ($uri.IsFile) {
+        Copy-Item -LiteralPath $uri.LocalPath -Destination $Path -Force
+    }
+    else {
+        Invoke-WebRequest -Uri $Url -OutFile $Path
+    }
+
+    if (-not (Test-Path -LiteralPath $Path) -or (Get-Item -LiteralPath $Path).Length -eq 0) {
+        throw "Download produced an empty file: $Path"
+    }
+}
+
+function Save-SdcmSubmissionPackagePair {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ProductId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $SubmissionId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Destination
+    )
+
+    if ($SubmissionId -notmatch '^\d+$') {
+        throw "submission-id must be numeric. Got: '$SubmissionId'."
+    }
+
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    $signedPath = Join-Path $Destination "Signed_$SubmissionId.zip"
+    $initialPath = Join-Path $Destination "Initial_$SubmissionId.cab"
+
+    Write-Host "Downloading signedPackage to $signedPath"
+    $null = Invoke-Sdcm submission download --product-id $ProductId --submission-id $SubmissionId --output-file $signedPath --overwrite
+
+    $got = Invoke-Sdcm submission get --product-id $ProductId --submission-id $SubmissionId
+    $submission = ConvertFrom-SdcmJson -Json $got
+    $initialUrl = Get-SdcmSubmissionDownloadUrl -Submission $submission -Type 'initialPackage'
+    if (-not $initialUrl) {
+        throw "Submission $SubmissionId has a signed package but no initialPackage download URL."
+    }
+
+    Write-Host "Downloading initialPackage to $initialPath"
+    Save-SdcmBlob -Url $initialUrl -Path $initialPath
+
+    return Find-PartnerSignedPackagePair -Root $Destination
 }
 
 function Get-SdcmEntityId {

--- a/build/ReleasePipeline.cs
+++ b/build/ReleasePipeline.cs
@@ -580,13 +580,15 @@ static class ReleaseStaging
                 section = section[..timestampIndex];
             }
 
-            Match match = Regex.Match(section, @"Issued to:\s*(.+)");
-            if (!match.Success)
+            // signtool /v prints each chain root-first. The leaf (the actual signer)
+            // is the last Issued to in the section.
+            MatchCollection matches = Regex.Matches(section, @"Issued to:\s*(.+)");
+            if (matches.Count == 0)
             {
                 continue;
             }
 
-            string value = match.Groups[1].Value.Trim();
+            string value = matches[^1].Groups[1].Value.Trim();
             if (!string.IsNullOrWhiteSpace(value))
             {
                 subjects.Add(value);

--- a/build/ReleasePipelineTests.cs
+++ b/build/ReleasePipelineTests.cs
@@ -156,19 +156,23 @@ static class ReleasePipelineTests
     {
         const string output = """
             Signing Certificate Chain:
-                Issued to: Nefarius Software Solutions e.U.
-                Issued by: Intermediate CA
-                    Issued to: Intermediate CA
-                    Issued by: Root CA
+                Issued to: DigiCert Assured ID Root CA
+                Issued by: DigiCert Assured ID Root CA
+                    Issued to: DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1
+                    Issued by: DigiCert Assured ID Root CA
+                        Issued to: Nefarius Software Solutions e.U.
+                        Issued by: DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1
             The signature is timestamped: Thu Jan 01 00:00:00 2026
             Timestamp Verified by:
                 Issued to: Timestamp Authority
                 Issued by: Timestamp Root
             Signing Certificate Chain:
-                Issued to: Microsoft Windows Hardware Compatibility Publisher
-                Issued by: Microsoft Windows Third Party Component CA 2014
+                Issued to: Microsoft Root Certificate Authority 2010
+                Issued by: Microsoft Root Certificate Authority 2010
                     Issued to: Microsoft Windows Third Party Component CA 2014
                     Issued by: Microsoft Root Certificate Authority 2010
+                        Issued to: Microsoft Windows Hardware Compatibility Publisher
+                        Issued by: Microsoft Windows Third Party Component CA 2014
             """;
         var issued = ReleaseStaging.ParseIssuedTo(output);
         AssertEqual(string.Join("|", issued),

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -226,7 +226,7 @@ gh release create setup-v3.6.0 `
 | `wait` job exit 9 | `--wait-timeout` 3600 elapsed; re-run failed jobs to resume the wait |
 | `wait` job: submission is still commitPending | The commit never landed; re-run the `upload` job before the wait |
 | `create` job: product-id and submission-id must be supplied together | Resume needs both ids, or neither |
-| Missing `Signed_<id>.zip` / `Initial_<id>.cab` pair | Downloaded the wrapper or submission CAB instead of the portal pair |
+| Missing `Signed_<id>.zip` / `Initial_<id>.cab` pair | Expanded `signedPackage` (driver files) instead of keeping it as `Signed_<id>.zip` and downloading `initialPackage` separately |
 | Multiple `dshidmini` packages | Point `MicrosoftPackagePath` at the zip or the single package folder |
 | DLL missing Microsoft signer | Downloaded the submission CAB instead of the dashboard's signed package |
 | DLL missing publisher signer | Microsoft package is not from this pipeline's EV-signed CAB |


### PR DESCRIPTION
Expanding the sdcm download looked for a portal pair inside driver files and failed a green submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partner package signing workflows by reliably downloading and staging signed and initial packages.
  * Added validation for downloaded package pairs, including clearer errors listing available files when expected packages are missing.
  * Improved support for package downloads from local files and remote URLs.
  * Improved certificate-signature processing to identify the final signer in certificate chains.

* **Documentation**
  * Updated troubleshooting guidance to reflect the current signed-package and initial-package download process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->