### PR TITLE
Require .NET 10 Desktop for ControlApp and fail BuildSetup if the MSI…

### DIFF
--- a/ControlApp.Tests/ControlApp.Tests.csproj
+++ b/ControlApp.Tests/ControlApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows10.0.17763.0</TargetFramework>
+        <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>

--- a/ControlApp/ControlApp.csproj
+++ b/ControlApp/ControlApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0-windows10.0.17763.0</TargetFramework>
+        <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <ApplicationIcon>..\assets\FireShock.ico</ApplicationIcon>

--- a/ControlApp/README.md
+++ b/ControlApp/README.md
@@ -1,6 +1,6 @@
 # <img src="../assets/FireShock.png" align="left" /> DsHidMini ControlApp
 
-![Requirements](https://img.shields.io/badge/Requires-.NET%209.0-blue.svg)
+![Requirements](https://img.shields.io/badge/Requires-.NET%2010-blue.svg)
 ![Platform](https://img.shields.io/badge/Platform-Windows%2010%2B-lightgrey.svg)
 
 **Desktop control application for the DsHidMini driver.**  
@@ -36,8 +36,8 @@ Configuration is stored under **%AppData%**; the app does not require administra
 
 | Requirement | Details |
 |-------------|---------|
-| **.NET** | .NET 9.0 |
-| **OS** | Windows 10 or later (targeting `net9.0-windows10.0.17763.0`) |
+| **.NET** | .NET 10 Desktop Runtime (x64) |
+| **OS** | Windows 10 or later (targeting `net10.0-windows10.0.17763.0`) |
 | **Driver** | [DsHidMini](https://github.com/ViGEm/DsHidMini) driver installed; at least one compatible controller connected for full functionality |
 | **Architecture** | AnyCPU or x64 (NUKE publish uses win-x64) |
 

--- a/build/ReleasePipeline.cs
+++ b/build/ReleasePipeline.cs
@@ -562,6 +562,11 @@ static class ReleaseStaging
         return report;
     }
 
+    public static void ValidateGeneratedMsi(string msiPath)
+    {
+        SetupMsiContract.ValidateGeneratedMsi(msiPath);
+    }
+
     public static IReadOnlyList<string> ParseIssuedTo(string signToolOutput)
     {
         if (string.IsNullOrWhiteSpace(signToolOutput))

--- a/build/ReleasePipelineTests.cs
+++ b/build/ReleasePipelineTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -16,6 +17,10 @@ static class ReleasePipelineTests
         TestIgfilterStaging();
         TestSetupValidationWithoutSignatures();
         TestSignatureParser();
+        TestSetupMsiContractAcceptsControlAppPayload();
+        TestSetupMsiContractRejectsMissingControlApp();
+        TestSetupMsiContractRejectsMissingShortcut();
+        TestSetupMsiContractRejectsMissingDotNetPrerequisite();
         Console.WriteLine("ReleasePipeline fixture tests passed");
     }
 
@@ -188,6 +193,110 @@ static class ReleasePipelineTests
             () => ReleaseStaging.RequireDualDriverSigners(["Microsoft Windows Hardware Compatibility Publisher"], "dshidmini.dll"),
             "microsoft-only rejected");
     }
+
+    static void TestSetupMsiContractAcceptsControlAppPayload()
+    {
+        IReadOnlyList<string> errors = SetupMsiContract.Validate(ValidSetupMsiContents());
+        AssertTrue(errors.Count == 0, nameof(TestSetupMsiContractAcceptsControlAppPayload));
+        AssertTrue(
+            SetupMsiContract.ContainsMsiName(["CONTRO~1.EXE|ControlApp.exe"], SetupMsiContract.ControlAppFileName),
+            "decodes MSI long file name");
+        AssertEqual(
+            SetupMsiContract.DecodeMsiName("DSHIDM~1|DsHidMini Control App"),
+            SetupMsiContract.ControlAppShortcutName,
+            "decodes MSI long shortcut name");
+    }
+
+    static void TestSetupMsiContractRejectsMissingControlApp()
+    {
+        SetupMsiContents contents = ValidSetupMsiContents() with { FileNames = ["dshidmini.dll"] };
+        IReadOnlyList<string> errors = SetupMsiContract.Validate(contents);
+        AssertTrue(errors.Any(error => error.Contains(SetupMsiContract.ControlAppFileName, StringComparison.Ordinal)),
+            nameof(TestSetupMsiContractRejectsMissingControlApp));
+    }
+
+    static void TestSetupMsiContractRejectsMissingShortcut()
+    {
+        SetupMsiContents contents = ValidSetupMsiContents() with { ShortcutNames = ["Unrelated"] };
+        IReadOnlyList<string> errors = SetupMsiContract.Validate(contents);
+        AssertTrue(
+            errors.Any(error => error.Contains(SetupMsiContract.ControlAppShortcutName, StringComparison.Ordinal)),
+            nameof(TestSetupMsiContractRejectsMissingShortcut));
+    }
+
+    static void TestSetupMsiContractRejectsMissingDotNetPrerequisite()
+    {
+        SetupMsiContents missingAction = ValidSetupMsiContents() with { CustomActions = [] };
+        AssertTrue(
+            SetupMsiContract.Validate(missingAction)
+                .Any(error => error.Contains(SetupMsiContract.DotNetRuntimeCustomAction, StringComparison.Ordinal)),
+            "missing custom action");
+
+        SetupMsiContents missingCondition = ValidSetupMsiContents() with
+        {
+            SequenceEntries =
+            [
+                new SetupMsiSequenceEntry
+                {
+                    Table = "InstallExecuteSequence",
+                    Action = SetupMsiContract.DotNetRuntimeCustomAction,
+                    Condition = "Installed"
+                }
+            ]
+        };
+        AssertTrue(
+            SetupMsiContract.Validate(missingCondition)
+                .Any(error => error.Contains(SetupMsiContract.NotInstalledCondition, StringComparison.Ordinal)),
+            "missing NOT Installed condition");
+
+        SetupMsiContents staleRuntimeError = ValidSetupMsiContents() with
+        {
+            Errors =
+            [
+                new SetupMsiError
+                {
+                    Id = SetupMsiContract.DotNetRuntimeErrorId,
+                    Message = "The .NET 9 Desktop Runtime (x64) is required by DsHidMini Control App."
+                }
+            ]
+        };
+        AssertTrue(
+            SetupMsiContract.Validate(staleRuntimeError)
+                .Any(error => error.Contains(SetupMsiContract.DotNetRuntimeErrorHint, StringComparison.Ordinal)),
+            "stale .NET 9 error text");
+    }
+
+    static SetupMsiContents ValidSetupMsiContents() => new()
+    {
+        FileNames = ["CONTRO~1.EXE|ControlApp.exe"],
+        ShortcutNames = ["DSHIDM~1|DsHidMini Control App"],
+        CustomActions =
+        [
+            new SetupMsiCustomAction
+            {
+                Id = SetupMsiContract.DotNetRuntimeCustomAction,
+                Source = "ActionRuntime.dll",
+                Target = SetupMsiContract.DotNetRuntimeCustomAction
+            }
+        ],
+        SequenceEntries =
+        [
+            new SetupMsiSequenceEntry
+            {
+                Table = "InstallExecuteSequence",
+                Action = SetupMsiContract.DotNetRuntimeCustomAction,
+                Condition = SetupMsiContract.NotInstalledCondition
+            }
+        ],
+        Errors =
+        [
+            new SetupMsiError
+            {
+                Id = SetupMsiContract.DotNetRuntimeErrorId,
+                Message = "The .NET 10 Desktop Runtime (x64) is required by DsHidMini Control App."
+            }
+        ]
+    };
 
     static ReleaseMetadata SampleMetadata() => new()
     {

--- a/build/ReleasePipelineTests.cs
+++ b/build/ReleasePipelineTests.cs
@@ -21,6 +21,7 @@ static class ReleasePipelineTests
         TestSetupMsiContractRejectsMissingControlApp();
         TestSetupMsiContractRejectsMissingShortcut();
         TestSetupMsiContractRejectsMissingDotNetPrerequisite();
+        TestSetupMsiContractRejectsNearMatchAndUiOnlyRuntimeAction();
         Console.WriteLine("ReleasePipeline fixture tests passed");
     }
 
@@ -264,6 +265,52 @@ static class ReleasePipelineTests
             SetupMsiContract.Validate(staleRuntimeError)
                 .Any(error => error.Contains(SetupMsiContract.DotNetRuntimeErrorHint, StringComparison.Ordinal)),
             "stale .NET 9 error text");
