### PR TITLE
Fix/xinput slot startup refresh

### DIFF
--- a/ControlApp/Models/DshmDevMan.cs
+++ b/ControlApp/Models/DshmDevMan.cs
@@ -1,4 +1,6 @@
-﻿using Nefarius.DsHidMini.ControlApp.Models.Util;
+using System.Threading;
+
+using Nefarius.DsHidMini.ControlApp.Models.Util;
 using Nefarius.DsHidMini.IPC;
 using Nefarius.DsHidMini.IPC.Models.Drivers;
 using Nefarius.DsHidMini.IPC.Models.Public;
@@ -9,7 +11,11 @@ namespace Nefarius.DsHidMini.ControlApp.Models;
 
 public class DshmDevMan
 {
+    private static readonly TimeSpan XusbRefreshDebounce = TimeSpan.FromMilliseconds(250);
+
     private DeviceNotificationListener? _listener;
+    private DeviceNotificationListener? _xusbListener;
+    private CancellationTokenSource? _xusbRefreshCts;
     //private readonly HostRadio _hostRadio;
 
     public List<PnPDevice> Devices { get; } = new();
@@ -27,6 +33,11 @@ public class DshmDevMan
         _listener.DeviceRemoved += OnListenerDevicesRemovedOrAdded;
         _listener.StartListen(DsHidMiniDriver.DeviceInterfaceGuid);
 
+        _xusbListener = new DeviceNotificationListener();
+        _xusbListener.DeviceArrived += OnXusbInterfaceChanged;
+        _xusbListener.DeviceRemoved += OnXusbInterfaceChanged;
+        _xusbListener.StartListen(XInputSlotResolver.XusbDeviceInterfaceGuid);
+
         UpdateConnectedDshmDevicesList();
     }
 
@@ -34,6 +45,12 @@ public class DshmDevMan
     {
         Log.Logger.Information("Stopping detection of DsHidMini devices");
         Devices.Clear();
+        _xusbRefreshCts?.Cancel();
+        _xusbRefreshCts?.Dispose();
+        _xusbRefreshCts = null;
+        _xusbListener?.StopListen();
+        _xusbListener?.Dispose();
+        _xusbListener = null;
         _listener?.StopListen();
         _listener?.Dispose();
         _listener = null;
@@ -43,6 +60,45 @@ public class DshmDevMan
     {
         Log.Logger.Information("DsHidMini devices added or removed. Updating device list");
         UpdateConnectedDshmDevicesList();
+    }
+
+    private void OnXusbInterfaceChanged(DeviceEventArgs e)
+    {
+        QueueXusbInterfaceRefresh();
+    }
+
+    /// <summary>
+    ///     Coalesces XUSB arrive/remove bursts (common on Bluetooth) and then asks the UI to
+    ///     re-resolve player slots without rebuilding the DsHidMini device list.
+    /// </summary>
+    private void QueueXusbInterfaceRefresh()
+    {
+        CancellationTokenSource cts = new();
+        CancellationTokenSource? previous = Interlocked.Exchange(ref _xusbRefreshCts, cts);
+        previous?.Cancel();
+        previous?.Dispose();
+
+        CancellationToken token = cts.Token;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(XusbRefreshDebounce, token).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            Log.Logger.Debug("XUSB interfaces changed. Refreshing XInput slot resolution.");
+            XInputSlotResolver.InvalidateResolutionCache();
+            XInputInterfacesUpdated?.Invoke(this, EventArgs.Empty);
+        }, token);
     }
 
     private void UpdateConnectedDshmDevicesList()
@@ -122,4 +178,9 @@ public class DshmDevMan
     }
 
     public event EventHandler? ConnectedDeviceListUpdated;
+
+    /// <summary>
+    ///     Raised after XUSB interfaces appear or disappear so existing devices can retry slot lookup.
+    /// </summary>
+    public event EventHandler? XInputInterfacesUpdated;
 }

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -12,13 +12,20 @@ using Nefarius.Utilities.DeviceManagement.PnP;
 namespace Nefarius.DsHidMini.ControlApp.Models.Util;
 
 /// <summary>