+    }
+
+    static void TestSetupMsiContractRejectsNearMatchAndUiOnlyRuntimeAction()
+    {
+        SetupMsiContents nearMatch = ValidSetupMsiContents() with
+        {
+            CustomActions =
+            [
+                new SetupMsiCustomAction
+                {
+                    Id = "CheckDotNetRuntimeProbe",
+                    Source = "ActionRuntime.dll",
+                    Target = SetupMsiContract.DotNetRuntimeCustomAction
+                }
+            ],
+            SequenceEntries =
+            [
+                new SetupMsiSequenceEntry
+                {
+                    Table = "InstallExecuteSequence",
+                    Action = "CheckDotNetRuntimeProbe",
+                    Condition = SetupMsiContract.NotInstalledCondition
+                }
+            ]
+        };
+        AssertTrue(
+            SetupMsiContract.Validate(nearMatch)
+                .Any(error => error.Contains(SetupMsiContract.DotNetRuntimeCustomAction, StringComparison.Ordinal)),
+            "near-match custom action");
+
+        SetupMsiContents uiOnly = ValidSetupMsiContents() with
+        {
+            SequenceEntries =
+            [
+                new SetupMsiSequenceEntry
+                {
+                    Table = "InstallUISequence",
+                    Action = SetupMsiContract.DotNetRuntimeCustomAction,
+                    Condition = SetupMsiContract.NotInstalledCondition
+                }
+            ]
+        };
+        AssertTrue(
+            SetupMsiContract.Validate(uiOnly)
+                .Any(error => error.Contains("InstallExecuteSequence", StringComparison.Ordinal)),
+            "UI-only sequence");
     }
 
     static SetupMsiContents ValidSetupMsiContents() => new()

--- a/build/ReleaseTargets.cs
+++ b/build/ReleaseTargets.cs
@@ -198,6 +198,10 @@ partial class Build
                 throw new InvalidOperationException($"MSI not found: {msiInSetup} or {msiInBin}");
             }
 
+            ReleaseStaging.ValidateGeneratedMsi(msiPath);
+            Log.Information(
+                "Generated MSI includes ControlApp.exe, the Start Menu shortcut, and the .NET 10 Desktop prerequisite");
+
             InvokeSignTool(
                 $"sign /v /n \"{SignCertName}\" /tr {SignTimestampUrl} /fd sha256 /td sha256 \"{msiPath}\"");
             ReleaseStaging.RequirePublisherSigner(

--- a/build/SetupMsiContract.cs
+++ b/build/SetupMsiContract.cs
@@ -44,34 +44,23 @@ static class SetupMsiContract
             errors.Add($"Shortcut table is missing '{ControlAppShortcutName}'.");
         }
 
-        IReadOnlyList<SetupMsiCustomAction> runtimeActions = contents.CustomActions
-            .Where(action =>
-                ContainsIgnoreCase(action.Id, DotNetRuntimeCustomAction) ||
-                ContainsIgnoreCase(action.Source, DotNetRuntimeCustomAction) ||
-                ContainsIgnoreCase(action.Target, DotNetRuntimeCustomAction))
-            .ToArray();
+        bool hasRuntimeAction = contents.CustomActions.Any(action =>
+            string.Equals(action.Id, DotNetRuntimeCustomAction, StringComparison.OrdinalIgnoreCase));
 