-///     Resolves the Windows XInput user index (0-3) for a DsHidMini device in XInput HID mode by matching the
-///     controller's XUSB interface (via PnP base container ID) and issuing the same LED IOCTL as XInputBridge
-///     GlobalState::SymlinkToUserIndex.
+///     Resolves the Windows XInput user index (0-3) for a DsHidMini device in XInput HID mode.
+///     USB typically exposes an XUSB interface that can be matched by PnP container ID (same LED IOCTL as
+///     XInputBridge). Bluetooth XInput HID devices often have no XUSB interface and only the machine-wide
+///     container ID, so resolution also walks HID children and, when unique, the occupied XInput slots.
 /// </summary>
 internal static class XInputSlotResolver
 {
     private const byte InvalidXInputUserId = 0xFF;
+
+    /// <summary>
+    ///     Windows reports this container for devices that are not part of a unique physical device group
+    ///     (typical for BTHPS3 Bluetooth stacks). It must not be used to pair siblings.
+    /// </summary>
+    private static readonly Guid LocalMachineContainerId = Guid.Parse("00000000-0000-0000-FFFF-FFFFFFFFFFFF");
 
     /// <summary>
     ///     Short-lived negative cache to avoid hammering PnP/XUSB on repeated misses without permanently
@@ -32,9 +39,11 @@ internal static class XInputSlotResolver
     // Same IOCTL (0x8000E008) as XInputBridge GlobalState::SymlinkToUserIndex.
     private const uint IoctlXusbGetLedState = 0x8000E008;
 
-    private static readonly ConcurrentDictionary<Guid, byte> ResolutionCacheByBaseContainer = new();
+    private static readonly ConcurrentDictionary<string, byte> ResolutionCacheByInstanceId =
+        new(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly ConcurrentDictionary<Guid, DateTime> NegativeResolutionExpiryByBaseContainer = new();
+    private static readonly ConcurrentDictionary<string, DateTime> NegativeResolutionExpiryByInstanceId =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     ///     Cache-generation token incremented when caches are invalidated to prevent stale writes after a clear.
@@ -44,8 +53,11 @@ internal static class XInputSlotResolver
     /// <summary>
     ///     XUSB device interface class GUID (see XInputBridge/Macros.h).
     /// </summary>
-    private static readonly Guid XusbInterfaceClassGuid =
+    internal static readonly Guid XusbDeviceInterfaceGuid =
         Guid.Parse("{EC87F1E3-C13B-4100-B5F7-8B84D54260CB}");
+
+    private static readonly Guid HidDeviceInterfaceGuid =
+        Guid.Parse("{4D1E55B2-F16F-11CF-88CB-001111000030}");
 
     private static SetupApiWrapper.DevPropKey ToDevPropKey(DevicePropertyKey key) =>
         new(key.CategoryGuid, key.PropertyIdentifier);
@@ -80,8 +92,8 @@ internal static class XInputSlotResolver
     public static void InvalidateResolutionCache()
     {
         Interlocked.Increment(ref _cacheGeneration);
-        ResolutionCacheByBaseContainer.Clear();
-        NegativeResolutionExpiryByBaseContainer.Clear();
+        ResolutionCacheByInstanceId.Clear();
+        NegativeResolutionExpiryByInstanceId.Clear();
     }
 
     /// <summary>
@@ -98,19 +110,16 @@ internal static class XInputSlotResolver
         bool ignoreNegativeCache = false)
     {
         userIndex = InvalidXInputUserId;
-        if (!TryGetBaseContainerId(dshmDevice.InstanceId, out Guid dshmContainer))
-        {
-            return false;
-        }
+        string instanceId = dshmDevice.InstanceId;
 
-        if (ResolutionCacheByBaseContainer.TryGetValue(dshmContainer, out byte cached))
+        if (ResolutionCacheByInstanceId.TryGetValue(instanceId, out byte cached))
         {
             userIndex = cached;
             return true;
         }
 
         if (!ignoreNegativeCache
-            && NegativeResolutionExpiryByBaseContainer.TryGetValue(dshmContainer, out DateTime negUntil)
+            && NegativeResolutionExpiryByInstanceId.TryGetValue(instanceId, out DateTime negUntil)
             && DateTime.UtcNow < negUntil)
         {
             return false;
@@ -119,14 +128,46 @@ internal static class XInputSlotResolver
         // Capture generation before resolving to prevent stale writes after InvalidateResolutionCache
         long generationSnapshot = Interlocked.Read(ref _cacheGeneration);
 
-        foreach (string xusbPath in EnumeratePresentXusbDeviceInterfacePaths())
+        if (TryResolveViaXusbContainer(dshmDevice, out userIndex)
+            || TryResolveViaXinputHidChild(dshmDevice, out userIndex)
+            || TryResolveViaUniqueOccupiedXinputSlot(dshmDevice, out userIndex))
+        {
+            if (Interlocked.Read(ref _cacheGeneration) == generationSnapshot)
+            {
+                NegativeResolutionExpiryByInstanceId.TryRemove(instanceId, out _);
+                ResolutionCacheByInstanceId[instanceId] = userIndex;
+            }
+
+            return true;
+        }
+
+        if (Interlocked.Read(ref _cacheGeneration) == generationSnapshot)
+        {
+            NegativeResolutionExpiryByInstanceId[instanceId] = DateTime.UtcNow.Add(NegativeResolutionCacheTtl);
+        }
+
+        userIndex = InvalidXInputUserId;
+        return false;
+    }
+
+    private static bool TryResolveViaXusbContainer(PnPDevice dshmDevice, out byte userIndex)
+    {
+        userIndex = InvalidXInputUserId;
+        if (!TryGetBaseContainerId(dshmDevice.InstanceId, out Guid dshmContainer)
+            || !IsUniqueContainerId(dshmContainer))
+        {
+            return false;
+        }
+
+        foreach (string xusbPath in EnumeratePresentDeviceInterfacePaths(XusbDeviceInterfaceGuid))
         {
             if (!TryGetDeviceInstanceIdFromInterfacePath(xusbPath, out string? xusbInstanceId))
             {
                 continue;
             }
 
-            if (!TryGetBaseContainerId(xusbInstanceId, out Guid xusbContainer) || xusbContainer != dshmContainer)
+            if (!TryGetBaseContainerId(xusbInstanceId, out Guid xusbContainer)
+                || xusbContainer != dshmContainer)
             {
                 continue;
             }
@@ -134,32 +175,154 @@ internal static class XInputSlotResolver
             if (TrySymlinkToUserIndex(xusbPath, out byte idx) && idx != InvalidXInputUserId)
             {
                 userIndex = idx;
-                // Only write to cache if generation hasn't changed (no InvalidateResolutionCache since we started)
-                if (Interlocked.Read(ref _cacheGeneration) == generationSnapshot)
-                {
-                    NegativeResolutionExpiryByBaseContainer.TryRemove(dshmContainer, out _);
-                    ResolutionCacheByBaseContainer[dshmContainer] = idx;
-                }
                 return true;
             }
         }
 
-        // Only write negative cache if generation hasn't changed
-        if (Interlocked.Read(ref _cacheGeneration) == generationSnapshot)
-        {
-            NegativeResolutionExpiryByBaseContainer[dshmContainer] = DateTime.UtcNow.Add(NegativeResolutionCacheTtl);
-        }
         return false;
     }
 
+    private static bool TryResolveViaXinputHidChild(PnPDevice dshmDevice, out byte userIndex)
+    {
+        userIndex = InvalidXInputUserId;
+        foreach (string hidPath in EnumeratePresentDeviceInterfacePaths(HidDeviceInterfaceGuid))
+        {
+            if (!TryGetDeviceInstanceIdFromInterfacePath(hidPath, out string? hidInstanceId)
+                || !IsXInputHidInstanceId(hidInstanceId)
+                || !TryGetParentInstanceId(hidInstanceId, out string? parentId)
+                || !InstanceIdsEqual(parentId, dshmDevice.InstanceId))
+            {
+                continue;
+            }
+
+            if (TrySymlinkToUserIndex(hidPath, out byte idx) && idx != InvalidXInputUserId)
+            {
+                userIndex = idx;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveViaUniqueOccupiedXinputSlot(PnPDevice dshmDevice, out byte userIndex)
+    {
+        userIndex = InvalidXInputUserId;
+        if (!HasXInputHidChild(dshmDevice))
+        {
+            return false;
+        }
+
+        int occupiedCount = 0;
+        byte occupiedIndex = InvalidXInputUserId;
+        for (byte i = 0; i < 4; i++)
+        {
+            if (!TryIsXinputSlotOccupied(i))
+            {
+                continue;
+            }
+
+            occupiedCount++;
+            occupiedIndex = i;
+        }
+
+        if (occupiedCount != 1)
+        {
+            return false;
+        }
+
+        userIndex = occupiedIndex;
+        return true;
+    }
+
+    private static bool HasXInputHidChild(PnPDevice dshmDevice)
+    {
+        foreach (string hidPath in EnumeratePresentDeviceInterfacePaths(HidDeviceInterfaceGuid))
+        {
+            if (TryGetDeviceInstanceIdFromInterfacePath(hidPath, out string? hidInstanceId)
+                && IsXInputHidInstanceId(hidInstanceId)
+                && TryGetParentInstanceId(hidInstanceId, out string? parentId)
+                && InstanceIdsEqual(parentId, dshmDevice.InstanceId))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsUniqueContainerId(Guid containerId) =>
+        containerId != Guid.Empty && containerId != LocalMachineContainerId;
+
+    private static bool IsXInputHidInstanceId(string instanceId) =>
+        instanceId.Contains("VID_045E", StringComparison.OrdinalIgnoreCase)
+        && instanceId.Contains("PID_02FF", StringComparison.OrdinalIgnoreCase);
+
+    private static bool InstanceIdsEqual(string? left, string? right) =>
+        !string.IsNullOrEmpty(left)
+        && !string.IsNullOrEmpty(right)
+        && string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryGetParentInstanceId(string instanceId, out string? parentId)
+    {
+        parentId = null;
+        try
+        {
+            PnPDevice device = PnPDevice.GetDeviceByInstanceId(instanceId);
+            parentId = device.GetProperty<string>(DevicePropertyKey.Device_Parent);
+            return !string.IsNullOrEmpty(parentId);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryIsXinputSlotOccupied(byte userIndex)
+    {
+        try
+        {
+            return XInputGetState(userIndex, out _) == 0;
+        }
+        catch (DllNotFoundException)
+        {
+            return false;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XinputGamepad
+    {
+        public ushort Buttons;
+        public byte LeftTrigger;
+        public byte RightTrigger;
+        public short ThumbLX;
+        public short ThumbLY;
+        public short ThumbRX;
+        public short ThumbRY;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XinputState
+    {
+        public uint PacketNumber;
+        public XinputGamepad Gamepad;
+    }
+
+    [DllImport("xinput1_4.dll", EntryPoint = "XInputGetState")]
+    private static extern uint XInputGetState(uint userIndex, out XinputState state);
+
     /// <summary>
-    ///     Yields symbolic link paths for all present device interfaces of class <see cref="XusbInterfaceClassGuid" />.
+    ///     Yields symbolic link paths for all present device interfaces of the given class.
     /// </summary>
-    /// <returns>Device interface paths (e.g. for use with <see cref="TrySymlinkToUserIndex" />).</returns>
-    private static IEnumerable<string> EnumeratePresentXusbDeviceInterfacePaths()
+    private static IEnumerable<string> EnumeratePresentDeviceInterfacePaths(Guid interfaceClassGuid)
     {
         uint lenChars = 0;
-        Guid g = XusbInterfaceClassGuid;
+        Guid g = interfaceClassGuid;
         SetupApiWrapper.ConfigManagerResult r = SetupApiWrapper.CM_Get_Device_Interface_List_SizeW(
             ref lenChars,
             ref g,

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -128,9 +128,10 @@ internal static class XInputSlotResolver
         // Capture generation before resolving to prevent stale writes after InvalidateResolutionCache
         long generationSnapshot = Interlocked.Read(ref _cacheGeneration);
 
+        IReadOnlyList<XinputHidChild> xinputHidChildren = EnumerateXinputHidChildren();
         if (TryResolveViaXusbContainer(dshmDevice, out userIndex)
-            || TryResolveViaXinputHidChild(dshmDevice, out userIndex)
-            || TryResolveViaUniqueOccupiedXinputSlot(dshmDevice, out userIndex))
+            || TryResolveViaXinputHidChild(dshmDevice, xinputHidChildren, out userIndex)
+            || TryResolveViaUniqueOccupiedXinputSlot(dshmDevice, xinputHidChildren, out userIndex))
         {
             if (Interlocked.Read(ref _cacheGeneration) == generationSnapshot)
             {
@@ -182,20 +183,39 @@ internal static class XInputSlotResolver
         return false;
     }
 
-    private static bool TryResolveViaXinputHidChild(PnPDevice dshmDevice, out byte userIndex)
+    private readonly record struct XinputHidChild(string Path, string ParentInstanceId);
+
+    private static List<XinputHidChild> EnumerateXinputHidChildren()
     {
-        userIndex = InvalidXInputUserId;
+        List<XinputHidChild> children = [];
         foreach (string hidPath in EnumeratePresentDeviceInterfacePaths(HidDeviceInterfaceGuid))
         {
             if (!TryGetDeviceInstanceIdFromInterfacePath(hidPath, out string? hidInstanceId)
                 || !IsXInputHidInstanceId(hidInstanceId)
                 || !TryGetParentInstanceId(hidInstanceId, out string? parentId)
-                || !InstanceIdsEqual(parentId, dshmDevice.InstanceId))
+                || parentId is null)
             {
                 continue;
             }
 
-            if (TrySymlinkToUserIndex(hidPath, out byte idx) && idx != InvalidXInputUserId)
+            children.Add(new XinputHidChild(hidPath, parentId));
+        }
+
+        return children;
+    }
+
+    private static bool TryResolveViaXinputHidChild(PnPDevice dshmDevice,
+        IReadOnlyList<XinputHidChild> xinputHidChildren, out byte userIndex)
+    {
+        userIndex = InvalidXInputUserId;
+        foreach (XinputHidChild child in xinputHidChildren)
+        {
+            if (!InstanceIdsEqual(child.ParentInstanceId, dshmDevice.InstanceId))
+            {
+                continue;
+            }
+
+            if (TrySymlinkToUserIndex(child.Path, out byte idx) && idx != InvalidXInputUserId)
             {
                 userIndex = idx;
                 return true;
@@ -205,10 +225,13 @@ internal static class XInputSlotResolver
         return false;
     }
 
-    private static bool TryResolveViaUniqueOccupiedXinputSlot(PnPDevice dshmDevice, out byte userIndex)
+    private static bool TryResolveViaUniqueOccupiedXinputSlot(PnPDevice dshmDevice,
+        IReadOnlyList<XinputHidChild> xinputHidChildren, out byte userIndex)
     {
         userIndex = InvalidXInputUserId;
-        if (!HasXInputHidChild(dshmDevice))
+        int xinputDshmDeviceCount = CountXinputModeDshmDevices(xinputHidChildren);
+        if (xinputDshmDeviceCount != 1
+            || !HasXInputHidChild(dshmDevice, xinputHidChildren))
         {
             return false;
         }
@@ -235,14 +258,22 @@ internal static class XInputSlotResolver
         return true;
     }
 
-    private static bool HasXInputHidChild(PnPDevice dshmDevice)
+    private static int CountXinputModeDshmDevices(IReadOnlyList<XinputHidChild> xinputHidChildren)
     {
-        foreach (string hidPath in EnumeratePresentDeviceInterfacePaths(HidDeviceInterfaceGuid))
+        HashSet<string> parents = new(StringComparer.OrdinalIgnoreCase);
+        foreach (XinputHidChild child in xinputHidChildren)
         {
-            if (TryGetDeviceInstanceIdFromInterfacePath(hidPath, out string? hidInstanceId)
-                && IsXInputHidInstanceId(hidInstanceId)
-                && TryGetParentInstanceId(hidInstanceId, out string? parentId)
-                && InstanceIdsEqual(parentId, dshmDevice.InstanceId))
+            parents.Add(child.ParentInstanceId);
+        }
+
+        return parents.Count;
+    }
+
+    private static bool HasXInputHidChild(PnPDevice dshmDevice, IReadOnlyList<XinputHidChild> xinputHidChildren)
+    {
+        foreach (XinputHidChild child in xinputHidChildren)
+        {
+            if (InstanceIdsEqual(child.ParentInstanceId, dshmDevice.InstanceId))
             {
                 return true;
             }

--- a/ControlApp/Models/Util/XInputSlotResolver.cs
+++ b/ControlApp/Models/Util/XInputSlotResolver.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 
 using Windows.Win32;
@@ -88,7 +88,14 @@ internal static class XInputSlotResolver
     ///     Returns the XInput user index (0-3) for this DsHidMini device, or false if it cannot be determined.
     ///     Call only when the device is in XInput HID mode.
     /// </summary>
-    internal static bool TryGetXInputUserIndex(PnPDevice dshmDevice, out byte userIndex)
+    /// <param name="dshmDevice">The DsHidMini PnP device to resolve.</param>
+    /// <param name="userIndex">Receives the XInput user index (0-3) on success.</param>
+    /// <param name="ignoreNegativeCache">
+    ///     When true, skip the short-lived miss cache so a scheduled retry can re-query PnP/XUSB.
+    ///     Successful slot entries and cache-generation guards stay in effect.
+    /// </param>
+    internal static bool TryGetXInputUserIndex(PnPDevice dshmDevice, out byte userIndex,
+        bool ignoreNegativeCache = false)
     {
         userIndex = InvalidXInputUserId;
         if (!TryGetBaseContainerId(dshmDevice.InstanceId, out Guid dshmContainer))
@@ -102,7 +109,8 @@ internal static class XInputSlotResolver
             return true;
         }
 
-        if (NegativeResolutionExpiryByBaseContainer.TryGetValue(dshmContainer, out DateTime negUntil)
+        if (!ignoreNegativeCache
+            && NegativeResolutionExpiryByBaseContainer.TryGetValue(dshmContainer, out DateTime negUntil)
             && DateTime.UtcNow < negUntil)
         {
             return false;

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Threading;
 
 using Nefarius.DsHidMini.ControlApp.Models;
@@ -63,6 +63,7 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
         _dshmConfigManager = dshmConfigManager;
         _appSnackbarMessagesService = appSnackbarMessagesService;
         _dshmDevMan.ConnectedDeviceListUpdated += OnConnectedDevicesListUpdated;
+        _dshmDevMan.XInputInterfacesUpdated += OnXInputInterfacesUpdated;
         _dshmConfigManager.DshmConfigurationUpdated += OnDshmConfigUpdated;
         _contentDialogService = contentDialogService;
         _addressValidator = addressValidator;
@@ -112,6 +113,24 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
     private void OnConnectedDevicesListUpdated(object? obj, EventArgs? eventArgs)
     {
         RefreshDevicesList();
+    }
+
+    private void OnXInputInterfacesUpdated(object? obj, EventArgs? eventArgs)
+    {
+        Application.Current?.Dispatcher.BeginInvoke(new Action(async void () =>
+        {
+            try
+            {
+                foreach (DeviceViewModel device in Devices.ToList())
+                {
+                    await device.RefreshXInputSlotAsync();
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Logger.Error(e, "Error refreshing XInput slots after XUSB change");
+            }
+        }));
     }
 
     [RelayCommand]

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -30,6 +30,13 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
 
     private int _xInputSlotRefreshGeneration;
 
+    private static readonly TimeSpan[] XInputSlotRetryDelays =
+    [
+        TimeSpan.FromMilliseconds(250),
+        TimeSpan.FromMilliseconds(500),
+        TimeSpan.FromSeconds(1)
+    ];
+
     private readonly DeviceData _deviceUserData;
 
     // ------------------------------------------------------ FIELDS
@@ -597,6 +604,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        Interlocked.Increment(ref _xInputSlotRefreshGeneration);
         _batteryQuery.Dispose();
         GC.SuppressFinalize(this);
     }
@@ -678,11 +686,70 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         }
 
         PnPDevice device = Device;
-        (bool ok, byte userIndex) = await Task.Run(() =>
+        (bool ok, byte userIndex) = await ResolveXInputUserIndexAsync(device, ignoreNegativeCache: false);
+        if (await TryApplyXInputSlotResultAsync(refreshGeneration, ok, userIndex))
         {
-            bool success = XInputSlotResolver.TryGetXInputUserIndex(device, out byte idx);
+            return;
+        }
+
+        _ = RetryXInputSlotLabelAsync(refreshGeneration, device);
+    }
+
+    private async Task RetryXInputSlotLabelAsync(int refreshGeneration, PnPDevice device)
+    {
+        try
+        {
+            foreach (TimeSpan delay in XInputSlotRetryDelays)
+            {
+                await Task.Delay(delay);
+                if (refreshGeneration != _xInputSlotRefreshGeneration)
+                {
+                    return;
+                }
+
+                (bool ok, byte userIndex) = await ResolveXInputUserIndexAsync(device, ignoreNegativeCache: true);
+                if (await TryApplyXInputSlotResultAsync(refreshGeneration, ok, userIndex))
+                {
+                    return;
+                }
+            }
+
+            await ApplyXInputSlotLabelsAsync(refreshGeneration, "Unavailable", "XInput: Unavailable");
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "XInput slot retry failed for device '{Address}'", DeviceAddress);
+        }
+    }
+
+    private static Task<(bool ok, byte userIndex)> ResolveXInputUserIndexAsync(PnPDevice device,
+        bool ignoreNegativeCache)
+    {
+        return Task.Run(() =>
+        {
+            bool success = XInputSlotResolver.TryGetXInputUserIndex(device, out byte idx, ignoreNegativeCache);
             return (success, idx);
         });
+    }
+
+    private async Task<bool> TryApplyXInputSlotResultAsync(int refreshGeneration, bool ok, byte userIndex)
+    {
+        if (!ok)
+        {
+            return false;
+        }
+
+        await ApplyXInputSlotLabelsAsync(refreshGeneration, $"Player {userIndex + 1}",
+            $"XInput: Player {userIndex + 1}");
+        return true;
+    }
+
+    private async Task ApplyXInputSlotLabelsAsync(int refreshGeneration, string detail, string banner)
+    {
+        if (Application.Current is null)
+        {
+            return;
+        }
 
         await Application.Current.Dispatcher.InvokeAsync(() =>
         {
@@ -699,16 +766,8 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
             }
 
             OnPropertyChanged(nameof(IsXInputHidMode));
-            if (ok)
-            {
-                XInputSlotDetail = $"Player {userIndex + 1}";
-                XInputSlotBanner = $"XInput: Player {userIndex + 1}";
-            }
-            else
-            {
-                XInputSlotDetail = "Unavailable";
-                XInputSlotBanner = "XInput: Unavailable";
-            }
+            XInputSlotDetail = detail;
+            XInputSlotBanner = banner;
         });
     }
 

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -30,11 +30,17 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
 
     private int _xInputSlotRefreshGeneration;
 
+    /// <summary>
+    ///     Backoff after an XInput miss. Wireless XUSB interfaces and LED slot assignment
+    ///     often appear several seconds after the DsHidMini device itself.
+    /// </summary>
     private static readonly TimeSpan[] XInputSlotRetryDelays =
     [
         TimeSpan.FromMilliseconds(250),
         TimeSpan.FromMilliseconds(500),
-        TimeSpan.FromSeconds(1)
+        TimeSpan.FromSeconds(1),
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(4)
     ];
 
     private readonly DeviceData _deviceUserData;
@@ -672,6 +678,11 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(BluetoothOutputReportTransport));
         await RefreshXInputSlotLabelAsync();
     }
+
+    /// <summary>
+    ///     Re-resolves the XInput player slot without reloading the rest of the device settings.
+    /// </summary>
+    internal Task RefreshXInputSlotAsync() => RefreshXInputSlotLabelAsync();
 
     private async Task RefreshXInputSlotLabelAsync()
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and assignment of XInput player slots, including wireless controllers.
  * Added automatic retries when slot information is temporarily unavailable.
  * Updated player-slot labels when XInput interfaces change without reloading the device list.
  * Improved handling of controller connections, disconnections, and reassignment.
  * Improved slot resolution for controllers with multiple related interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->