-        if (runtimeActions.Count == 0)
+        if (!hasRuntimeAction)
         {
             errors.Add($"CustomAction table is missing {DotNetRuntimeCustomAction}.");
         }
 
-        HashSet<string> runtimeActionIds = new(
-            runtimeActions.Select(action => action.Id).Where(id => !string.IsNullOrWhiteSpace(id)),
-            StringComparer.OrdinalIgnoreCase);
-        if (runtimeActionIds.Count == 0)
-        {
-            runtimeActionIds.Add(DotNetRuntimeCustomAction);
-        }
-
         bool sequenced = contents.SequenceEntries.Any(entry =>
-            runtimeActionIds.Contains(entry.Action) &&
+            string.Equals(entry.Table, "InstallExecuteSequence", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(entry.Action, DotNetRuntimeCustomAction, StringComparison.OrdinalIgnoreCase) &&
             ContainsIgnoreCase(entry.Condition, NotInstalledCondition));
 
         if (!sequenced)
         {
             errors.Add(
-                $"{DotNetRuntimeCustomAction} is missing from InstallExecuteSequence/InstallUISequence " +
+                $"{DotNetRuntimeCustomAction} is missing from InstallExecuteSequence " +
                 $"with condition '{NotInstalledCondition}'.");
         }
 

--- a/build/SetupMsiContract.cs
+++ b/build/SetupMsiContract.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform("windows")]
+static class SetupMsiContract
+{
+    public const string ControlAppFileName = "ControlApp.exe";
+    public const string ControlAppShortcutName = "DsHidMini Control App";
+    public const string DotNetRuntimeCustomAction = "CheckDotNetRuntime";
+    public const string DotNetRuntimeErrorId = "9001";
+    public const string DotNetRuntimeErrorHint = ".NET 10 Desktop Runtime";
+    public const string NotInstalledCondition = "NOT Installed";
+
+    public static void ValidateGeneratedMsi(string msiPath)
+    {
+        IReadOnlyList<string> errors = Validate(ReadMsi(msiPath));
+        if (errors.Count == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Generated MSI is missing the ControlApp packaging contract:" + Environment.NewLine +
+            string.Join(Environment.NewLine, errors.Select(error => "- " + error)));
+    }
+
+    public static IReadOnlyList<string> Validate(SetupMsiContents contents)
+    {
+        ArgumentNullException.ThrowIfNull(contents);
+
+        List<string> errors = [];
+
+        if (!ContainsMsiName(contents.FileNames, ControlAppFileName))
+        {
+            errors.Add($"File table is missing {ControlAppFileName}.");
+        }
+
+        if (!ContainsMsiName(contents.ShortcutNames, ControlAppShortcutName))
+        {
+            errors.Add($"Shortcut table is missing '{ControlAppShortcutName}'.");
+        }
+
+        IReadOnlyList<SetupMsiCustomAction> runtimeActions = contents.CustomActions
+            .Where(action =>
+                ContainsIgnoreCase(action.Id, DotNetRuntimeCustomAction) ||
+                ContainsIgnoreCase(action.Source, DotNetRuntimeCustomAction) ||
+                ContainsIgnoreCase(action.Target, DotNetRuntimeCustomAction))
+            .ToArray();
+
+        if (runtimeActions.Count == 0)
+        {
+            errors.Add($"CustomAction table is missing {DotNetRuntimeCustomAction}.");
+        }
+
+        HashSet<string> runtimeActionIds = new(
+            runtimeActions.Select(action => action.Id).Where(id => !string.IsNullOrWhiteSpace(id)),
+            StringComparer.OrdinalIgnoreCase);
+        if (runtimeActionIds.Count == 0)
+        {
+            runtimeActionIds.Add(DotNetRuntimeCustomAction);
+        }
+
+        bool sequenced = contents.SequenceEntries.Any(entry =>
+            runtimeActionIds.Contains(entry.Action) &&
+            ContainsIgnoreCase(entry.Condition, NotInstalledCondition));
+
+        if (!sequenced)
+        {
+            errors.Add(
+                $"{DotNetRuntimeCustomAction} is missing from InstallExecuteSequence/InstallUISequence " +
+                $"with condition '{NotInstalledCondition}'.");
+        }
+
+        bool runtimeError = contents.Errors.Any(error =>
+            string.Equals(error.Id, DotNetRuntimeErrorId, StringComparison.OrdinalIgnoreCase) &&
+            ContainsIgnoreCase(error.Message, DotNetRuntimeErrorHint));
+
+        if (!runtimeError)
+        {
+            errors.Add(
+                $"Error {DotNetRuntimeErrorId} must mention '{DotNetRuntimeErrorHint}'.");
+        }
+
+        return errors;
+    }
+
+    public static SetupMsiContents ReadMsi(string msiPath)
+    {
+        if (!File.Exists(msiPath))
+        {
+            throw new InvalidOperationException($"MSI not found: {msiPath}");
+        }
+
+        Type installerType = Type.GetTypeFromProgID("WindowsInstaller.Installer")
+                             ?? throw new InvalidOperationException(
+                                 "Windows Installer COM (WindowsInstaller.Installer) is unavailable.");
+
+        object installer = Activator.CreateInstance(installerType)
+                           ?? throw new InvalidOperationException("Failed to create Windows Installer COM object.");
+        object database = null;
+        try
+        {
+            database = installerType.InvokeMember(
+                "OpenDatabase",
+                System.Reflection.BindingFlags.InvokeMethod,
+                binder: null,
+                target: installer,
+                args: [msiPath, 0]);
+
+            HashSet<string> tables = new(ReadColumn(database, "SELECT `Name` FROM `_Tables`"), StringComparer.OrdinalIgnoreCase);
+            return new SetupMsiContents
+            {
+                FileNames = tables.Contains("File")
+                    ? ReadColumn(database, "SELECT `FileName` FROM `File`")
+                    : [],
+                ShortcutNames = tables.Contains("Shortcut")
+                    ? ReadColumn(database, "SELECT `Name` FROM `Shortcut`")
+                    : [],
+                CustomActions = tables.Contains("CustomAction")
+                    ? ReadCustomActions(database)
+                    : [],
+                SequenceEntries = ReadSequenceEntries(database, tables),
+                Errors = tables.Contains("Error")
+                    ? ReadErrors(database)
+                    : []
+            };
+        }
+        finally
+        {
+            ReleaseCom(database);
+            ReleaseCom(installer);
+        }
+    }
+
+    public static bool ContainsMsiName(IEnumerable<string> values, string expected)
+    {
+        return values.Any(value =>
+            string.Equals(DecodeMsiName(value), expected, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static string DecodeMsiName(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        int pipe = value.IndexOf('|');
+        return pipe >= 0 ? value[(pipe + 1)..] : value;
+    }
+
+    static IReadOnlyList<SetupMsiCustomAction> ReadCustomActions(object database)
+    {
+        return ReadRows(database, "SELECT `Action`, `Source`, `Target` FROM `CustomAction`")
+            .Select(row => new SetupMsiCustomAction
+            {
+                Id = row.ElementAtOrDefault(0),
+                Source = row.ElementAtOrDefault(1),
+                Target = row.ElementAtOrDefault(2)
+            })
+            .ToArray();
+    }
+
+    static IReadOnlyList<SetupMsiSequenceEntry> ReadSequenceEntries(object database, ISet<string> tables)
+    {
+        List<SetupMsiSequenceEntry> entries = [];
+        foreach (string table in new[] { "InstallExecuteSequence", "InstallUISequence" })
+        {
+            if (!tables.Contains(table))
+            {
+                continue;
+            }
+
+            entries.AddRange(
+                ReadRows(database, $"SELECT `Action`, `Condition` FROM `{table}`")
+                    .Select(row => new SetupMsiSequenceEntry
+                    {
+                        Table = table,
+                        Action = row.ElementAtOrDefault(0),
+                        Condition = row.ElementAtOrDefault(1)
+                    }));
+        }
+
+        return entries;
+    }
+
+    static IReadOnlyList<SetupMsiError> ReadErrors(object database)
+    {
+        return ReadRows(database, "SELECT `Error`, `Message` FROM `Error`")
+            .Select(row => new SetupMsiError
+            {
+                Id = row.ElementAtOrDefault(0),
+                Message = row.ElementAtOrDefault(1)
+            })
+            .ToArray();
+    }
+
+    static IReadOnlyList<string> ReadColumn(object database, string sql)
+    {
+        return ReadRows(database, sql)
+            .Select(row => row.ElementAtOrDefault(0))
+            .Where(value => !string.IsNullOrEmpty(value))
+            .ToArray();
+    }
+
+    static IReadOnlyList<string[]> ReadRows(object database, string sql)
+    {
+        object view = database.GetType().InvokeMember(
+            "OpenView",
+            System.Reflection.BindingFlags.InvokeMethod,
+            binder: null,
+            target: database,
+            args: [sql]);
+
+        try
+        {
+            view.GetType().InvokeMember(
+                "Execute",
+                System.Reflection.BindingFlags.InvokeMethod,
+                binder: null,
+                target: view,
+                args: [null]);
+
+            List<string[]> rows = [];
+            while (true)
+            {
+                object record = view.GetType().InvokeMember(
+                    "Fetch",
+                    System.Reflection.BindingFlags.InvokeMethod,
+                    binder: null,
+                    target: view,
+                    args: null);
+                if (record == null)
+                {
+                    break;
+                }
+
+                try
+                {
+                    int fieldCount = Convert.ToInt32(
+                        record.GetType().InvokeMember(
+                            "FieldCount",
+                            System.Reflection.BindingFlags.GetProperty,
+                            binder: null,
+                            target: record,
+                            args: null));
+                    string[] row = new string[fieldCount];
+                    for (int i = 1; i <= fieldCount; i++)
+                    {
+                        row[i - 1] = Convert.ToString(
+                            record.GetType().InvokeMember(
+                                "StringData",
+                                System.Reflection.BindingFlags.GetProperty,
+                                binder: null,
+                                target: record,
+                                args: [i]));
+                    }
+
+                    rows.Add(row);
+                }
+                finally
+                {
+                    ReleaseCom(record);
+                }
+            }
+
+            return rows;
+        }
+        finally
+        {
+            ReleaseCom(view);
+        }
+    }
+
+    static bool ContainsIgnoreCase(string value, string expected)
+    {
+        return !string.IsNullOrEmpty(value) &&
+               value.IndexOf(expected, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    static void ReleaseCom(object value)
+    {
+        if (value != null && Marshal.IsComObject(value))
+        {
+            Marshal.FinalReleaseComObject(value);
+        }
+    }
+}
+
+sealed record SetupMsiContents
+{
+    public IReadOnlyList<string> FileNames { get; init; } = [];
+
+    public IReadOnlyList<string> ShortcutNames { get; init; } = [];
+
+    public IReadOnlyList<SetupMsiCustomAction> CustomActions { get; init; } = [];
+
+    public IReadOnlyList<SetupMsiSequenceEntry> SequenceEntries { get; init; } = [];
+
+    public IReadOnlyList<SetupMsiError> Errors { get; init; } = [];
+}
+
+sealed class SetupMsiCustomAction
+{
+    public string Id { get; init; }
+
+    public string Source { get; init; }
+
+    public string Target { get; init; }
+}
+
+sealed class SetupMsiSequenceEntry
+{
+    public string Table { get; init; }
+
+    public string Action { get; init; }
+
+    public string Condition { get; init; }
+}
+
+sealed class SetupMsiError
+{
+    public string Id { get; init; }
+
+    public string Message { get; init; }
+}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -190,7 +190,12 @@ Output:
 setup\Nefarius_DsHidMini_Drivers_x64_arm64_v3.6.0.msi
 ```
 
-The target EV-signs the MSI, verifies the publisher signature, and logs the SHA-256. Building `setup/DsHidMini.Installer.csproj` without `GenerateMsi=true` only compiles; it does not emit an MSI.
+`BuildSetup` opens the generated MSI read-only and requires `ControlApp.exe` in the `File` table, the `DsHidMini Control App` Start Menu shortcut, and the `CheckDotNetRuntime` custom action sequenced with `NOT Installed` plus Error `9001` mentioning the .NET 10 Desktop Runtime. The target then EV-signs the MSI, verifies the publisher signature, and logs the SHA-256. Building `setup/DsHidMini.Installer.csproj` without `GenerateMsi=true` only compiles; it does not emit an MSI.
+
+Clean-VM smoke checks before publishing:
+
+- Windows x64 (and ARM64 if available) with the .NET 10 Desktop Runtime (x64) already installed: MSI installs the driver, `ControlApp.exe` is under Program Files, the Start Menu shortcut launches ControlApp.
+- The same machine family **without** that runtime: setup aborts with Error 9001 and does not leave a partial driver install.
 
 ### 7. Publish
 
@@ -232,6 +237,7 @@ gh release create setup-v3.6.0 `
 | DLL missing publisher signer | Microsoft package is not from this pipeline's EV-signed CAB |
 | `StageIgfilter` cannot find `nssmkig_ARM64` | Source tree is incomplete or named differently |
 | MSI build missing files | `ValidateSetupInputs` was skipped or staging was cleaned |
+| `BuildSetup` ControlApp packaging contract failed | Generated MSI omitted `ControlApp.exe`, the Start Menu shortcut, or the .NET 10 Desktop prerequisite |
 | `BuildSetup` SetupVersion mismatch | Typed `3.6.1` against a `v3.6.0` run |
 
 ## Related code

--- a/setup/InstallScript.cs
+++ b/setup/InstallScript.cs
@@ -108,7 +108,7 @@ internal class InstallScript
                     new FileShortcut("DsHidMini Control App",
                         @"%ProgramMenu%\Nefarius Software Solutions\DsHidMini"))
             ),
-            // check for .NET 9 Desktop Runtime before any files are laid down
+            // check for .NET 10 Desktop Runtime before any files are laid down
             new ManagedAction(CustomActions.CheckDotNetRuntime, Return.check,
                 When.Before,
                 Step.LaunchConditions,
@@ -122,10 +122,10 @@ internal class InstallScript
             new Error("9000",
                 "Driver installation succeeded but a reboot is required to be fully operational. " +
                 "After the setup is finished, please reboot the system before using the software."),
-            // .NET 9 Desktop Runtime missing
+            // .NET 10 Desktop Runtime missing
             new Error("9001",
-                "The .NET 9 Desktop Runtime (x64) is required by DsHidMini Control App. " +
-                "Please download and install it from https://dotnet.microsoft.com/download/dotnet/9.0 " +
+                "The .NET 10 Desktop Runtime (x64) is required by DsHidMini Control App. " +
+                "Please download and install it from https://dotnet.microsoft.com/download/dotnet/10.0 " +
                 "and then re-run this installer."),
             // install BthPS3
             new ManagedAction(CustomActions.InstallBthPS3, Return.check,
@@ -266,7 +266,7 @@ internal class InstallScript
 public static class CustomActions
 {
     /// <summary>
-    ///     Verifies that the .NET 9 Desktop Runtime (x64) is installed before setup proceeds.
+    ///     Verifies that the .NET 10 Desktop Runtime (x64) is installed before setup proceeds.
     ///     Aborts the install with a user-facing message when the runtime is absent.
     /// </summary>
     /// <remarks>
@@ -278,6 +278,7 @@ public static class CustomActions
     [CustomAction]
     public static ActionResult CheckDotNetRuntime(Session session)
     {
+        const int requiredMajor = 10;
         string runtimeDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
             "dotnet", "shared", "Microsoft.WindowsDesktop.App");
@@ -291,11 +292,11 @@ public static class CustomActions
                 foreach (string versionDir in Directory.GetDirectories(runtimeDir))
                 {
                     string dirName = Path.GetFileName(versionDir);
-                    // strip pre-release suffix (e.g. "9.0.0-preview.3") before parsing
+                    // strip pre-release suffix (e.g. "10.0.0-preview.3") before parsing
                     int dashIndex = dirName.IndexOf('-');
                     string numericPart = dashIndex >= 0 ? dirName.Substring(0, dashIndex) : dirName;
                     if (Version.TryParse(numericPart, out Version? installedVersion) &&
-                        installedVersion.Major >= 9)
+                        installedVersion.Major >= requiredMajor)
                     {
                         session.Log($".NET Desktop Runtime {installedVersion} found - prerequisite satisfied.");
                         return ActionResult.Success;
@@ -305,10 +306,10 @@ public static class CustomActions
         }
         catch (Exception ex)
         {
-            session.Log($"Failed to probe .NET 9 Desktop Runtime directory: {ex}");
+            session.Log($"Failed to probe .NET {requiredMajor} Desktop Runtime directory: {ex}");
         }
 
-        session.Log(".NET 9 Desktop Runtime not found, aborting installation.");
+        session.Log($".NET {requiredMajor} Desktop Runtime not found, aborting installation.");
 
         Record record = new(1);
         record[1] = "9001";

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,6 +1,6 @@
 # DsHidMini setup
 
-WixSharp MSI that installs the dual-architecture DsHidMini driver, `igfilter`, ControlApp, nefcon, and the vicius-based updater.
+WixSharp MSI that installs the dual-architecture DsHidMini driver, `igfilter`, ControlApp, nefcon, and the vicius-based updater. ControlApp is a framework-dependent win-x64 app and requires the **.NET 10 Desktop Runtime (x64)**; setup aborts with Error 9001 when that runtime is missing.
 
 Production releases are **not** built from this folder in Visual Studio. Follow [docs/RELEASE.md](../docs/RELEASE.md): tag `vMAJOR.MINOR.PATCH`, submit the partner CAB to Microsoft, ingest the signed package, then run `.\build.cmd BuildSetup`.
 
@@ -25,6 +25,8 @@ artifacts/bin/ControlApp.exe
 ```
 
 `igfilter` is a maintainer-supplied external payload. It is not produced by this repository.
+
+`BuildSetup` verifies the generated MSI contains `ControlApp.exe`, the `DsHidMini Control App` Start Menu shortcut, and the .NET 10 Desktop prerequisite custom action before it EV-signs the package.
 
 Building `DsHidMini.Installer.csproj` without `GenerateMsi=true` only compiles the generator. MSI emission is gated on `.\build.cmd BuildSetup`.
 


### PR DESCRIPTION
… drops it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Requirements**
  * ControlApp and its installer now require the .NET 10 Desktop Runtime (x64).
  * Improved missing-runtime detection, guidance, and error messaging.

* **Installer Improvements**
  * Release builds verify required application files, Start Menu shortcuts, runtime prerequisites, and installation error metadata before signing.

* **Documentation**
  * Updated setup and release documentation with .NET 10 requirements, prerequisite behavior, MSI validation details, and clean-machine installation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->