### PR TITLE
Add Sony-compatible USB motion support for DualShock 3 pads.

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -39,6 +39,7 @@
         "Restore",
         "StageIgfilter",
         "TestConfigParser",
+        "TestControlApp",
         "TestReleasePipeline",
         "TestXInputBridge",
         "ValidateSetupInputs"

--- a/ControlApp.Tests/MotionIpcLayoutTests.cs
+++ b/ControlApp.Tests/MotionIpcLayoutTests.cs
@@ -1,0 +1,93 @@
+using System.Runtime.InteropServices;
+
+using Nefarius.DsHidMini.IPC.Models;
+using Nefarius.DsHidMini.IPC.Models.Drivers;
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class MotionIpcLayoutTests
+{
+    [Fact]
+    public void HidSlot_RemainsSixtyBytes()
+    {
+        Assert.Equal(60, Marshal.SizeOf<IPC_HID_INPUT_REPORT_MESSAGE>());
+        Assert.Equal(4, (int)Marshal.OffsetOf<IPC_HID_INPUT_REPORT_MESSAGE>(nameof(IPC_HID_INPUT_REPORT_MESSAGE.SequenceNumber)));
+    }
+
+    [Fact]
+    public void MotionSnapshot_IsEightyBytes_VersionOne()
+    {
+        Assert.Equal(DsMotionSnapshot.Size, Marshal.SizeOf<DsMotionSnapshot>());
+        Assert.Equal(80, Marshal.SizeOf<DsMotionSnapshot>());
+        Assert.Equal((ushort)1, DsMotionSnapshot.CurrentVersion);
+        Assert.Equal(4, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.SequenceNumber)));
+        Assert.Equal(0, Marshal.SizeOf<DsMotionSnapshot>() % sizeof(int));
+    }
+
+    [Fact]
+    public void MotionSnapshot_FieldOffsets_MatchDriverPack1()
+    {
+        Assert.Equal(0, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.SlotIndex)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.Version)));
+        Assert.Equal(10, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.Flags)));
+        Assert.Equal(44, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.AccelMilliGX)));
+        Assert.Equal(68, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.TimestampQpc)));
+        Assert.Equal(76, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.CalByte)));
+        Assert.Equal(77, (int)Marshal.OffsetOf<DsMotionSnapshot>(nameof(DsMotionSnapshot.MotionPath)));
+    }
+
+    [Fact]
+    public void MotionFlags_MatchDriverConstants()
+    {
+        Assert.Equal(0x0001, (int)DsMotionSnapshotFlags.Available);
+        Assert.Equal(0x0002, (int)DsMotionSnapshotFlags.Fallback);
+        Assert.Equal(0x0004, (int)DsMotionSnapshotFlags.HardwareCal);
+        Assert.Equal(0x0008, (int)DsMotionSnapshotFlags.Tracker);
+    }
+
+    [Fact]
+    public void MotionPath_MatchesIdentificationEnum()
+    {
+        Assert.Equal((byte)DsIdentificationMotionPath.Unknown, (byte)0);
+        Assert.Equal((byte)DsIdentificationMotionPath.PlainZero, (byte)1);
+        Assert.Equal((byte)DsIdentificationMotionPath.HwCal, (byte)2);
+        Assert.Equal((byte)DsIdentificationMotionPath.Sixaxis, (byte)3);
+    }
+
+    [Fact]
+    public void SeqlockCopy_RejectsOddGeneration()
+    {
+        DsMotionSnapshot snapshot = new()
+        {
+            SlotIndex = 1,
+            SequenceNumber = 3,
+            Version = 1,
+            Flags = DsMotionSnapshotFlags.Available
+        };
+
+        Assert.True((snapshot.SequenceNumber & 1) != 0);
+        snapshot.SequenceNumber = 4;
+        Assert.True((snapshot.SequenceNumber & 1) == 0);
+        Assert.Equal(1u, snapshot.SlotIndex);
+    }
+
+    [Fact]
+    public void FallbackSnapshot_IsPresentedAsNominal()
+    {
+        DsMotionSnapshot snapshot = new()
+        {
+            Flags = DsMotionSnapshotFlags.Fallback,
+            AccelZeroX = 512,
+            AccelOneGX = 399,
+            GyroZero = 512
+        };
+
+        Assert.True(snapshot.IsFallback);
+        Assert.False(snapshot.IsAvailable);
+        Assert.Equal(512, snapshot.AccelZeroX);
+        Assert.Equal(399, snapshot.AccelOneGX);
+    }
+}

--- a/ControlApp.Tests/MotionOrientationTests.cs
+++ b/ControlApp.Tests/MotionOrientationTests.cs
@@ -1,0 +1,98 @@
+using Nefarius.DsHidMini.ControlApp.Models.Motion;
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class MotionOrientationTests
+{
+    private static DsMotionSnapshot Sample(int mx, int my, int mz, int mdps, uint index, ulong qpc)
+    {
+        return new DsMotionSnapshot
+        {
+            Flags = DsMotionSnapshotFlags.Available,
+            AccelMilliGX = mx,
+            AccelMilliGY = my,
+            AccelMilliGZ = mz,
+            GyroMilliDps = mdps,
+            SampleIndex = index,
+            TimestampQpc = qpc
+        };
+    }
+
+    [Fact]
+    public void FlatButtonsUp_IsLevel()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, 0, -1000, 0, 1, 1_000_000));
+
+        Assert.InRange(estimator.PitchDegrees, -1.0, 1.0);
+        Assert.InRange(estimator.RollDegrees, -1.0, 1.0);
+    }
+
+    [Fact]
+    public void RightGripDown_PitchesNegative()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(1000, 0, 0, 0, 1, 1_000_000));
+
+        Assert.True(estimator.PitchDegrees < -80);
+    }
+
+    [Fact]
+    public void TriggerEdgeDown_RollsNegative()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, -1000, 0, 0, 1, 1_000_000));
+
+        Assert.True(estimator.RollDegrees < -80);
+    }
+
+    [Fact]
+    public void YawIntegratesCorrectedRate()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, 0, -1000, 90_000, 1, 0));
+        estimator.Update(Sample(0, 0, -1000, 90_000, 2, 100_000));
+
+        Assert.InRange(estimator.YawDegrees, 8.9, 9.1);
+    }
+
+    [Fact]
+    public void Recenter_ZerosYawOnly()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, -1000, 0, 90_000, 1, 0));
+        estimator.Update(Sample(0, -1000, 0, 90_000, 2, 100_000));
+        double roll = estimator.RollDegrees;
+
+        estimator.Recenter();
+
+        Assert.Equal(0, estimator.YawDegrees);
+        Assert.Equal(roll, estimator.RollDegrees);
+    }
+
+    [Fact]
+    public void Smoothing_BlendsGravity()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 0.5);
+        estimator.Update(Sample(0, 0, -1000, 0, 1, 1));
+        estimator.Update(Sample(1000, 0, 0, 0, 2, 2));
+
+        Assert.InRange(estimator.SmoothMilliGX, 499, 501);
+        Assert.InRange(estimator.SmoothMilliGZ, -501, -499);
+    }
+
+    [Fact]
+    public void DuplicateSampleIndex_DoesNotIntegrateAgain()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, 0, -1000, 90_000, 1, 0));
+        estimator.Update(Sample(0, 0, -1000, 90_000, 2, 100_000));
+        double yaw = estimator.YawDegrees;
+        estimator.Update(Sample(0, 0, -1000, 90_000, 2, 200_000));
+
+        Assert.Equal(yaw, estimator.YawDegrees);
+    }
+}

--- a/ControlApp.Tests/MotionProcessingTests.cs
+++ b/ControlApp.Tests/MotionProcessingTests.cs
@@ -1,0 +1,124 @@
+using Nefarius.DsHidMini.ControlApp.Models.Motion;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class MotionProcessingTests
+{
+    // DS3-A1a EEPROM from docs/MOTION.md
+    private const int ZeroX = 498;
+    private const int OneGX = 386;
+    private const int ZeroY = 494;
+    private const int OneGY = 383;
+    private const int ZeroZ = 496;
+    private const int OneGZ = 387;
+
+    [Theory]
+    [InlineData(494, 509, false)]
+    [InlineData(607, 621, false)]
+    [InlineData(383, 397, false)]
+    public void AccelX_MatchesMotionDoc_WithoutMirror(int raw, int expected, bool mirror)
+    {
+        Assert.Equal(expected, DsMotionMath.CalibrateAccel(raw, ZeroX, OneGX, mirror));
+    }
+
+    [Theory]
+    [InlineData(475, 493)]
+    [InlineData(385, 402)]
+    [InlineData(603, 622)]
+    public void AccelY_MatchesMotionDoc(int raw, int expected)
+    {
+        Assert.Equal(expected, DsMotionMath.CalibrateAccel(raw, ZeroY, OneGY, false));
+    }
+
+    [Theory]
+    [InlineData(396, 409)]
+    [InlineData(624, 644)]
+    public void AccelZ_MatchesMotionDoc(int raw, int expected)
+    {
+        Assert.Equal(expected, DsMotionMath.CalibrateAccel(raw, ZeroZ, OneGZ, false));
+    }
+
+    [Fact]
+    public void AccelX_MirrorHappensAfterCalibration()
+    {
+        int cal = DsMotionMath.CalibrateAccel(607, ZeroX, OneGX, false);
+        Assert.Equal(621, cal);
+        Assert.Equal(0x3FF - 621, DsMotionMath.CalibrateAccel(607, ZeroX, OneGX, true));
+    }
+
+    [Fact]
+    public void Accel_ZeroEqualsOneG_PassesRawThrough()
+    {
+        Assert.Equal(500, DsMotionMath.CalibrateAccel(500, 512, 512, false));
+        Assert.Equal(0x3FF - 500, DsMotionMath.CalibrateAccel(500, 512, 512, true));
+    }
+
+    [Fact]
+    public void PlainZeroGyro_UsesEepromZero()
+    {
+        // DS3-A1a: EEPROM 481, idle ~482 → ~511
+        Assert.Equal(511, DsMotionMath.PlainZeroGyro(482, 481));
+        Assert.Equal(512, DsMotionMath.PlainZeroGyro(481, 481));
+    }
+
+    [Fact]
+    public void HwCalGyro_InvertsRawWithoutSoftwareZero()
+    {
+        // DS3-A2 idle 361 with factory cal applied
+        Assert.Equal(0x3FF - 361, DsMotionMath.HwCalReportedGyro(361));
+        Assert.Equal(512, DsMotionMath.HwCalReportedGyro(511));
+    }
+
+    [Fact]
+    public void SixaxisGyro_UsesZeroRefNotEepromWhenTrackerSeeded()
+    {
+        SonyGyroTracker tracker = new();
+        tracker.Initial(0x75, 513);
+        Assert.Equal(DsMotionMath.Clamp10(512 + tracker.ZeroRef - 513), tracker.Output);
+    }
+
+    [Fact]
+    public void Gyro_ClockwisePositive_AfterInversion()
+    {
+        // Raw falls for clockwise-from-above; Sony output must rise above 512.
+        Assert.True(DsMotionMath.PlainZeroGyro(400, 512) > 512);
+        Assert.True(DsMotionMath.HwCalReportedGyro(400) > 512);
+    }
+
+    [Fact]
+    public void MilliG_AndMilliDps_UseDocumentedScales()
+    {
+        Assert.Equal(1000, DsMotionMath.ToMilliG(512 + 113));
+        Assert.Equal(-1000, DsMotionMath.ToMilliG(512 - 113));
+        Assert.Equal(0, DsMotionMath.ToMilliDps(512));
+        Assert.Equal(5000 / 7, DsMotionMath.ToMilliDps(513));
+    }
+
+    [Fact]
+    public void Tracker_InitialCalByte_IsTruncatedNotClamped()
+    {
+        SonyGyroTracker tracker = new();
+        // Far-below-rest EEPROM zero forces a large negative step that wraps as u8.
+        byte sent = tracker.Initial(0, 200);
+        Assert.Equal(unchecked((byte)tracker.CalByteRaw), sent);
+        Assert.InRange(tracker.CalByteRaw, int.MinValue, int.MaxValue);
+    }
+
+    [Fact]
+    public void Tracker_StillRawConvergesCalByte()
+    {
+        SonyGyroTracker tracker = new();
+        tracker.Initial(0x7F, 521);
+
+        bool everChanged = false;
+        for (int i = 0; i < 800; i++)
+        {
+            tracker.Runtime(361, out bool changed);
+            everChanged |= changed;
+        }
+
+        Assert.True(everChanged || tracker.ZeroRef != 521);
+    }
+}

--- a/ControlApp.Tests/MotionViewerLifecycleTests.cs
+++ b/ControlApp.Tests/MotionViewerLifecycleTests.cs
@@ -1,0 +1,66 @@
+using Nefarius.DsHidMini.ControlApp.Models.Motion;
+using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
+using Nefarius.DsHidMini.IPC.Models.Drivers;
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class MotionViewerLifecycleTests
+{
+    [Fact]
+    public void SessionDispose_CancelsToken()
+    {
+        MotionViewerViewModel vm = new(1, "test");
+        Assert.False(vm.IsSessionCancelled);
+
+        vm.Dispose();
+
+        Assert.True(vm.IsSessionCancelled);
+    }
+
+    [Fact]
+    public void FallbackStatus_MentionsNominalCalibration()
+    {
+        string text = MotionStatusFormatter.StatusText(true, true, true, isFallback: true);
+        Assert.Contains("nominal", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MissingTelemetry_MentionsOlderDriver()
+    {
+        string text = MotionStatusFormatter.StatusText(true, telemetryMapped: false, false, false);
+        Assert.Contains("no motion telemetry", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MissingIpc_IsUnavailable()
+    {
+        string text = MotionStatusFormatter.StatusText(false, false, false, false);
+        Assert.Contains("IPC", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(DsIdentificationMotionPath.PlainZero, "Software zero")]
+    [InlineData(DsIdentificationMotionPath.HwCal, "Hardware-calibrated")]
+    [InlineData(DsIdentificationMotionPath.Sixaxis, "SIXAXIS")]
+    [InlineData(DsIdentificationMotionPath.Unknown, "Unknown")]
+    public void PathLabel_MatchesControlAppCopy(DsIdentificationMotionPath path, string expected)
+    {
+        Assert.Contains(expected, MotionStatusFormatter.PathLabel(path), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SnapshotHelpers_ExposeFallbackAndAvailability()
+    {
+        DsMotionSnapshot snapshot = new()
+        {
+            Flags = DsMotionSnapshotFlags.Available | DsMotionSnapshotFlags.Fallback | DsMotionSnapshotFlags.Tracker
+        };
+
+        Assert.True(snapshot.IsAvailable);
+        Assert.True(snapshot.IsFallback);
+        Assert.True(snapshot.HasTracker);
+    }
+}

--- a/ControlApp.Tests/SonyGyroTracker.cs
+++ b/ControlApp.Tests/SonyGyroTracker.cs
@@ -1,0 +1,283 @@
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+/// <summary>
+///     Driver-faithful port of <c>research/ds3-motion/probe/GyroCal.cs</c>.
+///     <see cref="CalByte" /> is the truncated unclamped value Sony writes.
+/// </summary>
+internal sealed class SonyGyroTracker
+{
+    private const int Target = 512;
+    private const int StepQ10 = 0x6999;
+    private const int SettleInitial = 32;
+    private const int SettleAfterCal = 2;
+    private const int RawMax = 0x333;
+    private const int RawMin = 0xCC;
+    private const int BlockN = 16;
+    private const int BlockVarMax = 10;
+    private const int RingN = 4;
+    private const int RingRangeMax = 4;
+    private const int LongN = 0xEC;
+    private const int PendingTol0 = 100;
+    private const int PendingDecay = 1;
+
+    private readonly int[] _ring = new int[RingN];
+    private int _blockCount;
+    private int _blockMax = int.MinValue;
+    private int _blockMin = int.MaxValue;
+    private int _blockSum;
+    private int _calByte;
+    private int _lastRaw;
+    private int _longCount;
+    private int _longSum;
+    private bool _moving;
+    private int _output;
+    private bool _pending;
+    private int _pendingCal;
+    private int _pendingTol;
+    private int _pendingZero;
+    private int _ringFilled;
+    private int _ringIdx;
+    private int _ringSum;
+    private int _settleLeft;
+    private int _zeroRef;
+
+    public byte CalByte => unchecked((byte)_calByte);
+
+    public int CalByteRaw => _calByte;
+
+    public int ZeroRef => _zeroRef;
+
+    public int Output => _output;
+
+    private static int Q10(int x) => (x + ((x >> 31) & 0x3FF)) >> 10;
+
+    private static int Clamp10(int value) => value < 0 ? 0 : value > 1023 ? 1023 : value;
+
+    public byte Initial(ushort eepromCal, ushort eepromZero)
+    {
+        _calByte = eepromCal;
+        _lastRaw = eepromZero;
+        _settleLeft = SettleInitial;
+        Retarget(eepromZero, out _zeroRef, out _calByte);
+        _output = Clamp10(_zeroRef - eepromZero + Target);
+        return CalByte;
+    }
+
+    public int Runtime(int raw, out bool calChanged)
+    {
+        calChanged = false;
+
+        if (_settleLeft > 0)
+        {
+            _settleLeft--;
+            _lastRaw = raw;
+            return _output;
+        }
+
+        _output = Clamp10(Target - raw + _zeroRef);
+        calChanged = Track(raw);
+
+        if (_pending)
+        {
+            int jump = raw - _lastRaw;
+            if (-_pendingTol <= jump && jump <= _pendingTol)
+            {
+                _pendingTol -= PendingDecay;
+            }
+            else
+            {
+                ApplyPending();
+                ResetBlock();
+                calChanged = true;
+            }
+        }
+
+        _lastRaw = raw;
+        return _output;
+    }
+
+    private bool Retarget(int restAvg, out int zeroRef, out int calByte)
+    {
+        int delta = (Target - restAvg) * 1024;
+        if (-StepQ10 <= delta && delta <= StepQ10)
+        {
+            zeroRef = restAvg;
+            calByte = _calByte;
+            return false;
+        }
+
+        int steps = delta / StepQ10;
+        zeroRef = restAvg + Q10(steps * StepQ10);
+        calByte = _calByte + steps;
+        return true;
+    }
+
+    private bool Track(int raw)
+    {
+        if (raw > RawMax || raw < RawMin)
+        {
+            _moving = true;
+        }
+
+        _blockSum += raw;
+        if (raw > _blockMax)
+        {
+            _blockMax = raw;
+        }
+
+        if (raw < _blockMin)
+        {
+            _blockMin = raw;
+        }
+
+        if (++_blockCount != BlockN)
+        {
+            return false;
+        }
+
+        _blockCount = 0;
+        int blockAvg = (_blockSum + (BlockN / 2)) / BlockN;
+        _blockSum = 0;
+        int lastMin = _blockMin;
+        int lastMax = _blockMax;
+        _blockMin = int.MaxValue;
+        _blockMax = int.MinValue;
+        int variance = ((lastMax - blockAvg) * (lastMax - blockAvg)) + ((blockAvg - lastMin) * (blockAvg - lastMin));
+
+        _longSum += blockAvg;
+        if (++_longCount == LongN)
+        {
+            _longCount = 0;
+            int longAvg = (_longSum + (LongN / 2)) / LongN;
+            _longSum = 0;
+            if (Retarget(longAvg, out int z, out int c))
+            {
+                _pendingZero = z;
+                _pendingCal = c;
+                _pending = true;
+                _pendingTol = PendingTol0;
+            }
+            else
+            {
+                _pendingZero = _zeroRef = longAvg;
+            }
+        }
+
+        if (_moving)
+        {
+            _moving = false;
+            return false;
+        }
+
+        if (variance < BlockVarMax)
+        {
+            if (RingPush(blockAvg))
+            {
+                if (RingRange() < RingRangeMax)
+                {
+                    int restAvg = (_ringSum + (RingN / 2)) / RingN;
+                    _longCount = 0;
+                    _longSum = 0;
+                    bool changed = Retarget(restAvg, out _zeroRef, out int newCal);
+                    if (changed)
+                    {
+                        _calByte = newCal;
+                        RingReset();
+                        _settleLeft = SettleAfterCal;
+                    }
+
+                    _pending = false;
+                    return changed;
+                }
+            }
+
+            if (_pending)
+            {
+                ApplyPending();
+                RingReset();
+                _settleLeft = SettleAfterCal;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void ApplyPending()
+    {
+        _zeroRef = _pendingZero;
+        _calByte = _pendingCal;
+        _pending = false;
+        RingReset();
+        _longCount = 0;
+        _longSum = 0;
+    }
+
+    private void ResetBlock()
+    {
+        _blockCount = 0;
+        _blockSum = 0;
+        _blockMin = int.MaxValue;
+        _blockMax = int.MinValue;
+    }
+
+    private bool RingPush(int value)
+    {
+        int old = _ring[_ringIdx];
+        _ring[_ringIdx] = value;
+        _ringSum += value;
+        _ringIdx++;
+        if (_ringFilled < RingN)
+        {
+            _ringFilled++;
+            if (_ringFilled < RingN)
+            {
+                if (_ringIdx == RingN)
+                {
+                    _ringIdx = 0;
+                }
+
+                return false;
+            }
+        }
+        else
+        {
+            _ringSum -= old;
+        }
+
+        if (_ringIdx == RingN)
+        {
+            _ringIdx = 0;
+        }
+
+        return true;
+    }
+
+    private int RingRange()
+    {
+        int min = int.MaxValue;
+        int max = int.MinValue;
+        foreach (int v in _ring)
+        {
+            if (v > max)
+            {
+                max = v;
+            }
+
+            if (v < min)
+            {
+                min = v;
+            }
+        }
+
+        return max - min;
+    }
+
+    private void RingReset()
+    {
+        Array.Clear(_ring);
+        _ringFilled = 0;
+        _ringIdx = 0;
+        _ringSum = 0;
+    }
+}

--- a/ControlApp/ControlApp.csproj
+++ b/ControlApp/ControlApp.csproj
@@ -37,6 +37,7 @@
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+        <PackageReference Include="HelixToolkit.Wpf" Version="3.1.2" />
         <PackageReference Include="WPF-UI" Version="4.2.0" />
         <PackageReference Include="WPF-UI.DependencyInjection" Version="4.2.0" />
         <PackageReference Include="WPF-UI.Tray" Version="4.2.0" />

--- a/ControlApp/Models/Motion/DsMotionMath.cs
+++ b/ControlApp/Models/Motion/DsMotionMath.cs
@@ -1,0 +1,67 @@
+namespace Nefarius.DsHidMini.ControlApp.Models.Motion;
+
+/// <summary>
+///     Sony-compatible motion formulas from <c>docs/MOTION.md</c> / <c>driver/DsMotion.c</c>.
+/// </summary>
+internal static class DsMotionMath
+{
+    public const int AccelGain = 113;
+    public const int NominalZero = 512;
+    public const int NominalOneG = NominalZero - AccelGain;
+
+    public static int Q10(int value)
+    {
+        return (value + ((value >> 31) & 0x3FF)) >> 10;
+    }
+
+    public static int Clamp10(int value)
+    {
+        if (value < 0)
+        {
+            return 0;
+        }
+
+        return value > 1023 ? 1023 : value;
+    }
+
+    public static int CalibrateAccel(int raw, int zero, int oneG, bool mirror)
+    {
+        int cal;
+        if (zero != oneG)
+        {
+            int t = ((raw - zero) * 1024 / (zero - oneG)) * AccelGain;
+            cal = Q10(t) + NominalZero;
+        }
+        else
+        {
+            cal = raw;
+        }
+
+        if (mirror)
+        {
+            cal = 0x3FF - cal;
+        }
+
+        return cal;
+    }
+
+    public static int PlainZeroGyro(int raw, int eepromZero)
+    {
+        return Clamp10(NominalZero + eepromZero - raw);
+    }
+
+    public static int HwCalReportedGyro(int raw)
+    {
+        return Clamp10(0x3FF - raw);
+    }
+
+    public static int ToMilliG(int calibrated)
+    {
+        return ((calibrated - NominalZero) * 1000) / AccelGain;
+    }
+
+    public static int ToMilliDps(int calibrated)
+    {
+        return ((calibrated - NominalZero) * 5000) / 7;
+    }
+}

--- a/ControlApp/Models/Motion/MotionOrientationEstimator.cs
+++ b/ControlApp/Models/Motion/MotionOrientationEstimator.cs
@@ -1,0 +1,110 @@
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+namespace Nefarius.DsHidMini.ControlApp.Models.Motion;
+
+/// <summary>
+///     Diagnostic pad pose: smoothed gravity for pitch/roll, integrated yaw from
+///     the single SIXAXIS gyro. Yaw drifts; call <see cref="Recenter" /> to zero it.
+/// </summary>
+internal sealed class MotionOrientationEstimator
+{
+    private readonly double _smoothing;
+    private bool _hasGravity;
+    private bool _hasTiming;
+    private ulong _lastQpc;
+    private double _smoothX;
+    private double _smoothY;
+    private double _smoothZ;
+    private uint _lastSampleIndex;
+
+    public MotionOrientationEstimator(double qpcFrequency, double smoothing = 0.18)
+    {
+        QpcFrequency = qpcFrequency > 0 ? qpcFrequency : 10_000_000;
+        _smoothing = Math.Clamp(smoothing, 0.01, 1.0);
+    }
+
+    public double QpcFrequency { get; }
+
+    public double PitchDegrees { get; private set; }
+
+    public double RollDegrees { get; private set; }
+
+    public double YawDegrees { get; private set; }
+
+    public double SmoothMilliGX => _smoothX;
+
+    public double SmoothMilliGY => _smoothY;
+
+    public double SmoothMilliGZ => _smoothZ;
+
+    public void Recenter()
+    {
+        YawDegrees = 0;
+    }
+
+    public void Reset()
+    {
+        _hasGravity = false;
+        _hasTiming = false;
+        _lastQpc = 0;
+        _lastSampleIndex = 0;
+        _smoothX = 0;
+        _smoothY = 0;
+        _smoothZ = -1000;
+        PitchDegrees = 0;
+        RollDegrees = 0;
+        YawDegrees = 0;
+    }
+
+    public void Update(in DsMotionSnapshot snapshot)
+    {
+        if (!snapshot.IsAvailable)
+        {
+            return;
+        }
+
+        if (snapshot.SampleIndex == _lastSampleIndex && _hasGravity)
+        {
+            return;
+        }
+
+        double gx = snapshot.AccelMilliGX;
+        double gy = snapshot.AccelMilliGY;
+        double gz = snapshot.AccelMilliGZ;
+
+        if (!_hasGravity)
+        {
+            _smoothX = gx;
+            _smoothY = gy;
+            _smoothZ = gz;
+            _hasGravity = true;
+        }
+        else
+        {
+            _smoothX += (gx - _smoothX) * _smoothing;
+            _smoothY += (gy - _smoothY) * _smoothing;
+            _smoothZ += (gz - _smoothZ) * _smoothing;
+        }
+
+        double ax = _smoothX / 1000.0;
+        double ay = _smoothY / 1000.0;
+        double az = _smoothZ / 1000.0;
+        double horiz = Math.Sqrt((ay * ay) + (az * az));
+
+        PitchDegrees = Math.Atan2(-ax, horiz) * (180.0 / Math.PI);
+        RollDegrees = Math.Atan2(ay, -az) * (180.0 / Math.PI);
+
+        if (_hasTiming && snapshot.TimestampQpc > _lastQpc)
+        {
+            double dt = (snapshot.TimestampQpc - _lastQpc) / QpcFrequency;
+            if (dt > 0 && dt < 0.25)
+            {
+                YawDegrees += (snapshot.GyroMilliDps / 1000.0) * dt;
+            }
+        }
+
+        _hasTiming = true;
+        _lastQpc = snapshot.TimestampQpc;
+        _lastSampleIndex = snapshot.SampleIndex;
+    }
+}

--- a/ControlApp/Models/Motion/MotionStatusFormatter.cs
+++ b/ControlApp/Models/Motion/MotionStatusFormatter.cs
@@ -1,0 +1,40 @@
+using Nefarius.DsHidMini.IPC.Models.Drivers;
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+namespace Nefarius.DsHidMini.ControlApp.Models.Motion;
+
+internal static class MotionStatusFormatter
+{
+    public static string PathLabel(DsIdentificationMotionPath path)
+    {
+        return path switch
+        {
+            DsIdentificationMotionPath.HwCal => "Hardware-calibrated gyro",
+            DsIdentificationMotionPath.PlainZero => "Software zero",
+            DsIdentificationMotionPath.Sixaxis => "SIXAXIS",
+            _ => "Unknown"
+        };
+    }
+
+    public static string StatusText(bool ipcAvailable, bool telemetryMapped, bool gotSnapshot, bool isFallback)
+    {
+        if (!ipcAvailable)
+        {
+            return "Driver IPC is not available.";
+        }
+
+        if (!telemetryMapped)
+        {
+            return "This driver build has no motion telemetry region.";
+        }
+
+        if (!gotSnapshot)
+        {
+            return "Waiting for a motion sample…";
+        }
+
+        return isFallback
+            ? "Using nominal calibration (Bluetooth or EEPROM read fallback)."
+            : "Live USB calibration.";
+    }
+}

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -167,6 +167,17 @@ public class AppSnackbarMessagesService
         );
     }
 
+    public void ShowMotionViewerFailedMessage(string detail)
+    {
+        _snackbarService.Show(
+            "Motion viewer unavailable",
+            detail,
+            ControlAppearance.Danger,
+            new SymbolIcon(SymbolRegular.DismissCircle24),
+            TimeSpan.FromSeconds(8)
+        );
+    }
+
     public void ShowUsbPowerOffFailedMessage(string detail)
     {
         _snackbarService.Show(

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -10,6 +10,8 @@ using Nefarius.DsHidMini.ControlApp.Models.Enums;
 using Nefarius.DsHidMini.ControlApp.Models.Util;
 using Nefarius.DsHidMini.ControlApp.Models.Util.Web;
 using Nefarius.DsHidMini.ControlApp.Services;
+using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
+using Nefarius.DsHidMini.ControlApp.Views.Windows;
 using Nefarius.DsHidMini.IPC;
 using Nefarius.DsHidMini.IPC.Models.Drivers;
 using Nefarius.DsHidMini.IPC.Models.Public;
@@ -44,6 +46,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     ];
 
     private readonly DeviceData _deviceUserData;
+    private MotionViewerWindow? _motionViewer;
 
     // ------------------------------------------------------ FIELDS
 
@@ -612,6 +615,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
     {
         Interlocked.Increment(ref _xInputSlotRefreshGeneration);
         _batteryQuery.Dispose();
+        CloseMotionViewer();
         GC.SuppressFinalize(this);
     }
 
@@ -1022,6 +1026,58 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
         }
 
         return PhysicalAddress.Parse(normalized);
+    }
+
+    public bool CanOpenMotionViewer =>
+        DsHidMiniInterop.IsAvailable && DsHidMiniInterop.TryGetIpcSlotIndex(Device) is not null;
+
+    public string MotionViewerToolTip =>
+        CanOpenMotionViewer
+            ? "Open a live motion readout and diagnostic 3D pose for this controller."
+            : "Motion viewer needs driver IPC and a published device slot.";
+
+    [RelayCommand]
+    private void OpenMotionViewer()
+    {
+        if (_motionViewer is { IsVisible: true })
+        {
+            _motionViewer.Activate();
+            return;
+        }
+
+        int? slot = DsHidMiniInterop.TryGetIpcSlotIndex(Device);
+        if (slot is not int deviceIndex)
+        {
+            _appSnackbarMessagesService.ShowMotionViewerFailedMessage(
+                "The driver did not report an IPC slot for this device.");
+            return;
+        }
+
+        if (!DsHidMiniInterop.IsAvailable)
+        {
+            _appSnackbarMessagesService.ShowMotionViewerFailedMessage(
+                "Driver IPC is not available. Confirm the controller is still connected.");
+            return;
+        }
+
+        MotionViewerViewModel viewer = new(deviceIndex, DeviceAddressFriendly ?? DeviceAddress);
+        _motionViewer = new MotionViewerWindow(viewer)
+        {
+            Owner = Application.Current.MainWindow
+        };
+        _motionViewer.Closed += (_, _) => _motionViewer = null;
+        _motionViewer.Show();
+    }
+
+    private void CloseMotionViewer()
+    {
+        if (_motionViewer is null)
+        {
+            return;
+        }
+
+        _motionViewer.Close();
+        _motionViewer = null;
     }
 
     [RelayCommand]

--- a/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
+++ b/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics;
+using System.Windows;
+
+using Nefarius.DsHidMini.ControlApp.Models.Motion;
+using Nefarius.DsHidMini.IPC;
+using Nefarius.DsHidMini.IPC.Models.Public;
+
+using Wpf.Ui.Controls;
+
+namespace Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
+
+public sealed partial class MotionViewerViewModel : ObservableObject, IDisposable
+{
+    private readonly int _deviceIndex;
+    private readonly MotionOrientationEstimator _estimator;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly object _interopLock = new();
+    private DsHidMiniInterop? _interop;
+    private Task? _pumpTask;
+    private int _uiGeneration;
+    private bool _disposed;
+
+    public MotionViewerViewModel(int deviceIndex, string deviceTitle)
+    {
+        _deviceIndex = deviceIndex;
+        Title = $"Motion viewer — {deviceTitle}";
+        _estimator = new MotionOrientationEstimator(Stopwatch.Frequency);
+        StatusText = MotionStatusFormatter.StatusText(true, false, false, false);
+    }
+
+    public string Title { get; }
+
+    internal MotionOrientationEstimator Estimator => _estimator;
+
+    public event EventHandler? PoseChanged;
+
+    [ObservableProperty]
+    private string _statusText = "";
+
+    [ObservableProperty]
+    private bool _isPaused;
+
+    [ObservableProperty]
+    private bool _isUnavailable;
+
+    [ObservableProperty]
+    private InfoBarSeverity _statusSeverity = InfoBarSeverity.Informational;
+
+    [ObservableProperty]
+    private string _rawAccelText = "—";
+
+    [ObservableProperty]
+    private string _calAccelText = "—";
+
+    [ObservableProperty]
+    private string _accelGText = "—";
+
+    [ObservableProperty]
+    private string _rawGyroText = "—";
+
+    [ObservableProperty]
+    private string _calGyroText = "—";
+
+    [ObservableProperty]
+    private string _gyroDpsText = "—";
+
+    [ObservableProperty]
+    private string _eepromText = "—";
+
+    [ObservableProperty]
+    private string _trackerText = "—";
+
+    [ObservableProperty]
+    private string _pathText = "—";
+
+    [ObservableProperty]
+    private string _sampleText = "—";
+
+    [ObservableProperty]
+    private string _yawNote =
+        "Yaw is integrated from the single SIXAXIS gyro and will drift. Use Recenter after holding the pad still.";
+
+    public CancellationToken SessionToken => _cts.Token;
+
+    public bool IsSessionCancelled { get; private set; }
+
+    public void Start()
+    {
+        _pumpTask = Task.Run(PumpAsync);
+    }
+
+    [RelayCommand]
+    private void Recenter()
+    {
+        _estimator.Recenter();
+        PoseChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void TogglePause()
+    {
+        IsPaused = !IsPaused;
+    }
+
+    private async Task PumpAsync()
+    {
+        try
+        {
+            if (!DsHidMiniInterop.IsAvailable)
+            {
+                PublishUnavailable(MotionStatusFormatter.StatusText(false, false, false, false));
+                return;
+            }
+
+            lock (_interopLock)
+            {
+                _interop = new DsHidMiniInterop();
+            }
+
+            bool mapped = _interop.HasMotionTelemetry;
+            if (!mapped)
+            {
+                PublishUnavailable(MotionStatusFormatter.StatusText(true, false, false, false));
+                return;
+            }
+
+            while (!_cts.IsCancellationRequested)
+            {
+                DsMotionSnapshot snapshot = default;
+                bool got;
+                try
+                {
+                    got = _interop.GetMotionSnapshot(_deviceIndex, out snapshot, TimeSpan.FromMilliseconds(40));
+                }
+                catch (Exception ex)
+                {
+                    PublishUnavailable(ex.Message);
+                    return;
+                }
+
+                if (_cts.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                if (!got || snapshot.SlotIndex == 0)
+                {
+                    PublishUnavailable("The controller disconnected or its IPC slot is empty.");
+                    return;
+                }
+
+                if (!IsPaused)
+                {
+                    _estimator.Update(snapshot);
+                }
+
+                int generation = Interlocked.Increment(ref _uiGeneration);
+                DsMotionSnapshot copy = snapshot;
+                await Application.Current.Dispatcher.InvokeAsync(() =>
+                {
+                    if (_disposed || generation != Volatile.Read(ref _uiGeneration))
+                    {
+                        return;
+                    }
+
+                    ApplySnapshot(copy, mapped);
+                    PoseChanged?.Invoke(this, EventArgs.Empty);
+                });
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            PublishUnavailable(ex.Message);
+        }
+    }
+
+    private void ApplySnapshot(in DsMotionSnapshot snapshot, bool mapped)
+    {
+        IsUnavailable = false;
+        StatusSeverity = snapshot.IsFallback ? InfoBarSeverity.Warning : InfoBarSeverity.Informational;
+        StatusText = MotionStatusFormatter.StatusText(true, mapped, snapshot.IsAvailable, snapshot.IsFallback);
+        PathText = MotionStatusFormatter.PathLabel(snapshot.MotionPath);
+        RawAccelText = $"{snapshot.RawAccelX}  {snapshot.RawAccelY}  {snapshot.RawAccelZ}";
+        CalAccelText = $"{snapshot.CalAccelX}  {snapshot.CalAccelY}  {snapshot.CalAccelZ}";
+        AccelGText =
+            $"{snapshot.AccelMilliGX / 1000.0:0.00}  {snapshot.AccelMilliGY / 1000.0:0.00}  {snapshot.AccelMilliGZ / 1000.0:0.00} g";
+        RawGyroText = snapshot.RawGyro.ToString();
+        CalGyroText = snapshot.CalGyro.ToString();
+        GyroDpsText = $"{snapshot.GyroMilliDps / 1000.0:0.00} deg/s";
+        EepromText =
+            $"X {snapshot.AccelZeroX}/{snapshot.AccelOneGX}  Y {snapshot.AccelZeroY}/{snapshot.AccelOneGY}  Z {snapshot.AccelZeroZ}/{snapshot.AccelOneGZ}  G {snapshot.GyroZero}/{snapshot.GyroEepromCal}";
+        TrackerText = $"zero {snapshot.ZeroRef}  cal 0x{snapshot.CalByte:X2}  tracker {(snapshot.HasTracker ? "on" : "off")}";
+        SampleText = $"#{snapshot.SampleIndex}  QPC {snapshot.TimestampQpc}";
+    }
+
+    private void PublishUnavailable(string message)
+    {
+        Application.Current?.Dispatcher.BeginInvoke(() =>
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            IsUnavailable = true;
+            StatusSeverity = InfoBarSeverity.Error;
+            StatusText = message;
+        });
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        IsSessionCancelled = true;
+        _cts.Cancel();
+        lock (_interopLock)
+        {
+            _interop?.Dispose();
+            _interop = null;
+        }
+
+        _cts.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
+++ b/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
@@ -15,10 +15,13 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
     private readonly MotionOrientationEstimator _estimator;
     private readonly CancellationTokenSource _cts = new();
     private readonly object _interopLock = new();
+    private readonly object _shutdownLock = new();
     private DsHidMiniInterop? _interop;
     private Task? _pumpTask;
+    private Task? _shutdownTask;
     private int _uiGeneration;
     private bool _disposed;
+    private const int SnapshotMissBudget = 10;
 
     public MotionViewerViewModel(int deviceIndex, string deviceTitle)
     {
@@ -124,6 +127,7 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
                 return;
             }
 
+            int misses = 0;
             while (!_cts.IsCancellationRequested)
             {
                 DsMotionSnapshot snapshot = default;
@@ -143,11 +147,25 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
                     return;
                 }
 
-                if (!got || snapshot.SlotIndex == 0)
+                if (got && snapshot.SlotIndex == 0)
                 {
                     PublishUnavailable("The controller disconnected or its IPC slot is empty.");
                     return;
                 }
+
+                if (!got)
+                {
+                    misses++;
+                    if (misses >= SnapshotMissBudget)
+                    {
+                        PublishUnavailable("The controller disconnected or its IPC slot is empty.");
+                        return;
+                    }
+
+                    continue;
+                }
+
+                misses = 0;
 
                 if (!IsPaused)
                 {
@@ -156,7 +174,13 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
 
                 int generation = Interlocked.Increment(ref _uiGeneration);
                 DsMotionSnapshot copy = snapshot;
-                await Application.Current.Dispatcher.InvokeAsync(() =>
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher is null)
+                {
+                    return;
+                }
+
+                await dispatcher.InvokeAsync(() =>
                 {
                     if (_disposed || generation != Volatile.Read(ref _uiGeneration))
                     {
@@ -213,14 +237,40 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
 
     public void Dispose()
     {
-        if (_disposed)
+        _ = ShutdownAsync();
+    }
+
+    internal Task ShutdownAsync()
+    {
+        lock (_shutdownLock)
         {
-            return;
+            if (_shutdownTask is not null)
+            {
+                return _shutdownTask;
+            }
+
+            _disposed = true;
+            IsSessionCancelled = true;
+            _cts.Cancel();
+            _shutdownTask = CompleteShutdownAsync();
+            return _shutdownTask;
+        }
+    }
+
+    private async Task CompleteShutdownAsync()
+    {
+        Task? pump = _pumpTask;
+        if (pump is not null)
+        {
+            try
+            {
+                await pump.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
 
-        _disposed = true;
-        IsSessionCancelled = true;
-        _cts.Cancel();
         lock (_interopLock)
         {
             _interop?.Dispose();

--- a/ControlApp/Views/Pages/DevicesPage.xaml
+++ b/ControlApp/Views/Pages/DevicesPage.xaml
@@ -170,6 +170,33 @@
                                                 </ui:Button>
                                             </Viewbox>
 
+                                            <!--  Motion viewer (issue #217)  -->
+                                            <Viewbox Margin="0" DockPanel.Dock="Left">
+                                                <ui:Button
+                                                    Width="50"
+                                                    Height="50"
+                                                    Padding="5"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Stretch"
+                                                    HorizontalContentAlignment="Stretch"
+                                                    Command="{Binding OpenMotionViewerCommand}"
+                                                    FontStyle="Normal"
+                                                    IsEnabled="{Binding CanOpenMotionViewer}"
+                                                    ToolTip="{Binding MotionViewerToolTip}"
+                                                    ToolTipService.InitialShowDelay="200">
+                                                    <ui:Button.Content>
+                                                        <Viewbox>
+                                                            <ui:SymbolIcon
+                                                                Margin="0"
+                                                                HorizontalAlignment="Center"
+                                                                FontSize="28"
+                                                                Foreground="White"
+                                                                Symbol="Cube24" />
+                                                        </Viewbox>
+                                                    </ui:Button.Content>
+                                                </ui:Button>
+                                            </Viewbox>
+
                                             <!--  Power cycle/Reconnect button  -->
                                             <Viewbox Margin="0" DockPanel.Dock="Left">
                                                 <ui:Button

--- a/ControlApp/Views/UserControls/DeviceUserControl.xaml
+++ b/ControlApp/Views/UserControls/DeviceUserControl.xaml
@@ -169,6 +169,14 @@
                                     Text="{Binding IdentificationMotionPath}" />
                             </DockPanel>
                             <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
+                                <ui:Button
+                                    DockPanel.Dock="Left"
+                                    Command="{Binding OpenMotionViewerCommand}"
+                                    Content="Motion viewer"
+                                    IsEnabled="{Binding CanOpenMotionViewer}"
+                                    ToolTip="{Binding MotionViewerToolTip}" />
+                            </DockPanel>
+                            <DockPanel Margin="{StaticResource MyKey_NextLineSpacement}" DockPanel.Dock="Top">
                                 <ui:TextBlock
                                     DockPanel.Dock="Left"
                                     Style="{StaticResource MyKey_InfoDescriptionTextbox}"

--- a/ControlApp/Views/Windows/MotionViewerWindow.xaml
+++ b/ControlApp/Views/Windows/MotionViewerWindow.xaml
@@ -1,0 +1,100 @@
+<ui:FluentWindow
+    x:Class="Nefarius.DsHidMini.ControlApp.Views.Windows.MotionViewerWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:h="http://helix-toolkit.org/wpf"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="{Binding Title}"
+    Width="980"
+    Height="640"
+    MinWidth="820"
+    MinHeight="520"
+    d:DesignHeight="640"
+    d:DesignWidth="980"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    ExtendsContentIntoTitleBar="True"
+    WindowStartupLocation="CenterOwner"
+    mc:Ignorable="d">
+    <DockPanel>
+        <ui:TitleBar
+            Title="{Binding Title}"
+            DockPanel.Dock="Top" />
+        <Grid Margin="16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="340" />
+                <ColumnDefinition Width="16" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <DockPanel Grid.Column="0" LastChildFill="True">
+                <StackPanel DockPanel.Dock="Top">
+                    <ui:TextBlock
+                        FontTypography="Subtitle"
+                        Text="Live readout" />
+                    <ui:InfoBar
+                        Margin="0,8,0,8"
+                        IsClosable="False"
+                        IsOpen="True"
+                        Message="{Binding StatusText}"
+                        Severity="{Binding StatusSeverity}" />
+                    <ui:TextBlock Margin="0,4,0,0" Text="{Binding PathText}" />
+                    <ui:TextBlock Margin="0,12,0,0" Text="Raw accel X Y Z" />
+                    <ui:TextBlock Text="{Binding RawAccelText}" />
+                    <ui:TextBlock Margin="0,8,0,0" Text="Calibrated accel" />
+                    <ui:TextBlock Text="{Binding CalAccelText}" />
+                    <ui:TextBlock Margin="0,8,0,0" Text="Acceleration" />
+                    <ui:TextBlock Text="{Binding AccelGText}" />
+                    <ui:TextBlock Margin="0,8,0,0" Text="Raw / calibrated gyro" />
+                    <ui:TextBlock Text="{Binding RawGyroText}" />
+                    <ui:TextBlock Text="{Binding CalGyroText}" />
+                    <ui:TextBlock Text="{Binding GyroDpsText}" />
+                    <ui:TextBlock Margin="0,8,0,0" Text="EEPROM calibration" />
+                    <ui:TextBlock TextWrapping="Wrap" Text="{Binding EepromText}" />
+                    <ui:TextBlock Margin="0,8,0,0" Text="Tracker" />
+                    <ui:TextBlock Text="{Binding TrackerText}" />
+                    <ui:TextBlock Margin="0,8,0,0" Text="Sample" />
+                    <ui:TextBlock Text="{Binding SampleText}" />
+                    <ui:TextBlock
+                        Margin="0,12,0,0"
+                        TextWrapping="Wrap"
+                        Text="{Binding YawNote}" />
+                </StackPanel>
+                <StackPanel
+                    Margin="0,16,0,0"
+                    DockPanel.Dock="Bottom"
+                    Orientation="Horizontal">
+                    <ui:Button
+                        Margin="0,0,8,0"
+                        Command="{Binding RecenterCommand}"
+                        Content="Recenter" />
+                    <ui:Button Command="{Binding TogglePauseCommand}">
+                        <ui:Button.Style>
+                            <Style BasedOn="{StaticResource {x:Type ui:Button}}" TargetType="ui:Button">
+                                <Setter Property="Content" Value="Pause" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsPaused}" Value="True">
+                                        <Setter Property="Content" Value="Resume" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ui:Button.Style>
+                    </ui:Button>
+                </StackPanel>
+            </DockPanel>
+            <h:HelixViewport3D
+                x:Name="Viewport"
+                Grid.Column="2"
+                ZoomExtentsWhenLoaded="True">
+                <h:DefaultLights />
+                <h:GridLinesVisual3D
+                    Length="12"
+                    MajorDistance="4"
+                    MinorDistance="1"
+                    Width="12" />
+                <ModelVisual3D x:Name="PadModel" />
+            </h:HelixViewport3D>
+        </Grid>
+    </DockPanel>
+</ui:FluentWindow>

--- a/ControlApp/Views/Windows/MotionViewerWindow.xaml.cs
+++ b/ControlApp/Views/Windows/MotionViewerWindow.xaml.cs
@@ -1,0 +1,102 @@
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+
+using HelixToolkit.Wpf;
+
+using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
+
+namespace Nefarius.DsHidMini.ControlApp.Views.Windows;
+
+public partial class MotionViewerWindow
+{
+    private readonly AxisAngleRotation3D _pitch = new(new Vector3D(0, 0, 1), 0);
+    private readonly AxisAngleRotation3D _roll = new(new Vector3D(1, 0, 0), 0);
+    private readonly AxisAngleRotation3D _yaw = new(new Vector3D(0, 1, 0), 0);
+    private readonly MotionViewerViewModel _viewModel;
+
+    public MotionViewerWindow(MotionViewerViewModel viewModel)
+    {
+        _viewModel = viewModel;
+        DataContext = viewModel;
+        InitializeComponent();
+        BuildPadModel();
+        viewModel.PoseChanged += OnPoseChanged;
+        Closed += (_, _) =>
+        {
+            viewModel.PoseChanged -= OnPoseChanged;
+            viewModel.Dispose();
+        };
+        viewModel.Start();
+    }
+
+    private void OnPoseChanged(object? sender, EventArgs e)
+    {
+        _yaw.Angle = _viewModel.Estimator.YawDegrees;
+        _pitch.Angle = _viewModel.Estimator.PitchDegrees;
+        _roll.Angle = _viewModel.Estimator.RollDegrees;
+    }
+
+    private void BuildPadModel()
+    {
+        PadModel.Children.Add(new BoxVisual3D
+        {
+            Center = new Point3D(0, 0.15, 0),
+            Length = 3.6,
+            Width = 1.8,
+            Height = 0.3,
+            Fill = new SolidColorBrush(Colors.SteelBlue)
+        });
+        PadModel.Children.Add(new BoxVisual3D
+        {
+            Center = new Point3D(-1.7, -0.15, 0.15),
+            Length = 0.9,
+            Width = 1.3,
+            Height = 0.45,
+            Fill = new SolidColorBrush(Colors.DodgerBlue)
+        });
+        PadModel.Children.Add(new BoxVisual3D
+        {
+            Center = new Point3D(1.7, -0.15, 0.15),
+            Length = 0.9,
+            Width = 1.3,
+            Height = 0.45,
+            Fill = new SolidColorBrush(Colors.DodgerBlue)
+        });
+        PadModel.Children.Add(new BoxVisual3D
+        {
+            Center = new Point3D(0, 0.28, 0.55),
+            Length = 1.1,
+            Width = 0.45,
+            Height = 0.12,
+            Fill = new SolidColorBrush(Colors.LightSteelBlue)
+        });
+
+        Transform3DGroup transform = new();
+        transform.Children.Add(new RotateTransform3D(_roll));
+        transform.Children.Add(new RotateTransform3D(_pitch));
+        transform.Children.Add(new RotateTransform3D(_yaw));
+        PadModel.Transform = transform;
+
+        Viewport.Children.Add(new ArrowVisual3D
+        {
+            Point1 = new Point3D(0, 0, 0),
+            Point2 = new Point3D(2.4, 0, 0),
+            Diameter = 0.06,
+            Fill = Brushes.IndianRed
+        });
+        Viewport.Children.Add(new ArrowVisual3D
+        {
+            Point1 = new Point3D(0, 0, 0),
+            Point2 = new Point3D(0, 2.0, 0),
+            Diameter = 0.06,
+            Fill = Brushes.YellowGreen
+        });
+        Viewport.Children.Add(new ArrowVisual3D
+        {
+            Point1 = new Point3D(0, 0, 0),
+            Point2 = new Point3D(0, 0, 2.0),
+            Diameter = 0.06,
+            Fill = Brushes.CornflowerBlue
+        });
+    }
+}

--- a/ControlApp/Views/Windows/MotionViewerWindow.xaml.cs
+++ b/ControlApp/Views/Windows/MotionViewerWindow.xaml.cs
@@ -21,10 +21,10 @@ public partial class MotionViewerWindow
         InitializeComponent();
         BuildPadModel();
         viewModel.PoseChanged += OnPoseChanged;
-        Closed += (_, _) =>
+        Closed += async (_, _) =>
         {
             viewModel.PoseChanged -= OnPoseChanged;
-            viewModel.Dispose();
+            await viewModel.ShutdownAsync();
         };
         viewModel.Start();
     }

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
@@ -109,6 +109,140 @@ public partial class DsHidMiniInterop
     }
 
     /// <summary>
+    ///     Attempts to read the current <see cref="DsMotionSnapshot" /> for a device slot.
+    /// </summary>
+    /// <remarks>
+    ///     Uses the same per-slot HID wait event as <see cref="GetRawInputReport" />.
+    ///     When the connected driver has no motion region (older builds), this
+    ///     returns <see langword="false" />. Check <see cref="HasMotionTelemetry" />.
+    /// </remarks>
+    /// <param name="deviceIndex">The one-based device index.</param>
+    /// <param name="snapshot">Receives a stable seqlock copy when the method returns true.</param>
+    /// <param name="timeout">Optional timeout to wait for a snapshot update. Default invocation returns immediately.</param>
+    /// <returns>
+    ///     TRUE if <paramref name="snapshot" /> was filled, FALSE if motion telemetry
+    ///     is unavailable, the slot is empty, or a timeout expired.
+    /// </returns>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public unsafe bool GetMotionSnapshot(int deviceIndex, out DsMotionSnapshot snapshot, TimeSpan? timeout = null)
+    {
+        snapshot = default;
+
+        if (!HasMotionTelemetry || _motionView is null)
+        {
+            return false;
+        }
+
+        ValidateDeviceIndex(deviceIndex);
+
+        nuint byteOffset = (nuint)((deviceIndex - 1) * Marshal.SizeOf<DsMotionSnapshot>());
+        void* pMessage = (byte*)_motionView.Value + byteOffset;
+        ref DsMotionSnapshot message = ref Unsafe.AsRef<DsMotionSnapshot>(pMessage);
+
+        if (timeout.HasValue)
+        {
+            EventWaitHandle waitEvent;
+            try
+            {
+                waitEvent = GetOrOpenHidReportWaitEvent(deviceIndex);
+            }
+            catch (WaitHandleCannotBeOpenedException)
+            {
+                return false;
+            }
+
+            Stopwatch waitClock = Stopwatch.StartNew();
+            TimeSpan waitBudget = timeout.Value < TimeSpan.Zero ? TimeSpan.Zero : timeout.Value;
+            while (true)
+            {
+                int sequence = Volatile.Read(ref message.SequenceNumber);
+                if ((sequence & 1) == 0
+                    && sequence != 0
+                    && (!_lastSeenMotionSequences.TryGetValue(deviceIndex, out int lastSeen) || sequence != lastSeen))
+                {
+                    return TryCopyMotionSnapshot(deviceIndex, ref message, waitBudget - waitClock.Elapsed, out snapshot);
+                }
+
+                if (message.SlotIndex == 0)
+                {
+                    return false;
+                }
+
+                TimeSpan waitRemaining = waitBudget - waitClock.Elapsed;
+                if (waitRemaining <= TimeSpan.Zero)
+                {
+                    return false;
+                }
+
+                if ((sequence & 1) == 0
+                    && _lastSeenMotionSequences.TryGetValue(deviceIndex, out lastSeen)
+                    && sequence == lastSeen)
+                {
+                    Thread.Sleep((int)Math.Min(waitRemaining.TotalMilliseconds, 1));
+                }
+                else
+                {
+                    waitEvent.WaitOne(waitRemaining);
+                }
+            }
+        }
+
+        return TryCopyMotionSnapshot(deviceIndex, ref message, timeout: null, out snapshot);
+    }
+
+    private bool TryCopyMotionSnapshot(
+        int deviceIndex,
+        ref DsMotionSnapshot message,
+        TimeSpan? timeout,
+        out DsMotionSnapshot snapshot
+    )
+    {
+        Stopwatch? copyClock = timeout.HasValue ? Stopwatch.StartNew() : null;
+        TimeSpan copyBudget = timeout.GetValueOrDefault();
+        bool allowOneAttempt = timeout.HasValue && copyBudget <= TimeSpan.Zero;
+
+        while (true)
+        {
+            if (copyClock is not null && !allowOneAttempt && copyClock.Elapsed >= copyBudget)
+            {
+                snapshot = default;
+                return false;
+            }
+
+            allowOneAttempt = false;
+
+            int first = Volatile.Read(ref message.SequenceNumber);
+            if ((first & 1) != 0)
+            {
+                Thread.Yield();
+                continue;
+            }
+
+            if (message.SlotIndex == 0)
+            {
+                snapshot = default;
+                return false;
+            }
+
+            if (message.SlotIndex != deviceIndex)
+            {
+                throw new DsHidMiniInteropUnexpectedReplyException();
+            }
+
+            DsMotionSnapshot copy = message;
+            int second = Volatile.Read(ref message.SequenceNumber);
+            if (first != second)
+            {
+                continue;
+            }
+
+            snapshot = copy;
+            _lastSeenMotionSequences[deviceIndex] = first;
+            return true;
+        }
+    }
+
+    /// <summary>
     ///     Copies a stable HID slot snapshot using the driver seqlock.
     /// </summary>
     private bool TryCopyRawInputReport(

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.Commands.cs
@@ -127,67 +127,75 @@ public partial class DsHidMiniInterop
     public unsafe bool GetMotionSnapshot(int deviceIndex, out DsMotionSnapshot snapshot, TimeSpan? timeout = null)
     {
         snapshot = default;
-
-        if (!HasMotionTelemetry || _motionView is null)
+        _motionViewLock.EnterReadLock();
+        try
         {
-            return false;
-        }
-
-        ValidateDeviceIndex(deviceIndex);
-
-        nuint byteOffset = (nuint)((deviceIndex - 1) * Marshal.SizeOf<DsMotionSnapshot>());
-        void* pMessage = (byte*)_motionView.Value + byteOffset;
-        ref DsMotionSnapshot message = ref Unsafe.AsRef<DsMotionSnapshot>(pMessage);
-
-        if (timeout.HasValue)
-        {
-            EventWaitHandle waitEvent;
-            try
-            {
-                waitEvent = GetOrOpenHidReportWaitEvent(deviceIndex);
-            }
-            catch (WaitHandleCannotBeOpenedException)
+            if (_motionView is null || IsNullMappedView(_motionView))
             {
                 return false;
             }
 
-            Stopwatch waitClock = Stopwatch.StartNew();
-            TimeSpan waitBudget = timeout.Value < TimeSpan.Zero ? TimeSpan.Zero : timeout.Value;
-            while (true)
+            ValidateDeviceIndex(deviceIndex);
+
+            nuint byteOffset = (nuint)((deviceIndex - 1) * Marshal.SizeOf<DsMotionSnapshot>());
+            void* pMessage = (byte*)_motionView.Value + byteOffset;
+            ref DsMotionSnapshot message = ref Unsafe.AsRef<DsMotionSnapshot>(pMessage);
+
+            if (timeout.HasValue)
             {
-                int sequence = Volatile.Read(ref message.SequenceNumber);
-                if ((sequence & 1) == 0
-                    && sequence != 0
-                    && (!_lastSeenMotionSequences.TryGetValue(deviceIndex, out int lastSeen) || sequence != lastSeen))
+                EventWaitHandle waitEvent;
+                try
                 {
-                    return TryCopyMotionSnapshot(deviceIndex, ref message, waitBudget - waitClock.Elapsed, out snapshot);
+                    waitEvent = GetOrOpenHidReportWaitEvent(deviceIndex);
                 }
-
-                if (message.SlotIndex == 0)
+                catch (WaitHandleCannotBeOpenedException)
                 {
                     return false;
                 }
 
-                TimeSpan waitRemaining = waitBudget - waitClock.Elapsed;
-                if (waitRemaining <= TimeSpan.Zero)
+                Stopwatch waitClock = Stopwatch.StartNew();
+                TimeSpan waitBudget = timeout.Value < TimeSpan.Zero ? TimeSpan.Zero : timeout.Value;
+                while (true)
                 {
-                    return false;
-                }
+                    int sequence = Volatile.Read(ref message.SequenceNumber);
+                    if ((sequence & 1) == 0
+                        && sequence != 0
+                        && (!_lastSeenMotionSequences.TryGetValue(deviceIndex, out int lastSeen) || sequence != lastSeen))
+                    {
+                        return TryCopyMotionSnapshot(deviceIndex, ref message, waitBudget - waitClock.Elapsed, out snapshot);
+                    }
 
-                if ((sequence & 1) == 0
-                    && _lastSeenMotionSequences.TryGetValue(deviceIndex, out lastSeen)
-                    && sequence == lastSeen)
-                {
-                    Thread.Sleep((int)Math.Min(waitRemaining.TotalMilliseconds, 1));
-                }
-                else
-                {
-                    waitEvent.WaitOne(waitRemaining);
+                    if (message.SlotIndex == 0)
+                    {
+                        return false;
+                    }
+
+                    TimeSpan waitRemaining = waitBudget - waitClock.Elapsed;
+                    if (waitRemaining <= TimeSpan.Zero)
+                    {
+                        return false;
+                    }
+
+                    if ((sequence & 1) == 0
+                        && _lastSeenMotionSequences.TryGetValue(deviceIndex, out lastSeen)
+                        && sequence == lastSeen)
+                    {
+                        Thread.Sleep((int)Math.Min(waitRemaining.TotalMilliseconds, 1));
+                    }
+                    else
+                    {
+                        waitEvent.WaitOne(waitRemaining);
+                    }
                 }
             }
-        }
 
-        return TryCopyMotionSnapshot(deviceIndex, ref message, timeout: null, out snapshot);
+            return TryCopyMotionSnapshot(deviceIndex, ref message, timeout: null, out snapshot);
+
+        }
+        finally
+        {
+            _motionViewLock.ExitReadLock();
+        }
     }
 
     private bool TryCopyMotionSnapshot(

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.cs
@@ -43,9 +43,11 @@ public sealed partial class DsHidMiniInterop : IDisposable
 
     private SafeFileHandle? _fileMapping;
     private MEMORY_MAPPED_VIEW_ADDRESS? _hidView;
+    private MEMORY_MAPPED_VIEW_ADDRESS? _motionView;
 
     private readonly ConcurrentDictionary<int, EventWaitHandle> _inputReportWaitEvents = new();
     private readonly ConcurrentDictionary<int, int> _lastSeenSequences = new();
+    private readonly ConcurrentDictionary<int, int> _lastSeenMotionSequences = new();
 
     private EventWaitHandle? _readEvent;
     private EventWaitHandle? _writeEvent;
@@ -100,6 +102,12 @@ public sealed partial class DsHidMiniInterop : IDisposable
         if (_hidView.HasValue)
         {
             PInvoke.UnmapViewOfFile(_hidView.Value);
+        }
+
+        if (_motionView.HasValue)
+        {
+            PInvoke.UnmapViewOfFile(_motionView.Value);
+            _motionView = null;
         }
 
         _fileMapping?.Dispose();
@@ -173,6 +181,21 @@ public sealed partial class DsHidMiniInterop : IDisposable
             {
                 throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to access HID view");
             }
+
+            //
+            // Optional third region at 2 * allocation granularity. Older
+            // drivers only expose two regions; MapViewOfFile then fails and
+            // GetMotionSnapshot returns false.
+            //
+            MEMORY_MAPPED_VIEW_ADDRESS motionView = PInvoke.MapViewOfFile(
+                _fileMapping,
+                FILE_MAP.FILE_MAP_READ,
+                0,
+                systemInfo.dwAllocationGranularity * 2,
+                systemInfo.dwAllocationGranularity
+            );
+
+            _motionView = IsNullMappedView(motionView) ? null : motionView;
         }
         catch (FileNotFoundException)
         {
@@ -246,6 +269,7 @@ public sealed partial class DsHidMiniInterop : IDisposable
                 || !string.Equals(previous, GetDeviceIdentity(device), StringComparison.OrdinalIgnoreCase))
             {
                 _lastSeenSequences.TryRemove(slot, out _);
+                _lastSeenMotionSequences.TryRemove(slot, out _);
             }
         }
 
@@ -314,7 +338,14 @@ public sealed partial class DsHidMiniInterop : IDisposable
     {
         DisposeInputReportWaitHandles();
         _lastSeenSequences.Clear();
+        _lastSeenMotionSequences.Clear();
     }
+
+    /// <summary>
+    ///     <see langword="true" /> when this client mapped the driver's motion
+    ///     telemetry region. Older drivers leave this <see langword="false" />.
+    /// </summary>
+    public bool HasMotionTelemetry => _motionView is { } view && !IsNullMappedView(view);
 
     private void DisposeInputReportWaitHandles()
     {

--- a/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/DsHidMiniInterop.cs
@@ -44,6 +44,7 @@ public sealed partial class DsHidMiniInterop : IDisposable
     private SafeFileHandle? _fileMapping;
     private MEMORY_MAPPED_VIEW_ADDRESS? _hidView;
     private MEMORY_MAPPED_VIEW_ADDRESS? _motionView;
+    private readonly ReaderWriterLockSlim _motionViewLock = new();
 
     private readonly ConcurrentDictionary<int, EventWaitHandle> _inputReportWaitEvents = new();
     private readonly ConcurrentDictionary<int, int> _lastSeenSequences = new();
@@ -104,10 +105,18 @@ public sealed partial class DsHidMiniInterop : IDisposable
             PInvoke.UnmapViewOfFile(_hidView.Value);
         }
 
-        if (_motionView.HasValue)
+        _motionViewLock.EnterWriteLock();
+        try
         {
-            PInvoke.UnmapViewOfFile(_motionView.Value);
-            _motionView = null;
+            if (_motionView.HasValue)
+            {
+                PInvoke.UnmapViewOfFile(_motionView.Value);
+                _motionView = null;
+            }
+        }
+        finally
+        {
+            _motionViewLock.ExitWriteLock();
         }
 
         _fileMapping?.Dispose();
@@ -187,15 +196,23 @@ public sealed partial class DsHidMiniInterop : IDisposable
             // drivers only expose two regions; MapViewOfFile then fails and
             // GetMotionSnapshot returns false.
             //
-            MEMORY_MAPPED_VIEW_ADDRESS motionView = PInvoke.MapViewOfFile(
-                _fileMapping,
-                FILE_MAP.FILE_MAP_READ,
-                0,
-                systemInfo.dwAllocationGranularity * 2,
-                systemInfo.dwAllocationGranularity
-            );
+            _motionViewLock.EnterWriteLock();
+            try
+            {
+                MEMORY_MAPPED_VIEW_ADDRESS motionView = PInvoke.MapViewOfFile(
+                    _fileMapping,
+                    FILE_MAP.FILE_MAP_READ,
+                    0,
+                    systemInfo.dwAllocationGranularity * 2,
+                    systemInfo.dwAllocationGranularity
+                );
 
-            _motionView = IsNullMappedView(motionView) ? null : motionView;
+                _motionView = IsNullMappedView(motionView) ? null : motionView;
+            }
+            finally
+            {
+                _motionViewLock.ExitWriteLock();
+            }
         }
         catch (FileNotFoundException)
         {
@@ -345,7 +362,21 @@ public sealed partial class DsHidMiniInterop : IDisposable
     ///     <see langword="true" /> when this client mapped the driver's motion
     ///     telemetry region. Older drivers leave this <see langword="false" />.
     /// </summary>
-    public bool HasMotionTelemetry => _motionView is { } view && !IsNullMappedView(view);
+    public bool HasMotionTelemetry
+    {
+        get
+        {
+            _motionViewLock.EnterReadLock();
+            try
+            {
+                return _motionView is { } view && !IsNullMappedView(view);
+            }
+            finally
+            {
+                _motionViewLock.ExitReadLock();
+            }
+        }
+    }
 
     private void DisposeInputReportWaitHandles()
     {

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/MotionSnapshot.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/MotionSnapshot.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+using Nefarius.DsHidMini.IPC.Models.Drivers;
+
+namespace Nefarius.DsHidMini.IPC.Models.Public;
+
+/// <summary>
+///     Status bits for <see cref="DsMotionSnapshot" />. Must stay in sync with
+///     <c>DSHM_IPC_MOTION_FLAG_*</c> in the driver.
+/// </summary>
+[Flags]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public enum DsMotionSnapshotFlags : ushort
+{
+    None = 0,
+
+    /// <summary>
+    ///     The slot contains a processed sample.
+    /// </summary>
+    Available = 0x0001,
+
+    /// <summary>
+    ///     EEPROM page <c>0xA0</c> was not used. Nominal <c>zero=512</c>,
+    ///     <c>oneG=399</c> are in effect (Bluetooth, or a failed USB read).
+    /// </summary>
+    Fallback = 0x0002,
+
+    /// <summary>
+    ///     The driver is writing a hardware gyro cal byte on USB output reports.
+    /// </summary>
+    HardwareCal = 0x0004,
+
+    /// <summary>
+    ///     Sony's auto-zero tracker is running (<c>HW_CAL</c> / <c>SIXAXIS</c>).
+    /// </summary>
+    Tracker = 0x0008
+}
+
+/// <summary>
+///     Versioned per-slot motion telemetry. Pack=1, 80 bytes; must stay in sync
+///     with driver <c>IPC_MOTION_SNAPSHOT_MESSAGE</c>.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public struct DsMotionSnapshot
+{
+    public const ushort CurrentVersion = 1;
+
+    public const int Size = 80;
+
+    public uint SlotIndex;
+
+    public int SequenceNumber;
+
+    public ushort Version;
+
+    public DsMotionSnapshotFlags Flags;
+
+    public ushort AccelZeroX;
+
+    public ushort AccelZeroY;
+
+    public ushort AccelZeroZ;
+
+    public ushort AccelOneGX;
+
+    public ushort AccelOneGY;
+
+    public ushort AccelOneGZ;
+
+    public ushort GyroZero;
+
+    public ushort GyroEepromCal;
+
+    public ushort RawAccelX;
+
+    public ushort RawAccelY;
+
+    public ushort RawAccelZ;
+
+    public ushort RawGyro;
+
+    public short CalAccelX;
+
+    public short CalAccelY;
+
+    public short CalAccelZ;
+
+    public ushort CalGyro;
+
+    public int AccelMilliGX;
+
+    public int AccelMilliGY;
+
+    public int AccelMilliGZ;
+
+    public int GyroMilliDps;
+
+    public int ZeroRef;
+
+    public uint SampleIndex;
+
+    public ulong TimestampQpc;
+
+    public byte CalByte;
+
+    public DsIdentificationMotionPath MotionPath;
+
+    public byte Reserved0;
+
+    public byte Reserved1;
+
+    public bool IsAvailable => (Flags & DsMotionSnapshotFlags.Available) != 0;
+
+    public bool IsFallback => (Flags & DsMotionSnapshotFlags.Fallback) != 0;
+
+    public bool HasTracker => (Flags & DsMotionSnapshotFlags.Tracker) != 0;
+}

--- a/SDK/Nefarius.DsHidMini.IPC/README.md
+++ b/SDK/Nefarius.DsHidMini.IPC/README.md
@@ -29,14 +29,15 @@ Connect your .NET application to DsHidMini via shared memory and named synchroni
 
 DsHidMini is a Windows kernel-mode driver that enables SIXAXIS/DualShock 3 (and compatible) controllers to work as HID or XInput devices. This library is the **client-side SDK** that talks to the driver over:
 
-- **Shared memory** — command channel and HID input report data
+- **Shared memory** — command channel, HID input report data, and (on current drivers) a third allocation-granularity-aligned motion telemetry region. Older drivers expose only the first two regions; this SDK keeps mapping those unchanged.
 - **Named events and mutex** — request/response synchronization
 
 Use it from a .NET Standard 2.0 consumer or a .NET 10 Windows application (desktop, service, or tray tool) to:
 
 | Capability | Description |
 |------------|-------------|
-| **Read raw input** | Poll or wait for `DS3_RAW_INPUT_REPORT` (buttons, sticks, pressure, motion) |
+| **Read raw input** | Poll or wait for `DS3_RAW_INPUT_REPORT` (buttons, sticks, pressure, raw motion bytes) |
+| **Read motion telemetry** | Poll or wait for `DsMotionSnapshot` (calibrated accel/gyro, EEPROM pairs, tracker state). Older drivers without the third shared-memory region return `false`. |
 | **Pair to host** | Set the Bluetooth host address the controller pairs to (`SetHostAddress`) or pair to the active local radio (`PairToCurrentHost`) |
 | **Player index** | Set the player LED slot (1–7) with `SetPlayerIndex` (volatile) |
 | **LED pattern** | Apply flags plus four independent effect blocks with `SetLedPattern` (volatile) |
@@ -123,7 +124,9 @@ if (gotReport)
 | **`DsHidMiniInterop()`** | Connects to the driver IPC. Throws if not available. Subscribes to device arrival/removal for reconnection. |
 | **`void Dispose()`** | Releases mapped views, file mapping, and events. Implement `IDisposable` and dispose when done. |
 | **`void Reconnect()`** | Re-opens mutex, events, and shared memory (e.g. after all devices were removed). Throws if still no device. |
+| **`bool HasMotionTelemetry`** | `true` when this client mapped the driver’s motion region. `false` on older drivers. |
 | **`bool GetRawInputReport(int deviceIndex, ref DS3_RAW_INPUT_REPORT report, TimeSpan? timeout)`** | Fills `report` with the last or next raw HID report. Use `timeout: null` for immediate read; use e.g. `TimeSpan.FromMilliseconds(20)` for event-based waiting on the driver’s named per-slot manual-reset event (`Global\DsHidMiniHidReportEvent` + index). Multiple clients can wait on the same slot. Returns `false` if the slot is empty, or if a timeout was requested and no wait object exists for that slot (nothing connected there). |
+| **`bool GetMotionSnapshot(int deviceIndex, out DsMotionSnapshot snapshot, TimeSpan? timeout)`** | Fills `snapshot` with the last or next seqlock-protected motion telemetry. Uses the same per-slot wait event as `GetRawInputReport`. Returns `false` when the driver has no motion region, the slot is empty, or a timeout expires. |
 | **`void SendPing()`** | Sends a ping to the driver and waits for a reply (liveness check). |
 | **`SetHostResult SetHostAddress(int deviceIndex, PhysicalAddress hostAddress)`** | Writes the new Bluetooth host address (pairing). Does not persist pairing mode. Returns write/read NTSTATUS in `SetHostResult`. |
 | **`SetHostResult PairToCurrentHost(int deviceIndex)`** | Pairs the device to the active local Bluetooth radio. Wired devices only; does not persist pairing mode. |
@@ -156,7 +159,15 @@ All device-indexed APIs use a **one-based** device index (see [Device index](#de
 - **Sticks:** `LeftThumbX/Y`, `RightThumbX/Y` (0x00 = min, 0x80 = center, 0xFF = max).  
 - **Pressure:** `report.Pressure.Values` — per-button pressure (Up, Down, Left, Right, L1, R1, L2, R2, Triangle, Circle, Cross, Square).  
 - **Battery:** `BatteryStatus` (see `DsBatteryStatus` in API docs).  
-- **Motion:** `AccelerometerX/Y/Z`, `Gyroscope`.
+- **Motion:** `AccelerometerX/Y/Z`, `Gyroscope` as raw big-endian device bytes. Prefer `GetMotionSnapshot` for calibrated values.
+
+### `DsMotionSnapshot` (calibrated motion)
+
+- **Layout:** 80-byte `Pack = 1` struct, version `DsMotionSnapshot.CurrentVersion` (`1`). Must stay in sync with driver `IPC_MOTION_SNAPSHOT_MESSAGE`.
+- **Flags:** `Available`, `Fallback` (nominal 512/399), `HardwareCal`, `Tracker`.
+- **Calibration:** EEPROM `AccelZero*` / `AccelOneG*` pairs, `GyroZero`, `GyroEepromCal`, live `CalByte`, `ZeroRef`, `MotionPath`.
+- **Samples:** raw and Sony-corrected axes, milli-g, milli-deg/s, `SampleIndex`, QPC timestamp.
+- **Compatibility:** mapping the third region is optional. `HasMotionTelemetry` is `false` and `GetMotionSnapshot` returns `false` against older drivers.
 
 ### `SetHostResult` (pairing result)
 

--- a/SDK/Nefarius.DsHidMini.IPC/docs/index.md
+++ b/SDK/Nefarius.DsHidMini.IPC/docs/index.md
@@ -30,6 +30,10 @@
 
 - [DS3_RAW_INPUT_REPORT](./nefarius.dshidmini.ipc.models.public.ds3_raw_input_report.md)
 
+- [DsMotionSnapshot](./nefarius.dshidmini.ipc.models.public.dsmotionsnapshot.md)
+
+- [DsMotionSnapshotFlags](./nefarius.dshidmini.ipc.models.public.dsmotionsnapshotflags.md)
+
 - [SetHostResult](./nefarius.dshidmini.ipc.models.public.sethostresult.md)
 
 - [WDF_USB_CONTROL_SETUP_PACKET](./nefarius.dshidmini.ipc.models.public.wdf_usb_control_setup_packet.md)

--- a/SDK/Nefarius.DsHidMini.IPC/docs/nefarius.dshidmini.ipc.dshidminiinterop.md
+++ b/SDK/Nefarius.DsHidMini.IPC/docs/nefarius.dshidmini.ipc.dshidminiinterop.md
@@ -26,6 +26,18 @@ public static bool IsAvailable { get; }
 
 [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)<br>
 
+### <a id="properties-hasmotiontelemetry"/>**HasMotionTelemetry**
+
+`true` when this client mapped the driver’s motion telemetry region. Older drivers leave this `false`.
+
+```csharp
+public bool HasMotionTelemetry { get; }
+```
+
+#### Property Value
+
+[Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)<br>
+
 ## Constructors
 
 ### <a id="constructors-.ctor"/>**DsHidMiniInterop()**
@@ -96,6 +108,33 @@ If `timeout` is null, this method returns the last known input report copy immed
  When `timeout` is set, the implementation waits on the driver's per-slot named manual-reset event
  (same DACL as other IPC objects); it does not require administrator elevation. Multiple clients can wait on the
  same slot without splitting wakeups.
+
+### <a id="methods-getmotionsnapshot"/>**GetMotionSnapshot(Int32, out DsMotionSnapshot, Nullable&lt;TimeSpan&gt;)**
+
+Attempts to read the current [DsMotionSnapshot](./nefarius.dshidmini.ipc.models.public.dsmotionsnapshot.md) for a device slot.
+
+```csharp
+public bool GetMotionSnapshot(int deviceIndex, out DsMotionSnapshot snapshot, Nullable<TimeSpan> timeout)
+```
+
+#### Parameters
+
+`deviceIndex` [Int32](https://learn.microsoft.com/dotnet/api/system.int32)<br>
+The one-based device index.
+
+`snapshot` [DsMotionSnapshot](./nefarius.dshidmini.ipc.models.public.dsmotionsnapshot.md)<br>
+Receives a stable seqlock copy when the method returns true.
+
+`timeout` [Nullable](https://learn.microsoft.com/dotnet/api/system.nullable-1)<[TimeSpan](https://learn.microsoft.com/dotnet/api/system.timespan)><br>
+Optional timeout to wait for a snapshot update. Default invocation returns immediately.
+
+#### Returns
+
+TRUE if `snapshot` was filled, FALSE if motion telemetry is unavailable, the slot is empty, or a timeout expires.
+
+**Remarks:**
+
+Uses the same per-slot HID wait event as [GetRawInputReport](./nefarius.dshidmini.ipc.dshidminiinterop.md#methods-getrawinputreport). When the connected driver has no motion region, this returns `false`. Check [HasMotionTelemetry](./nefarius.dshidmini.ipc.dshidminiinterop.md#properties-hasmotiontelemetry).
 
 ### <a id="methods-reconnect"/>**Reconnect()**
 

--- a/SDK/Nefarius.DsHidMini.IPC/docs/nefarius.dshidmini.ipc.models.public.dsmotionsnapshot.md
+++ b/SDK/Nefarius.DsHidMini.IPC/docs/nefarius.dshidmini.ipc.models.public.dsmotionsnapshot.md
@@ -1,0 +1,38 @@
+# DsMotionSnapshot
+
+Namespace: Nefarius.DsHidMini.IPC.Models.Public
+
+Versioned per-slot motion telemetry. Pack=1, 80 bytes; must stay in sync with driver `IPC_MOTION_SNAPSHOT_MESSAGE`.
+
+```csharp
+public struct DsMotionSnapshot
+```
+
+## Fields
+
+| Name | Type | Description |
+|------|------|-------------|
+| `SlotIndex` | `UInt32` | One-based IPC slot. |
+| `SequenceNumber` | `Int32` | Seqlock generation (odd = write in progress). |
+| `Version` | `UInt16` | Snapshot layout version (`CurrentVersion` = 1). |
+| `Flags` | `DsMotionSnapshotFlags` | Availability / fallback / tracker bits. |
+| `AccelZeroX/Y/Z` | `UInt16` | EEPROM 0 g readings. |
+| `AccelOneGX/Y/Z` | `UInt16` | EEPROM −1 g readings. |
+| `GyroZero` | `UInt16` | EEPROM gyro rest reading. |
+| `GyroEepromCal` | `UInt16` | EEPROM factory cal byte. |
+| `RawAccelX/Y/Z`, `RawGyro` | `UInt16` | Host-order raw sensor values. |
+| `CalAccelX/Y/Z` | `Int16` | Sony-calibrated accelerometer (X mirrored). |
+| `CalGyro` | `UInt16` | Sony-calibrated yaw gyro. |
+| `AccelMilliGX/Y/Z` | `Int32` | Calibrated acceleration in milli-g. |
+| `GyroMilliDps` | `Int32` | Calibrated yaw rate in milli-deg/s. |
+| `ZeroRef` | `Int32` | Tracker or EEPROM gyro zero. |
+| `SampleIndex` | `UInt32` | Monotonic sample counter. |
+| `TimestampQpc` | `UInt64` | `QueryPerformanceCounter` timestamp. |
+| `CalByte` | `Byte` | Active output cal byte. |
+| `MotionPath` | `DsIdentificationMotionPath` | Gyro path. |
+
+## Properties
+
+- `IsAvailable`, `IsFallback`, `HasTracker`
+- `CurrentVersion` = 1
+- `Size` = 80

--- a/SDK/Nefarius.DsHidMini.IPC/docs/nefarius.dshidmini.ipc.models.public.dsmotionsnapshotflags.md
+++ b/SDK/Nefarius.DsHidMini.IPC/docs/nefarius.dshidmini.ipc.models.public.dsmotionsnapshotflags.md
@@ -1,0 +1,18 @@
+# DsMotionSnapshotFlags
+
+Namespace: Nefarius.DsHidMini.IPC.Models.Public
+
+Status bits for [DsMotionSnapshot](./nefarius.dshidmini.ipc.models.public.dsmotionsnapshot.md). Must stay in sync with `DSHM_IPC_MOTION_FLAG_*` in the driver.
+
+```csharp
+[Flags]
+public enum DsMotionSnapshotFlags : ushort
+```
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `None` | 0 | No flags. |
+| `Available` | 0x0001 | The slot contains a processed sample. |
+| `Fallback` | 0x0002 | Nominal calibration is in effect. |
+| `HardwareCal` | 0x0004 | The driver writes a hardware gyro cal byte. |
+| `Tracker` | 0x0008 | Sony's auto-zero tracker is running. |

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -464,6 +464,25 @@ partial class Build : NukeBuild
         });
 
     /// <summary>
+    /// Run ControlApp / IPC managed tests (motion ABI, orientation, config).
+    /// </summary>
+    [UsedImplicitly]
+    public Target TestControlApp => _ => _
+        .Executes(() =>
+        {
+            AbsolutePath project = RootDirectory / "ControlApp.Tests" / "ControlApp.Tests.csproj";
+            if (!File.Exists(project))
+            {
+                throw new InvalidOperationException($"ControlApp.Tests project not found at {project}");
+            }
+
+            DotNetTasks.DotNetTest(s => s
+                .SetProjectFile(project)
+                .SetConfiguration(Configuration)
+                .SetLoggers("console;verbosity=minimal"));
+        });
+
+    /// <summary>
     /// Run native DsHidMini.json parser regressions.
     /// </summary>
     [UsedImplicitly]

--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -1,10 +1,10 @@
 # DualShock 3 / SIXAXIS motion sensors
 
-Research notes for [issue #217](https://github.com/nefarius/DsHidMini/issues/217)
+Research notes and implemented behavior for [issue #217](https://github.com/nefarius/DsHidMini/issues/217)
 (motion support). Feature `0x01` is parsed and published as device properties
-(see [What DsHidMini publishes](#what-dshidmini-publishes)); motion output is
-**not** implemented yet beyond the SIXAXIS.SYS byte-swap described in
-[What DsHidMini does today](#what-dshidmini-does-today).
+(see [What DsHidMini publishes](#what-dshidmini-publishes)). USB motion
+calibration, Sony-compatible correction, IPC telemetry, and the ControlApp
+viewer are implemented; see [What DsHidMini does today](#what-dshidmini-does-today).
 
 Sources of truth used, in order of authority:
 
@@ -741,16 +741,33 @@ both platforms, so on Linux it is not zeroed either.
 
 ## What DsHidMini does today
 
-- **SIXAXIS.SYS-compatible mode** (`driver/DsHidMiniDrv.c`, `DSHM_ProcessHidInputReport`):
-  `X = 0x3FF - swap16(X)`, `Y = swap16(Y)`, `Z = swap16(Z)`, `G = swap16(G)` -
-  endianness fixed, X mirrored, **no calibration**, no cal byte. The sensors are
-  exposed only through the emulated `GetFeatureReport`, not the input report.
+- **USB EEPROM read** (`driver/DsMotion.c`, `DsUsb_PrepareHardware`): after
+  `0xF2`/`0xF5` and before the first output report, `SET`/`GET Feature 0xEF`
+  page `0xA0`. Eight big-endian pairs at offset `0x11` are cached. A failed or
+  invalid read does **not** fail device start; the driver keeps nominal
+  `zero=512`, `oneG=399` and sets the IPC fallback flag.
+- **Canonical processing** on every input report: gain-113 accelerometer
+  calibration, X mirrored *after* cal, and one of the three Sony gyro paths
+  from the Feature `0x01` field list (`PLAIN_ZERO` / `HW_CAL` / `SIXAXIS`).
+  Bluetooth uses the same formulas with the nominal fallback and does **not**
+  send hardware cal bytes or attempt `0xEF`.
+- **SIXAXIS.SYS-compatible GetFeature** (`DSHM_ProcessHidInputReport`): the
+  49-byte feature report now carries the calibrated, host-order Sony values.
+  The 12-byte SIXAXIS input report still has no motion fields.
+- **Gyro tracker**: `HW_CAL` and `SIXAXIS` USB pads run the Sony auto-zero
+  tracker (`research/ds3-motion/probe/GyroCal.cs`). When the cal byte steps,
+  the driver re-applies it on the next output report (unified `[5]/[6]` or
+  `[3]/[4]`). Sending the factory byte once is not enough.
+- **IPC**: the existing 60-byte raw HID slot is unchanged. A third
+  allocation-granularity-aligned region publishes `IPC_MOTION_SNAPSHOT_MESSAGE`
+  (80 bytes, version 1). `Nefarius.DsHidMini.IPC` maps it when present and
+  exposes `GetMotionSnapshot`.
+- **ControlApp**: per-device Motion viewer with numeric readout and a
+  diagnostic HelixToolkit pose (gravity pitch/roll, integrated yaw).
 - **DS4Windows-compatible mode** (`driver/DsHid.c`, `DS3_RAW_TO_DS4WINDOWS_HID_INPUT_REPORT`):
-  writes `Output[0..9]` and `Output[30]` only, so the DS4 gyro/accel fields at
-  offsets 13-24 stay zero.
-- Output report bytes 6-7 (with ID) are always `00 00`; equivalent to the PS3's
-  behaviour for pads without calibration field `0x07`.
-- `0xEF`/`0xF8`/`0xF7` are never sent (documented in `PS3_USB_STARTUP.md`).
+  still leaves the DS4 gyro/accel fields at offsets 13-24 zero. Mapping is
+  deferred until the axis permutation is verified.
+- `0xF8`/`0xF7` are still not sent. Bluetooth `0xEF` is deferred.
 
 ### Discrepancies a driver implementation must resolve
 
@@ -808,39 +825,36 @@ Ordered by how visible they are to an application that expects `sixaxis.sys`:
 10. **Bluetooth is untested.** `sixaxis.sys` does all of this over EP0; the same
     feature reports would have to travel the BthPS3 HID control channel.
 
-## Sketch for a future implementation (not part of this pass)
+## Deferred work
 
-1. During USB start (after `0xF2`/`0xF5`, before the first output report,
-   mirroring the PS3), do `SET 0xEF page A0` + `GET 0xEF`, parse the four pairs,
-   keep them in the device context. Over Bluetooth the same feature reports
-   go through the BthPS3 HID control channel (untested).
-2. Read `Feature 0x01` offsets 8 and 0x25/0x26.. and derive Sony's three flags
-   (`DS3_TYPE`, `PLAIN_ZERO`, `HW_CAL`). Interrupt-OUT reports are 49 bytes
-   (report ID at `[0]`): cal byte at bytes 6-7 (field-`0x07` DS3) or 4-5
-   (SIXAXIS). EP0 initialization uses the 48-byte payload (no report ID), so
-   the same pair sits one byte earlier: `[5]/[6]` (DS3) or `[3]/[4]`
-   (SIXAXIS). Seed with `Gyro.oneG`.
-3. Per input report: accel
-   `cal = ((raw - zero) * 1024 / (zero - oneG)) * 113 / 1024 + 512`, mirroring X
-   afterwards, with a `zero == oneG` passthrough guard; gyro per the flag table
-   in [What `sixaxis.sys` actually does](#what-sixaxissys-actually-does).
-4. DS4Windows mode: `accel_ds4 = (raw - zero) * 8192 / (zero - oneG)` with
-   the axis permutation checked against a reference DS4; gyro yaw scaled by the
-   measured ~1.4 counts per (deg/s) into the DS4 gyro-Y slot (a gain of about
-   11.4 for DS4's 16 LSB per deg/s), sign such that clockwise seen from above
-   stays positive, pitch/roll zero.
-5. Counterfeit handling: the `zero == oneG` guard is **not** enough, because
-   the pads seen here return a plausible `0200 0180` template and sail through
-   it. Keep the guard for a genuinely blank EEPROM, but also treat "this axis
-   has not changed in N seconds" as "no sensor" and suppress it, since one of
-   the two counterfeits freezes all four values and the other freezes only the
-   gyro. If `0xEF` fails outright, fall back to `zero = 512,
-   oneG = 512 - 113`.
+The items below were deliberately left out of the current implementation.
+
+1. Bluetooth `Feature 0xEF` over the BthPS3 HID control channel (untested).
+   Wireless pads currently use the documented nominal fallback.
+2. DS4Windows motion-field mapping: `accel_ds4 = (raw - zero) * 8192 / (zero - oneG)`
+   with the axis permutation checked against a reference DS4; gyro yaw scaled by
+   the measured ~1.4 counts per (deg/s) into the DS4 gyro-Y slot (a gain of about
+   11.4 for DS4's 16 LSB per deg/s).
+3. Counterfeit behavioural detection: treat "this axis has not changed in N
+   seconds" as "no sensor". The `zero == oneG` guard remains for a blank EEPROM
+   only; both seen counterfeits return a plausible `0200 0180` template.
+4. A turntable measurement of absolute gyro scale (currently ~1.4 counts/(deg/s)).
 
 ## Status and implementation roadmap
 
-Phase status: **research complete enough to implement**. No driver code was
-changed. Tools and raw dumps live in [`research/ds3-motion/`](../research/ds3-motion/README.md).
+Phase status: **USB path implemented** (driver motion subsystem, IPC snapshot,
+ControlApp viewer). Research dumps remain in
+[`research/ds3-motion/`](../research/ds3-motion/README.md).
+
+### Hardware verification checklist
+
+On at least one `PLAIN_ZERO` and one `HW_CAL` USB pad:
+
+- Flat rest centres near 512 after calibration; six accel poses match the sign table.
+- Clockwise-from-above yaw is positive in the corrected gyro / viewer.
+- Tracker-driven cal-byte resend and convergence (`HW_CAL` / `SIXAXIS`).
+- IPC snapshot and ControlApp Motion viewer (Recenter, expected yaw drift).
+- Disconnect / reconnect, and a failed EEPROM read falling back to 512/399.
 
 ### Verified (a driver can rely on these)
 
@@ -855,18 +869,21 @@ changed. Tools and raw dumps live in [`research/ds3-motion/`](../research/ds3-mo
 
 ### Implementation checklist (ordered)
 
-No code in this pass. Start here next time:
+Shipped in this pass:
 
-1. USB connect (after `0xF2`/`0xF5`, before first output; see `docs/PS3_USB_STARTUP.md`): `SET Feature 0xEF` page `0xA0` + `GET 0xEF`. Cache the four pairs in device context. `driver/DsHidMiniDrv.c` `DSHM_ProcessHidInputReport` / USB start path.
-2. Read `Feature 0x01` offsets 8 and `0x25`/`0x26..`; derive `DS3_TYPE` / `PLAIN_ZERO` / `HW_CAL`. On the 48-byte EP0 output payload place the cal byte at `[5]/[6]` when the field list sets `HW_CAL`, or `[3]/[4]` when it indicates the SIXAXIS path (including SIXAXIS-2); the 49-byte interrupt-OUT report uses bytes 6-7 / 4-5.
-3. Accel in `driver/DsHid.c` `DS3_RAW_TO_SIXAXIS_HID_INPUT_REPORT` and `DS3_RAW_TO_DS4WINDOWS_HID_INPUT_REPORT`: apply the gain-113 formula; move the existing X mirror to **after** cal. Raw layout: `include/DsHidMini/Ds3Types.h` `DS3_RAW_INPUT_REPORT`.
-4. Gyro: invert sign (`512 + zeroRef - raw` or `0x3FF - raw` on `HW_CAL`); apply EEPROM zero. Port `research/ds3-motion/probe/GyroCal.cs` for `HW_CAL`/`SIXAXIS` and re-send the cal byte when the tracker steps. Sending the factory byte once is **not** enough (DS3-A2 idles ~160 counts off).
-5. Counterfeit: if sensors never change, suppress motion / raw-passthrough. Keep `zero == oneG` as a blank-EEPROM guard only.
-6. DS4 frame: source frame is known; permutation + remaining signs still need a reference DS4 capture. Scale yaw by ~1.4 counts/(deg/s) into DS4's 16 LSB/(deg/s) (~gain 11.4).
-7. IPC + ControlApp: expose cal pairs, path flags, live raw/cal, tracker cal-byte.
-8. Bluetooth: same feature reports over BthPS3 HID control (`0xEF` over BT unverified).
+1. USB connect (after `0xF2`/`0xF5`, before first output): `SET Feature 0xEF` page `0xA0` + `GET 0xEF`. Cache the four pairs. Soft-fail to nominal 512/399.
+2. Feature `0x01` field list selects `PLAIN_ZERO` / `HW_CAL` / `SIXAXIS`. Cal byte at unified `[5]/[6]` or `[3]/[4]`.
+3. Accel gain-113 with post-cal X mirror; `zero == oneG` passthrough. Applied to the SIXAXIS GetFeature report and IPC snapshot, not the 12-byte SIXAXIS input report.
+4. Gyro sign inverted; tracker + cal-byte resend on `HW_CAL`/`SIXAXIS` USB pads.
+5. IPC third region + `GetMotionSnapshot`; ControlApp Motion viewer.
 
-Headline bug today: DsHidMini gyro sign is **backwards** vs `sixaxis.sys` on all three paths, and unzeroed. Full list: [Discrepancies](#discrepancies-a-driver-implementation-must-resolve).
+Still deferred:
+
+6. Counterfeit behavioural detection (frozen sensors). Keep `zero == oneG` as a blank-EEPROM guard only.
+7. DS4Windows motion-field mapping. Source frame is known; permutation + remaining signs still need a reference DS4 capture.
+8. Bluetooth `0xEF` over the BthPS3 HID control channel (unverified). Absolute gyro scale better than ~1.4 counts/(deg/s).
+
+Headline remaining gaps: Bluetooth EEPROM, DS4 axis mapping, counterfeit freeze detection, and a turntable gyro scale. Historical discrepancies versus pre-#217 DsHidMini are listed under [Discrepancies](#discrepancies-a-driver-implementation-must-resolve).
 
 ### Open measurements
 

--- a/docs/PS3_USB_STARTUP.md
+++ b/docs/PS3_USB_STARTUP.md
@@ -24,8 +24,8 @@ Identical across all three consoles and all six samples:
    has: `SET_REPORT Feature 0xF5` (pairing request), then a verifying
    `GET_REPORT Feature 0xF5` 27-75 ms later (varies by sample).
 6. `0xEF` / `0xF8` calibration-page reads (motion sensor calibration data;
-   not emulated by DsHidMini, see below; page layout and semantics in
-   [`MOTION.md`](MOTION.md#calibration-eeprom-feature-0xef-0xf8-0xf7)).
+   DsHidMini now soft-reads page `0xA0` via Feature `0xEF` on USB start, see
+   [`MOTION.md`](MOTION.md#what-dshidmini-does-today); `0xF8` is still unused).
 7. **`SET_REPORT Output 0x01` on EP0 (control endpoint), 48 bytes, no report
    ID, all zeros.** This is the pre-enable output report and the reason
    DsHidMini now sends an equivalent EP0 report during
@@ -49,9 +49,10 @@ Identical across all three consoles and all six samples:
 13. On unplug/disable: `SET_REPORT Feature 0xF4 42 0B 00 00`, preceded by
     one more all-zero EP0 report (same shape as step 7).
 
-No `SET_IDLE`, `0xEF`, `0xF7`, or `0xF8` traffic is emulated by DsHidMini;
-they are documented here only so future quirk work does not need to
-re-derive them from the pcaps.
+No `SET_IDLE`, `0xF7`, or `0xF8` traffic is emulated by DsHidMini. Feature
+`0xEF` page `0xA0` is soft-read on USB start for motion calibration (failure
+does not abort `PrepareHardware`). They remain documented here so future
+quirk work does not need to re-derive them from the pcaps.
 
 ## Report layouts
 

--- a/driver/Device.c
+++ b/driver/Device.c
@@ -250,6 +250,8 @@ void DsHidMini_DeviceCleanup(
 				RtlZeroMemory(pHIDBuffer->AlignmentPadding, sizeof(pHIDBuffer->AlignmentPadding));
 				InterlockedIncrement(&pHIDBuffer->SequenceNumber);
 			}
+
+			DsMotion_PublishOrClearIpcSnapshot(deviceContext, TRUE);
 		}
 		WdfWaitLockRelease(driverContext->IpcLock);
 
@@ -566,6 +568,8 @@ DsDevice_InitContext(
 	WDF_TIMER_CONFIG timerCfg;
 
 	FuncEntry(TRACE_DEVICE);
+
+	DsMotion_Initialize(&pDevCtx->Motion);
 
 	WdfWaitLockAcquire(pDrvCtx->SlotsLock, NULL);
 	{

--- a/driver/Device.h
+++ b/driver/Device.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <DmfModule.h>
 #include "DsIdentification.h"
+#include "DsMotion.h"
 
 
 EXTERN_C_START
@@ -322,6 +323,13 @@ typedef struct _DEVICE_CONTEXT
 		// 
 		BOOLEAN IdentificationPresent;
 		DS_IDENTIFICATION_INFO Identification;
+
+	//
+	// Motion calibration, gyro tracker, and last corrected sample.
+	// Seeded with nominal values; USB PrepareHardware may replace them
+	// from EEPROM page 0xA0. See docs/MOTION.md and issue #217.
+	// 
+	DS_MOTION_STATE Motion;
 
 	//
 	// Current reported battery status

--- a/driver/Driver.h
+++ b/driver/Driver.h
@@ -126,6 +126,16 @@ typedef struct _DSHM_DRIVER_CONTEXT
 				// 
 				size_t BufferSize;
 			} HID;
+
+			//
+			// High-frequency motion telemetry (issue #217). Mapped at
+			// 2 * allocation granularity so older SDKs keep working.
+			// 
+			struct
+			{
+				PUCHAR Buffer;
+				size_t BufferSize;
+			} Motion;
 		} SharedRegions;
 
 		//

--- a/driver/DsHidMiniDrv.c
+++ b/driver/DsHidMiniDrv.c
@@ -715,6 +715,9 @@ DSHM_ProcessHidInputReport(
 	}
 
 	DMF_CONTEXT_DsHidMini* pModCtx = DMF_CONTEXT_GET(dmfModule);
+	BOOLEAN calByteChanged = FALSE;
+
+	DsMotion_ProcessInputReport(Context, Report, &calByteChanged);
 
 	//
 	// Handle special case of SIXAXIS.SYS emulation. This writes into
@@ -722,6 +725,7 @@ DSHM_ProcessHidInputReport(
 	// held above (see DMF_ModuleReference(dmfModule) further up); this is
 	// moved here from the USB/Bluetooth receive callbacks, which used to
 	// touch this without holding any reference on [DsHidMini].
+	// Motion fields are the calibrated, host-order Sony values (issue #217).
 	// 
 	if (Context->Configuration.HidDeviceMode == DsHidMiniDeviceModeSixaxisCompatible)
 	{
@@ -731,10 +735,21 @@ DSHM_ProcessHidInputReport(
 			sizeof(DS3_RAW_INPUT_REPORT)
 		);
 
-		pModCtx->GetFeatureReport.AccelerometerX = 0x03FF - _byteswap_ushort(pModCtx->GetFeatureReport.AccelerometerX);
-		pModCtx->GetFeatureReport.AccelerometerY = _byteswap_ushort(pModCtx->GetFeatureReport.AccelerometerY);
-		pModCtx->GetFeatureReport.AccelerometerZ = _byteswap_ushort(pModCtx->GetFeatureReport.AccelerometerZ);
-		pModCtx->GetFeatureReport.Gyroscope = _byteswap_ushort(pModCtx->GetFeatureReport.Gyroscope);
+		if (Context->Motion.HasSample)
+		{
+			pModCtx->GetFeatureReport.AccelerometerX = (USHORT)Context->Motion.Sample.CalAccelX;
+			pModCtx->GetFeatureReport.AccelerometerY = (USHORT)Context->Motion.Sample.CalAccelY;
+			pModCtx->GetFeatureReport.AccelerometerZ = (USHORT)Context->Motion.Sample.CalAccelZ;
+			pModCtx->GetFeatureReport.Gyroscope = Context->Motion.Sample.CalGyro;
+		}
+	}
+
+	if (calByteChanged && Context->OutputReport.Lock != NULL)
+	{
+		WdfWaitLockAcquire(Context->OutputReport.Lock, NULL);
+		DsMotion_ApplyOutputCalByte(Context);
+		(void)DSHM_SendOutputReportUnlocked(Context, Ds3OutputReportSourceDriverLowPriority);
+		WdfWaitLockRelease(Context->OutputReport.Lock);
 	}
 
 	if (NT_SUCCESS(DMF_ModuleReference(pModCtx->DmfModuleVirtualHidMini)))

--- a/driver/DsMotion.c
+++ b/driver/DsMotion.c
@@ -1,0 +1,846 @@
+#include "Driver.h"
+#include "DsMotion.tmh"
+
+#define DS_MOTION_TARGET                 512
+#define DS_MOTION_SETTLE_INITIAL         32
+#define DS_MOTION_SETTLE_AFTER_CAL       2
+#define DS_MOTION_RAW_MAX                0x333
+#define DS_MOTION_RAW_MIN                0xCC
+#define DS_MOTION_BLOCK_N                16
+#define DS_MOTION_BLOCK_VAR_MAX          10
+#define DS_MOTION_RING_N                 4
+#define DS_MOTION_RING_RANGE_MAX         4
+#define DS_MOTION_LONG_N                 0xEC
+#define DS_MOTION_PENDING_TOL0           100
+#define DS_MOTION_INT_MIN                ((INT32)0x80000000)
+#define DS_MOTION_INT_MAX                ((INT32)0x7FFFFFFF)
+
+static
+INT32
+DsMotion_Q10(
+	_In_ INT32 Value
+)
+{
+	return (Value + ((Value >> 31) & 0x3FF)) >> 10;
+}
+
+static
+INT32
+DsMotion_Clamp10(
+	_In_ INT32 Value
+)
+{
+	if (Value < 0)
+	{
+		return 0;
+	}
+
+	if (Value > 1023)
+	{
+		return 1023;
+	}
+
+	return Value;
+}
+
+static
+INT32
+DsMotion_CalibrateAccelAxis(
+	_In_ INT32 Raw,
+	_In_ USHORT Zero,
+	_In_ USHORT OneG,
+	_In_ BOOLEAN Mirror
+)
+{
+	INT32 cal;
+	INT32 t;
+
+	if (Zero != OneG)
+	{
+		t = ((Raw - (INT32)Zero) * 1024 / ((INT32)Zero - (INT32)OneG)) * DS_MOTION_ACCEL_GAIN;
+		cal = DsMotion_Q10(t) + DS_MOTION_NOMINAL_ZERO;
+	}
+	else
+	{
+		cal = Raw;
+	}
+
+	if (Mirror)
+	{
+		cal = 0x3FF - cal;
+	}
+
+	return cal;
+}
+
+static
+INT32
+DsMotion_ToMilliG(
+	_In_ INT32 Calibrated
+)
+{
+	return ((Calibrated - DS_MOTION_NOMINAL_ZERO) * 1000) / DS_MOTION_ACCEL_GAIN;
+}
+
+static
+INT32
+DsMotion_ToMilliDps(
+	_In_ INT32 Calibrated
+)
+{
+	//
+	// ~1.4 counts per deg/s (docs/MOTION.md). (cal - 512) * 1000 / 1.4
+	// = (cal - 512) * 5000 / 7
+	// 
+	return ((Calibrated - DS_MOTION_NOMINAL_ZERO) * 5000) / 7;
+}
+
+static
+VOID
+DsMotion_TrackerResetBlock(
+	_Inout_ PDS_GYRO_TRACKER Tracker
+)
+{
+	Tracker->BlockCount = 0;
+	Tracker->BlockSum = 0;
+	Tracker->BlockMin = DS_MOTION_INT_MAX;
+	Tracker->BlockMax = DS_MOTION_INT_MIN;
+}
+
+static
+VOID
+DsMotion_TrackerRingReset(
+	_Inout_ PDS_GYRO_TRACKER Tracker
+)
+{
+	RtlZeroMemory(Tracker->Ring, sizeof(Tracker->Ring));
+	Tracker->RingFilled = 0;
+	Tracker->RingIdx = 0;
+	Tracker->RingSum = 0;
+}
+
+static
+BOOLEAN
+DsMotion_TrackerRetarget(
+	_Inout_ PDS_GYRO_TRACKER Tracker,
+	_In_ INT32 RestAvg,
+	_Out_ PINT32 ZeroRef,
+	_Out_ PINT32 CalByte
+)
+{
+	const INT32 delta = (DS_MOTION_TARGET - RestAvg) * 1024;
+
+	if (delta >= -DS_MOTION_GYRO_STEP_Q10 && delta <= DS_MOTION_GYRO_STEP_Q10)
+	{
+		*ZeroRef = RestAvg;
+		*CalByte = Tracker->CalByte;
+		return FALSE;
+	}
+
+	{
+		const INT32 steps = delta / DS_MOTION_GYRO_STEP_Q10;
+		*ZeroRef = RestAvg + DsMotion_Q10(steps * DS_MOTION_GYRO_STEP_Q10);
+		*CalByte = Tracker->CalByte + steps;
+		return TRUE;
+	}
+}
+
+static
+BOOLEAN
+DsMotion_TrackerRingPush(
+	_Inout_ PDS_GYRO_TRACKER Tracker,
+	_In_ INT32 Value
+)
+{
+	const INT32 old = Tracker->Ring[Tracker->RingIdx];
+
+	Tracker->Ring[Tracker->RingIdx] = Value;
+	Tracker->RingSum += Value;
+	Tracker->RingIdx++;
+
+	if (Tracker->RingFilled < DS_MOTION_RING_N)
+	{
+		Tracker->RingFilled++;
+		if (Tracker->RingFilled < DS_MOTION_RING_N)
+		{
+			if (Tracker->RingIdx == DS_MOTION_RING_N)
+			{
+				Tracker->RingIdx = 0;
+			}
+
+			return FALSE;
+		}
+	}
+	else
+	{
+		Tracker->RingSum -= old;
+	}
+
+	if (Tracker->RingIdx == DS_MOTION_RING_N)
+	{
+		Tracker->RingIdx = 0;
+	}
+
+	return TRUE;
+}
+
+static
+INT32
+DsMotion_TrackerRingRange(
+	_In_ const PDS_GYRO_TRACKER Tracker
+)
+{
+	INT32 minValue = DS_MOTION_INT_MAX;
+	INT32 maxValue = DS_MOTION_INT_MIN;
+	INT32 i;
+
+	for (i = 0; i < DS_MOTION_RING_N; i++)
+	{
+		if (Tracker->Ring[i] > maxValue)
+		{
+			maxValue = Tracker->Ring[i];
+		}
+
+		if (Tracker->Ring[i] < minValue)
+		{
+			minValue = Tracker->Ring[i];
+		}
+	}
+
+	return maxValue - minValue;
+}
+
+static
+VOID
+DsMotion_TrackerApplyPending(
+	_Inout_ PDS_GYRO_TRACKER Tracker
+)
+{
+	Tracker->ZeroRef = Tracker->PendingZero;
+	Tracker->CalByte = Tracker->PendingCal;
+	Tracker->Pending = FALSE;
+	DsMotion_TrackerRingReset(Tracker);
+	Tracker->LongCount = 0;
+	Tracker->LongSum = 0;
+}
+
+static
+BOOLEAN
+DsMotion_TrackerTrack(
+	_Inout_ PDS_GYRO_TRACKER Tracker,
+	_In_ INT32 Raw
+)
+{
+	INT32 blockAvg;
+	INT32 lastMin;
+	INT32 lastMax;
+	INT32 var;
+
+	if (Raw > DS_MOTION_RAW_MAX || Raw < DS_MOTION_RAW_MIN)
+	{
+		Tracker->Moving = TRUE;
+	}
+
+	Tracker->BlockSum += Raw;
+	if (Raw > Tracker->BlockMax)
+	{
+		Tracker->BlockMax = Raw;
+	}
+
+	if (Raw < Tracker->BlockMin)
+	{
+		Tracker->BlockMin = Raw;
+	}
+
+	if (++Tracker->BlockCount != DS_MOTION_BLOCK_N)
+	{
+		return FALSE;
+	}
+
+	Tracker->BlockCount = 0;
+	blockAvg = (Tracker->BlockSum + DS_MOTION_BLOCK_N / 2) / DS_MOTION_BLOCK_N;
+	Tracker->BlockSum = 0;
+	lastMin = Tracker->BlockMin;
+	lastMax = Tracker->BlockMax;
+	Tracker->BlockMin = DS_MOTION_INT_MAX;
+	Tracker->BlockMax = DS_MOTION_INT_MIN;
+	var = (lastMax - blockAvg) * (lastMax - blockAvg) +
+		(blockAvg - lastMin) * (blockAvg - lastMin);
+
+	Tracker->LongSum += blockAvg;
+	if (++Tracker->LongCount == DS_MOTION_LONG_N)
+	{
+		const INT32 longAvg = (Tracker->LongSum + DS_MOTION_LONG_N / 2) / DS_MOTION_LONG_N;
+		INT32 zeroRef;
+		INT32 calByte;
+
+		Tracker->LongCount = 0;
+		Tracker->LongSum = 0;
+
+		if (DsMotion_TrackerRetarget(Tracker, longAvg, &zeroRef, &calByte))
+		{
+			Tracker->PendingZero = zeroRef;
+			Tracker->PendingCal = calByte;
+			Tracker->Pending = TRUE;
+			Tracker->PendingTol = DS_MOTION_PENDING_TOL0;
+		}
+		else
+		{
+			Tracker->PendingZero = zeroRef;
+			Tracker->ZeroRef = longAvg;
+		}
+	}
+
+	if (Tracker->Moving)
+	{
+		Tracker->Moving = FALSE;
+		return FALSE;
+	}
+
+	if (var < DS_MOTION_BLOCK_VAR_MAX)
+	{
+		if (DsMotion_TrackerRingPush(Tracker, blockAvg))
+		{
+			if (DsMotion_TrackerRingRange(Tracker) < DS_MOTION_RING_RANGE_MAX)
+			{
+				const INT32 restAvg = (Tracker->RingSum + DS_MOTION_RING_N / 2) / DS_MOTION_RING_N;
+				INT32 newCal;
+				BOOLEAN changed;
+
+				Tracker->LongCount = 0;
+				Tracker->LongSum = 0;
+				changed = DsMotion_TrackerRetarget(
+					Tracker,
+					restAvg,
+					&Tracker->ZeroRef,
+					&newCal
+				);
+
+				if (changed)
+				{
+					Tracker->CalByte = newCal;
+					DsMotion_TrackerRingReset(Tracker);
+					Tracker->SettleLeft = DS_MOTION_SETTLE_AFTER_CAL;
+				}
+
+				Tracker->Pending = FALSE;
+				return changed;
+			}
+		}
+
+		if (Tracker->Pending)
+		{
+			DsMotion_TrackerApplyPending(Tracker);
+			Tracker->SettleLeft = DS_MOTION_SETTLE_AFTER_CAL;
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
+static
+VOID
+DsMotion_TrackerInitial(
+	_Inout_ PDS_GYRO_TRACKER Tracker,
+	_In_ USHORT EepromCal,
+	_In_ USHORT EepromZero
+)
+{
+	RtlZeroMemory(Tracker, sizeof(*Tracker));
+	Tracker->CalByte = (INT32)EepromCal;
+	Tracker->LastRaw = (INT32)EepromZero;
+	Tracker->SettleLeft = DS_MOTION_SETTLE_INITIAL;
+	Tracker->BlockMin = DS_MOTION_INT_MAX;
+	Tracker->BlockMax = DS_MOTION_INT_MIN;
+	DsMotion_TrackerRetarget(
+		Tracker,
+		(INT32)EepromZero,
+		&Tracker->ZeroRef,
+		&Tracker->CalByte
+	);
+	Tracker->Output = DsMotion_Clamp10(Tracker->ZeroRef - (INT32)EepromZero + DS_MOTION_TARGET);
+	Tracker->Initialized = TRUE;
+}
+
+static
+INT32
+DsMotion_TrackerRuntime(
+	_Inout_ PDS_GYRO_TRACKER Tracker,
+	_In_ INT32 Raw,
+	_Out_ PBOOLEAN CalChanged
+)
+{
+	*CalChanged = FALSE;
+
+	if (!Tracker->Initialized)
+	{
+		return DS_MOTION_TARGET;
+	}
+
+	if (Tracker->SettleLeft > 0)
+	{
+		Tracker->SettleLeft--;
+		Tracker->LastRaw = Raw;
+		return Tracker->Output;
+	}
+
+	Tracker->Output = DsMotion_Clamp10(DS_MOTION_TARGET - Raw + Tracker->ZeroRef);
+	*CalChanged = DsMotion_TrackerTrack(Tracker, Raw);
+
+	if (Tracker->Pending)
+	{
+		const INT32 jump = Raw - Tracker->LastRaw;
+
+		if (jump >= -Tracker->PendingTol && jump <= Tracker->PendingTol)
+		{
+			Tracker->PendingTol -= 1;
+		}
+		else
+		{
+			DsMotion_TrackerApplyPending(Tracker);
+			DsMotion_TrackerResetBlock(Tracker);
+			*CalChanged = TRUE;
+		}
+	}
+
+	Tracker->LastRaw = Raw;
+	return Tracker->Output;
+}
+
+static
+DS_IDENTIFICATION_MOTION_PATH
+DsMotion_ResolvePath(
+	_In_ const PDEVICE_CONTEXT Context
+)
+{
+	if (Context->IdentificationPresent &&
+		Context->Identification.MotionPath != DsIdentificationMotionPathUnknown)
+	{
+		return Context->Identification.MotionPath;
+	}
+
+	return DsIdentificationMotionPathPlainZero;
+}
+
+static
+UCHAR
+DsMotion_CurrentCalByte(
+	_In_ const PDS_MOTION_STATE Motion
+)
+{
+	if (Motion->Tracker.Initialized)
+	{
+		return (UCHAR)Motion->Tracker.CalByte;
+	}
+
+	return (UCHAR)Motion->Gyro.OneG;
+}
+
+VOID
+DsMotion_Initialize(
+	_Inout_ PDS_MOTION_STATE Motion
+)
+{
+	INT32 i;
+
+	RtlZeroMemory(Motion, sizeof(*Motion));
+	Motion->Fallback = TRUE;
+	Motion->Path = DsIdentificationMotionPathUnknown;
+
+	for (i = 0; i < 3; i++)
+	{
+		Motion->Accel[i].Zero = DS_MOTION_NOMINAL_ZERO;
+		Motion->Accel[i].OneG = DS_MOTION_NOMINAL_ONE_G;
+	}
+
+	Motion->Gyro.Zero = DS_MOTION_NOMINAL_ZERO;
+	Motion->Gyro.OneG = 0;
+}
+
+static
+BOOLEAN
+DsMotion_ParseEepromPage(
+	_In_reads_(BufferLength) const UCHAR* Buffer,
+	_In_ ULONG BufferLength,
+	_Out_ PDS_MOTION_STATE Motion
+)
+{
+	const UCHAR* payload;
+	INT32 i;
+
+	if (Buffer == NULL || Motion == NULL ||
+		BufferLength < DS_MOTION_EEPROM_PAYLOAD_OFFSET + 16)
+	{
+		return FALSE;
+	}
+
+	//
+	// The GET Feature 0xEF reply echoes the page select at offsets 5-7.
+	// Reject a mismatched page so a stale buffer cannot look like A0 data.
+	// 
+	if (BufferLength > 7 && Buffer[7] != 0 && Buffer[7] != DS_MOTION_EEPROM_PAGE)
+	{
+		return FALSE;
+	}
+
+	payload = &Buffer[DS_MOTION_EEPROM_PAYLOAD_OFFSET];
+
+	for (i = 0; i < 3; i++)
+	{
+		Motion->Accel[i].Zero = (USHORT)((payload[i * 4] << 8) | payload[i * 4 + 1]);
+		Motion->Accel[i].OneG = (USHORT)((payload[i * 4 + 2] << 8) | payload[i * 4 + 3]);
+	}
+
+	Motion->Gyro.Zero = (USHORT)((payload[12] << 8) | payload[13]);
+	Motion->Gyro.OneG = (USHORT)((payload[14] << 8) | payload[15]);
+	return TRUE;
+}
+
+VOID
+DsMotion_TryLoadUsbCalibration(
+	_In_ WDFDEVICE Device
+)
+{
+	const PDEVICE_CONTEXT pDevCtx = DeviceGetContext(Device);
+	UCHAR select[48];
+	UCHAR page[CONTROL_TRANSFER_BUFFER_LENGTH];
+	ULONG transferred = 0;
+	NTSTATUS status;
+
+	FuncEntry(TRACE_MOTION);
+
+	pDevCtx->Motion.Path = DsMotion_ResolvePath(pDevCtx);
+
+	RtlZeroMemory(select, sizeof(select));
+	select[4] = 0x03;
+	select[5] = 0x01;
+	select[6] = DS_MOTION_EEPROM_PAGE;
+
+	status = USB_SendControlRequest(
+		pDevCtx,
+		BmRequestHostToDevice,
+		BmRequestClass,
+		SetReport,
+		Ds3FeatureEeprom,
+		0,
+		select,
+		ARRAYSIZE(select),
+		NULL
+	);
+
+	if (!NT_SUCCESS(status))
+	{
+		TraceWarning(
+			TRACE_MOTION,
+			"SET Feature 0xEF page 0xA0 failed with %!STATUS!; using nominal calibration",
+			status
+		);
+		FuncExitNoReturn(TRACE_MOTION);
+		return;
+	}
+
+	RtlZeroMemory(page, sizeof(page));
+	status = USB_SendControlRequest(
+		pDevCtx,
+		BmRequestDeviceToHost,
+		BmRequestClass,
+		GetReport,
+		Ds3FeatureEeprom,
+		0,
+		page,
+		ARRAYSIZE(page),
+		&transferred
+	);
+
+	if (!NT_SUCCESS(status) ||
+		!DsMotion_ParseEepromPage(page, transferred, &pDevCtx->Motion))
+	{
+		TraceWarning(
+			TRACE_MOTION,
+			"GET Feature 0xEF page 0xA0 failed (status %!STATUS!, %lu bytes); using nominal calibration",
+			status,
+			transferred
+		);
+		FuncExitNoReturn(TRACE_MOTION);
+		return;
+	}
+
+	pDevCtx->Motion.Fallback = FALSE;
+	pDevCtx->Motion.Path = DsMotion_ResolvePath(pDevCtx);
+
+	if (pDevCtx->Motion.Path == DsIdentificationMotionPathHwCal ||
+		pDevCtx->Motion.Path == DsIdentificationMotionPathSixaxis)
+	{
+		DsMotion_TrackerInitial(
+			&pDevCtx->Motion.Tracker,
+			pDevCtx->Motion.Gyro.OneG,
+			pDevCtx->Motion.Gyro.Zero
+		);
+		pDevCtx->Motion.SendHardwareCal = TRUE;
+		DsMotion_ApplyOutputCalByte(pDevCtx);
+	}
+
+	TraceInformation(
+		TRACE_MOTION,
+		"EEPROM 0xA0 X=%u/%u Y=%u/%u Z=%u/%u G=%u/%u path=%d fallback=%!BOOLEAN!",
+		pDevCtx->Motion.Accel[0].Zero,
+		pDevCtx->Motion.Accel[0].OneG,
+		pDevCtx->Motion.Accel[1].Zero,
+		pDevCtx->Motion.Accel[1].OneG,
+		pDevCtx->Motion.Accel[2].Zero,
+		pDevCtx->Motion.Accel[2].OneG,
+		pDevCtx->Motion.Gyro.Zero,
+		pDevCtx->Motion.Gyro.OneG,
+		pDevCtx->Motion.Path,
+		pDevCtx->Motion.Fallback
+	);
+
+	FuncExitNoReturn(TRACE_MOTION);
+}
+
+VOID
+DsMotion_ApplyOutputCalByte(
+	_In_ PDEVICE_CONTEXT Context
+)
+{
+	PUCHAR raw = NULL;
+	SIZE_T length = 0;
+	const UCHAR cal = DsMotion_CurrentCalByte(&Context->Motion);
+
+	if (!Context->Motion.SendHardwareCal ||
+		Context->ConnectionType != DsDeviceConnectionTypeUsb)
+	{
+		return;
+	}
+
+	Ds3_GetRawOutputReportBuffer(Context, &raw, &length);
+	if (raw == NULL)
+	{
+		return;
+	}
+
+	if (Context->Motion.Path == DsIdentificationMotionPathHwCal && length > 7)
+	{
+		raw[6] = 0xFF;
+		raw[7] = cal;
+	}
+	else if (Context->Motion.Path == DsIdentificationMotionPathSixaxis && length > 5)
+	{
+		raw[4] = 0xFF;
+		raw[5] = cal;
+	}
+}
+
+VOID
+DsMotion_OverlayCalByteOnUnified(
+	_In_ PDEVICE_CONTEXT Context,
+	_Inout_updates_(Length) PUCHAR Unified,
+	_In_ ULONG Length
+)
+{
+	const UCHAR cal = DsMotion_CurrentCalByte(&Context->Motion);
+
+	if (!Context->Motion.SendHardwareCal || Unified == NULL)
+	{
+		return;
+	}
+
+	if (Context->Motion.Path == DsIdentificationMotionPathHwCal && Length > 6)
+	{
+		Unified[5] = 0xFF;
+		Unified[6] = cal;
+	}
+	else if (Context->Motion.Path == DsIdentificationMotionPathSixaxis && Length > 4)
+	{
+		Unified[3] = 0xFF;
+		Unified[4] = cal;
+	}
+}
+
+VOID
+DsMotion_ProcessInputReport(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ const PDS3_RAW_INPUT_REPORT Report,
+	_Out_ PBOOLEAN CalByteChanged
+)
+{
+	PDS_MOTION_STATE motion = &Context->Motion;
+	INT32 raw[4];
+	INT32 calAccel[3];
+	INT32 calGyro;
+	BOOLEAN trackerChanged = FALSE;
+	INT32 i;
+
+	*CalByteChanged = FALSE;
+
+	if (motion->Path == DsIdentificationMotionPathUnknown)
+	{
+		motion->Path = DsMotion_ResolvePath(Context);
+	}
+
+	raw[0] = _byteswap_ushort(Report->AccelerometerX);
+	raw[1] = _byteswap_ushort(Report->AccelerometerY);
+	raw[2] = _byteswap_ushort(Report->AccelerometerZ);
+	raw[3] = _byteswap_ushort(Report->Gyroscope);
+
+	for (i = 0; i < 3; i++)
+	{
+		calAccel[i] = DsMotion_CalibrateAccelAxis(
+			raw[i],
+			motion->Accel[i].Zero,
+			motion->Accel[i].OneG,
+			i == 0
+		);
+	}
+
+	switch (motion->Path)
+	{
+	case DsIdentificationMotionPathHwCal:
+		calGyro = DsMotion_Clamp10(0x3FF - raw[3]);
+		if (motion->Tracker.Initialized)
+		{
+			(void)DsMotion_TrackerRuntime(&motion->Tracker, raw[3], &trackerChanged);
+		}
+		break;
+
+	case DsIdentificationMotionPathSixaxis:
+		if (motion->Tracker.Initialized)
+		{
+			calGyro = DsMotion_TrackerRuntime(&motion->Tracker, raw[3], &trackerChanged);
+		}
+		else
+		{
+			calGyro = DsMotion_Clamp10(DS_MOTION_TARGET + (INT32)motion->Gyro.Zero - raw[3]);
+		}
+		break;
+
+	case DsIdentificationMotionPathPlainZero:
+	default:
+		calGyro = DsMotion_Clamp10(DS_MOTION_TARGET + (INT32)motion->Gyro.Zero - raw[3]);
+		break;
+	}
+
+	motion->Sample.Valid = TRUE;
+	motion->Sample.RawAccelX = (USHORT)raw[0];
+	motion->Sample.RawAccelY = (USHORT)raw[1];
+	motion->Sample.RawAccelZ = (USHORT)raw[2];
+	motion->Sample.RawGyro = (USHORT)raw[3];
+	motion->Sample.CalAccelX = (SHORT)calAccel[0];
+	motion->Sample.CalAccelY = (SHORT)calAccel[1];
+	motion->Sample.CalAccelZ = (SHORT)calAccel[2];
+	motion->Sample.CalGyro = (USHORT)calGyro;
+	motion->Sample.AccelMilliGX = DsMotion_ToMilliG(calAccel[0]);
+	motion->Sample.AccelMilliGY = DsMotion_ToMilliG(calAccel[1]);
+	motion->Sample.AccelMilliGZ = DsMotion_ToMilliG(calAccel[2]);
+	motion->Sample.GyroMilliDps = DsMotion_ToMilliDps(calGyro);
+	motion->Sample.SampleIndex++;
+	QueryPerformanceCounter(&motion->Sample.TimestampQpc);
+	motion->HasSample = TRUE;
+
+	*CalByteChanged = trackerChanged && motion->SendHardwareCal;
+}
+
+VOID
+DsMotion_FillIpcSnapshot(
+	_In_ PDEVICE_CONTEXT Context,
+	_Out_ PIPC_MOTION_SNAPSHOT_MESSAGE Snapshot
+)
+{
+	const PDS_MOTION_STATE motion = &Context->Motion;
+	UINT16 flags = 0;
+
+	RtlZeroMemory(Snapshot, sizeof(*Snapshot));
+	Snapshot->SlotIndex = Context->SlotIndex;
+	Snapshot->Version = DS_MOTION_IPC_SNAPSHOT_VERSION;
+	Snapshot->AccelZeroX = motion->Accel[0].Zero;
+	Snapshot->AccelZeroY = motion->Accel[1].Zero;
+	Snapshot->AccelZeroZ = motion->Accel[2].Zero;
+	Snapshot->AccelOneGX = motion->Accel[0].OneG;
+	Snapshot->AccelOneGY = motion->Accel[1].OneG;
+	Snapshot->AccelOneGZ = motion->Accel[2].OneG;
+	Snapshot->GyroZero = motion->Gyro.Zero;
+	Snapshot->GyroEepromCal = motion->Gyro.OneG;
+	Snapshot->CalByte = DsMotion_CurrentCalByte(motion);
+	Snapshot->MotionPath = (UCHAR)motion->Path;
+	Snapshot->ZeroRef = motion->Tracker.Initialized
+		? motion->Tracker.ZeroRef
+		: (INT32)motion->Gyro.Zero;
+
+	if (motion->HasSample)
+	{
+		flags |= DSHM_IPC_MOTION_FLAG_AVAILABLE;
+		Snapshot->RawAccelX = motion->Sample.RawAccelX;
+		Snapshot->RawAccelY = motion->Sample.RawAccelY;
+		Snapshot->RawAccelZ = motion->Sample.RawAccelZ;
+		Snapshot->RawGyro = motion->Sample.RawGyro;
+		Snapshot->CalAccelX = motion->Sample.CalAccelX;
+		Snapshot->CalAccelY = motion->Sample.CalAccelY;
+		Snapshot->CalAccelZ = motion->Sample.CalAccelZ;
+		Snapshot->CalGyro = motion->Sample.CalGyro;
+		Snapshot->AccelMilliGX = motion->Sample.AccelMilliGX;
+		Snapshot->AccelMilliGY = motion->Sample.AccelMilliGY;
+		Snapshot->AccelMilliGZ = motion->Sample.AccelMilliGZ;
+		Snapshot->GyroMilliDps = motion->Sample.GyroMilliDps;
+		Snapshot->SampleIndex = motion->Sample.SampleIndex;
+		Snapshot->TimestampQpc = (UINT64)motion->Sample.TimestampQpc.QuadPart;
+	}
+
+	if (motion->Fallback)
+	{
+		flags |= DSHM_IPC_MOTION_FLAG_FALLBACK;
+	}
+
+	if (motion->SendHardwareCal)
+	{
+		flags |= DSHM_IPC_MOTION_FLAG_HW_CAL;
+	}
+
+	if (motion->Tracker.Initialized)
+	{
+		flags |= DSHM_IPC_MOTION_FLAG_TRACKER;
+	}
+
+	Snapshot->Flags = flags;
+}
+
+VOID
+DsMotion_PublishOrClearIpcSnapshot(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ BOOLEAN Clear
+)
+{
+	const WDFDRIVER driver = WdfGetDriver();
+	const PDSHM_DRIVER_CONTEXT pDrvCtx = DriverGetContext(driver);
+	PIPC_MOTION_SNAPSHOT_MESSAGE slot;
+	size_t offset;
+
+	if (pDrvCtx->IPC.SharedRegions.Motion.Buffer == NULL || Context->SlotIndex < 1)
+	{
+		return;
+	}
+
+	offset = sizeof(IPC_MOTION_SNAPSHOT_MESSAGE) * (Context->SlotIndex - 1);
+	if (offset + sizeof(IPC_MOTION_SNAPSHOT_MESSAGE) > pDrvCtx->IPC.SharedRegions.Motion.BufferSize)
+	{
+		return;
+	}
+
+	slot = (PIPC_MOTION_SNAPSHOT_MESSAGE)(pDrvCtx->IPC.SharedRegions.Motion.Buffer + offset);
+	{
+		const LONG sequence = InterlockedIncrement(&slot->SequenceNumber);
+
+		if (Clear)
+		{
+			RtlZeroMemory(slot, sizeof(*slot));
+		}
+		else
+		{
+			DsMotion_FillIpcSnapshot(Context, slot);
+		}
+
+		slot->SequenceNumber = sequence;
+	}
+
+	InterlockedIncrement(&slot->SequenceNumber);
+}

--- a/driver/DsMotion.c
+++ b/driver/DsMotion.c
@@ -460,6 +460,50 @@ DsMotion_Initialize(
 
 static
 BOOLEAN
+DsMotion_IsValidAccelCal(
+	_In_ USHORT Zero,
+	_In_ USHORT OneG
+)
+{
+	INT32 span;
+
+	if (Zero > 1023 || OneG > 1023)
+	{
+		return FALSE;
+	}
+
+	//
+	// zero == oneG is Sony's documented passthrough for blank EEPROM.
+	// Any other pair must have a span large enough that
+	// ((raw - zero) * 1024 / span) * 113 stays inside INT32 for a
+	// 16-bit raw reading.
+	//
+	if (Zero == OneG)
+	{
+		return TRUE;
+	}
+
+	span = (INT32)Zero - (INT32)OneG;
+	if (span < 0)
+	{
+		span = -span;
+	}
+
+	return span >= 4;
+}
+
+static
+BOOLEAN
+DsMotion_IsValidGyroCal(
+	_In_ USHORT Zero,
+	_In_ USHORT CalByte
+)
+{
+	return Zero <= 1023 && CalByte <= 255;
+}
+
+static
+BOOLEAN
 DsMotion_ParseEepromPage(
 	_In_reads_(BufferLength) const UCHAR* Buffer,
 	_In_ ULONG BufferLength,
@@ -486,14 +530,39 @@ DsMotion_ParseEepromPage(
 
 	payload = &Buffer[DS_MOTION_EEPROM_PAYLOAD_OFFSET];
 
-	for (i = 0; i < 3; i++)
 	{
-		Motion->Accel[i].Zero = (USHORT)((payload[i * 4] << 8) | payload[i * 4 + 1]);
-		Motion->Accel[i].OneG = (USHORT)((payload[i * 4 + 2] << 8) | payload[i * 4 + 3]);
+		USHORT accelZero[3];
+		USHORT accelOneG[3];
+		USHORT gyroZero;
+		USHORT gyroCal;
+
+		for (i = 0; i < 3; i++)
+		{
+			accelZero[i] = (USHORT)((payload[i * 4] << 8) | payload[i * 4 + 1]);
+			accelOneG[i] = (USHORT)((payload[i * 4 + 2] << 8) | payload[i * 4 + 3]);
+			if (!DsMotion_IsValidAccelCal(accelZero[i], accelOneG[i]))
+			{
+				return FALSE;
+			}
+		}
+
+		gyroZero = (USHORT)((payload[12] << 8) | payload[13]);
+		gyroCal = (USHORT)((payload[14] << 8) | payload[15]);
+		if (!DsMotion_IsValidGyroCal(gyroZero, gyroCal))
+		{
+			return FALSE;
+		}
+
+		for (i = 0; i < 3; i++)
+		{
+			Motion->Accel[i].Zero = accelZero[i];
+			Motion->Accel[i].OneG = accelOneG[i];
+		}
+
+		Motion->Gyro.Zero = gyroZero;
+		Motion->Gyro.OneG = gyroCal;
 	}
 
-	Motion->Gyro.Zero = (USHORT)((payload[12] << 8) | payload[13]);
-	Motion->Gyro.OneG = (USHORT)((payload[14] << 8) | payload[15]);
 	return TRUE;
 }
 
@@ -828,18 +897,25 @@ DsMotion_PublishOrClearIpcSnapshot(
 
 	slot = (PIPC_MOTION_SNAPSHOT_MESSAGE)(pDrvCtx->IPC.SharedRegions.Motion.Buffer + offset);
 	{
-		const LONG sequence = InterlockedIncrement(&slot->SequenceNumber);
+		IPC_MOTION_SNAPSHOT_MESSAGE staging;
+
+		(void)InterlockedIncrement(&slot->SequenceNumber);
 
 		if (Clear)
 		{
-			RtlZeroMemory(slot, sizeof(*slot));
+			RtlZeroMemory(&staging, sizeof(staging));
 		}
 		else
 		{
-			DsMotion_FillIpcSnapshot(Context, slot);
+			DsMotion_FillIpcSnapshot(Context, &staging);
 		}
 
-		slot->SequenceNumber = sequence;
+		slot->SlotIndex = staging.SlotIndex;
+		RtlCopyMemory(
+			&slot->Version,
+			&staging.Version,
+			sizeof(staging) - FIELD_OFFSET(IPC_MOTION_SNAPSHOT_MESSAGE, Version)
+		);
 	}
 
 	InterlockedIncrement(&slot->SequenceNumber);

--- a/driver/DsMotion.h
+++ b/driver/DsMotion.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#define DS_MOTION_ACCEL_GAIN                 113
+#define DS_MOTION_NOMINAL_ZERO               512
+#define DS_MOTION_NOMINAL_ONE_G              (DS_MOTION_NOMINAL_ZERO - DS_MOTION_ACCEL_GAIN)
+#define DS_MOTION_GYRO_STEP_Q10              0x6999
+#define DS_MOTION_EEPROM_PAGE                0xA0
+#define DS_MOTION_EEPROM_PAYLOAD_OFFSET      0x11
+#define DS_MOTION_IPC_SNAPSHOT_VERSION       1
+
+#define DSHM_IPC_MOTION_FLAG_AVAILABLE       0x0001
+#define DSHM_IPC_MOTION_FLAG_FALLBACK        0x0002
+#define DSHM_IPC_MOTION_FLAG_HW_CAL          0x0004
+#define DSHM_IPC_MOTION_FLAG_TRACKER         0x0008
+
+#define Ds3FeatureEeprom                     0x03EF
+
+typedef struct _DEVICE_CONTEXT DEVICE_CONTEXT, *PDEVICE_CONTEXT;
+
+typedef struct _DS_MOTION_AXIS_CAL
+{
+	USHORT Zero;
+	USHORT OneG;
+} DS_MOTION_AXIS_CAL, *PDS_MOTION_AXIS_CAL;
+
+typedef struct _DS_GYRO_TRACKER
+{
+	INT32 CalByte;
+	INT32 ZeroRef;
+	INT32 LastRaw;
+	INT32 Output;
+	INT32 SettleLeft;
+	BOOLEAN Moving;
+	INT32 BlockCount;
+	INT32 BlockSum;
+	INT32 BlockMin;
+	INT32 BlockMax;
+	INT32 LongCount;
+	INT32 LongSum;
+	INT32 Ring[4];
+	INT32 RingFilled;
+	INT32 RingIdx;
+	INT32 RingSum;
+	BOOLEAN Pending;
+	INT32 PendingCal;
+	INT32 PendingZero;
+	INT32 PendingTol;
+	BOOLEAN Initialized;
+} DS_GYRO_TRACKER, *PDS_GYRO_TRACKER;
+
+typedef struct _DS_MOTION_SAMPLE
+{
+	BOOLEAN Valid;
+	USHORT RawAccelX;
+	USHORT RawAccelY;
+	USHORT RawAccelZ;
+	USHORT RawGyro;
+	SHORT CalAccelX;
+	SHORT CalAccelY;
+	SHORT CalAccelZ;
+	USHORT CalGyro;
+	INT32 AccelMilliGX;
+	INT32 AccelMilliGY;
+	INT32 AccelMilliGZ;
+	INT32 GyroMilliDps;
+	UINT32 SampleIndex;
+	LARGE_INTEGER TimestampQpc;
+} DS_MOTION_SAMPLE, *PDS_MOTION_SAMPLE;
+
+typedef struct _DS_MOTION_STATE
+{
+	BOOLEAN Fallback;
+	BOOLEAN SendHardwareCal;
+	BOOLEAN HasSample;
+	DS_IDENTIFICATION_MOTION_PATH Path;
+	DS_MOTION_AXIS_CAL Accel[3];
+	DS_MOTION_AXIS_CAL Gyro;
+	DS_GYRO_TRACKER Tracker;
+	DS_MOTION_SAMPLE Sample;
+} DS_MOTION_STATE, *PDS_MOTION_STATE;
+
+#include <pshpack1.h>
+typedef struct _IPC_MOTION_SNAPSHOT_MESSAGE
+{
+	UINT32 SlotIndex;
+	volatile LONG SequenceNumber;
+	UINT16 Version;
+	UINT16 Flags;
+	USHORT AccelZeroX;
+	USHORT AccelZeroY;
+	USHORT AccelZeroZ;
+	USHORT AccelOneGX;
+	USHORT AccelOneGY;
+	USHORT AccelOneGZ;
+	USHORT GyroZero;
+	USHORT GyroEepromCal;
+	USHORT RawAccelX;
+	USHORT RawAccelY;
+	USHORT RawAccelZ;
+	USHORT RawGyro;
+	SHORT CalAccelX;
+	SHORT CalAccelY;
+	SHORT CalAccelZ;
+	USHORT CalGyro;
+	INT32 AccelMilliGX;
+	INT32 AccelMilliGY;
+	INT32 AccelMilliGZ;
+	INT32 GyroMilliDps;
+	INT32 ZeroRef;
+	UINT32 SampleIndex;
+	UINT64 TimestampQpc;
+	UCHAR CalByte;
+	UCHAR MotionPath;
+	UCHAR Reserved0;
+	UCHAR Reserved1;
+} IPC_MOTION_SNAPSHOT_MESSAGE, *PIPC_MOTION_SNAPSHOT_MESSAGE;
+#include <poppack.h>
+
+C_ASSERT(sizeof(IPC_MOTION_SNAPSHOT_MESSAGE) == 80);
+C_ASSERT((FIELD_OFFSET(IPC_MOTION_SNAPSHOT_MESSAGE, SequenceNumber) % sizeof(LONG)) == 0);
+C_ASSERT((sizeof(IPC_MOTION_SNAPSHOT_MESSAGE) % sizeof(LONG)) == 0);
+
+VOID
+DsMotion_Initialize(
+	_Inout_ PDS_MOTION_STATE Motion
+);
+
+VOID
+DsMotion_TryLoadUsbCalibration(
+	_In_ WDFDEVICE Device
+);
+
+VOID
+DsMotion_ProcessInputReport(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ const PDS3_RAW_INPUT_REPORT Report,
+	_Out_ PBOOLEAN CalByteChanged
+);
+
+VOID
+DsMotion_ApplyOutputCalByte(
+	_In_ PDEVICE_CONTEXT Context
+);
+
+VOID
+DsMotion_OverlayCalByteOnUnified(
+	_In_ PDEVICE_CONTEXT Context,
+	_Inout_updates_(Length) PUCHAR Unified,
+	_In_ ULONG Length
+);
+
+VOID
+DsMotion_FillIpcSnapshot(
+	_In_ PDEVICE_CONTEXT Context,
+	_Out_ PIPC_MOTION_SNAPSHOT_MESSAGE Snapshot
+);
+
+VOID
+DsMotion_PublishOrClearIpcSnapshot(
+	_In_ PDEVICE_CONTEXT Context,
+	_In_ BOOLEAN Clear
+);

--- a/driver/DsUsb.c
+++ b/driver/DsUsb.c
@@ -612,15 +612,30 @@ NTSTATUS DsUsb_PrepareHardware(WDFDEVICE Device)
 		}
 
 		//
+		// Soft-read EEPROM page 0xA0 (Feature 0xEF) after address/pairing
+		// discovery and before the first output report. Failure must not
+		// abort PrepareHardware; DsMotion keeps the documented nominal
+		// fallback in that case (issue #217).
+		// 
+		DsMotion_TryLoadUsbCalibration(Device);
+
+		//
 		// Send initial output report. The PS3 itself sends an all-zero,
 		// 48-byte report over the control endpoint before it ever enables
 		// streaming (Feature 0xF4) - mirrored here (instead of the historical
 		// interrupt-OUT write) so devices without an OUT pipe get exactly the
 		// same treatment a genuine pad already receives from a real console
-		// (see issue #321 and docs/PS3_USB_STARTUP.md).
+		// (see issue #321 and docs/PS3_USB_STARTUP.md). Overlay the Sony
+		// gyro cal byte when this pad's path uses hardware trim.
 		// 
 		{
 			UCHAR zeroOutputReport[48] = { 0 };
+
+			DsMotion_OverlayCalByteOnUnified(
+				pDevCtx,
+				zeroOutputReport,
+				ARRAYSIZE(zeroOutputReport)
+			);
 
 			if (!NT_SUCCESS(status = DsUsb_Ds3SendOutputReportControl(
 				pDevCtx,

--- a/driver/IPC.c
+++ b/driver/IPC.c
@@ -29,6 +29,7 @@ static NTSTATUS DSHM_IPC_CreateResources(
 
 	PUCHAR pCmdBuf = NULL;
 	PUCHAR pHIDBuf = NULL;
+	PUCHAR pMotionBuf = NULL;
 	HANDLE hReadEvent = NULL;
 	HANDLE hWriteEvent = NULL;
 	HANDLE hMapFile = NULL;
@@ -43,12 +44,13 @@ static NTSTATUS DSHM_IPC_CreateResources(
 
 	DWORD cmdRegionSize = pageSize;
 	DWORD hidRegionSize = pageSize;
-	DWORD totalRegionSize = cmdRegionSize + hidRegionSize;
+	DWORD motionRegionSize = pageSize;
+	DWORD totalRegionSize = cmdRegionSize + hidRegionSize + motionRegionSize;
 
 	TraceVerbose(
 		TRACE_IPC,
-		"pageSize = %d, cmdRegionSize = %d, hidRegionSize = %d, totalRegionSize = %d",
-		pageSize, cmdRegionSize, hidRegionSize, totalRegionSize
+		"pageSize = %d, cmdRegionSize = %d, hidRegionSize = %d, motionRegionSize = %d, totalRegionSize = %d",
+		pageSize, cmdRegionSize, hidRegionSize, motionRegionSize, totalRegionSize
 	);	
 
 	SECURITY_ATTRIBUTES sa = { 0 };
@@ -191,6 +193,25 @@ static NTSTATUS DSHM_IPC_CreateResources(
 		goto exitFailure;
 	}
 
+	pMotionBuf = MapViewOfFile(
+		hMapFile,
+		FILE_MAP_ALL_ACCESS,
+		0,
+		pageSize * 2,
+		motionRegionSize
+	);
+
+	if (pMotionBuf == NULL)
+	{
+		lastError = GetLastError();
+		TraceError(
+			TRACE_IPC,
+			"Could not map view of file MOTION REGION (%!WINERROR!).",
+			lastError
+		);
+		goto exitFailure;
+	}
+
 	context->IPC.DispatchThreadTermination = hThreadTermination;
 	context->IPC.MapFile = hMapFile;
 	context->IPC.ConnectMutex = hMutex;
@@ -202,6 +223,9 @@ static NTSTATUS DSHM_IPC_CreateResources(
 
 	context->IPC.SharedRegions.HID.Buffer = pHIDBuf;
 	context->IPC.SharedRegions.HID.BufferSize = hidRegionSize;
+
+	context->IPC.SharedRegions.Motion.Buffer = pMotionBuf;
+	context->IPC.SharedRegions.Motion.BufferSize = motionRegionSize;
 
 	// 
 	// Start thread now that context is initialized at its minimum requirement
@@ -233,6 +257,8 @@ static NTSTATUS DSHM_IPC_CreateResources(
 		context->IPC.SharedRegions.Commands.BufferSize = 0;
 		context->IPC.SharedRegions.HID.Buffer = NULL;
 		context->IPC.SharedRegions.HID.BufferSize = 0;
+		context->IPC.SharedRegions.Motion.Buffer = NULL;
+		context->IPC.SharedRegions.Motion.BufferSize = 0;
 		goto exitFailure;
 	}
 
@@ -259,6 +285,9 @@ exitFailure:
 
 	if (pHIDBuf)
 		UnmapViewOfFile(pHIDBuf);
+
+	if (pMotionBuf)
+		UnmapViewOfFile(pMotionBuf);
 
 	if (hReadEvent)
 		CloseHandle(hReadEvent);
@@ -306,6 +335,9 @@ static void DSHM_IPC_DestroyResources(
 	if (context->IPC.SharedRegions.HID.Buffer)
 		UnmapViewOfFile(context->IPC.SharedRegions.HID.Buffer);
 
+	if (context->IPC.SharedRegions.Motion.Buffer)
+		UnmapViewOfFile(context->IPC.SharedRegions.Motion.Buffer);
+
 	if (context->IPC.MapFile)
 		CloseHandle(context->IPC.MapFile);
 
@@ -324,6 +356,8 @@ static void DSHM_IPC_DestroyResources(
 	context->IPC.SharedRegions.Commands.BufferSize = 0;
 	context->IPC.SharedRegions.HID.Buffer = NULL;
 	context->IPC.SharedRegions.HID.BufferSize = 0;
+	context->IPC.SharedRegions.Motion.Buffer = NULL;
+	context->IPC.SharedRegions.Motion.BufferSize = 0;
 	context->IPC.MapFile = NULL;
 	context->IPC.ReadEvent = NULL;
 	context->IPC.WriteEvent = NULL;

--- a/driver/InputReport.c
+++ b/driver/InputReport.c
@@ -51,6 +51,11 @@ DSHM_ParseInputReport(
 				SetEvent(DeviceContext->IPC.InputReportWaitHandle);
 			}
 
+			if (pDrvCtx->IPC.IsEnabled && pDrvCtx->IPC.SharedRegions.Motion.Buffer != NULL)
+			{
+				DsMotion_PublishOrClearIpcSnapshot(DeviceContext, FALSE);
+			}
+
 			WdfWaitLockRelease(pDrvCtx->IpcLock);
 		}
 	}

--- a/driver/OutputReport.c
+++ b/driver/OutputReport.c
@@ -149,6 +149,13 @@ DSHM_SendOutputReportUnlocked(
 			}
 		}
 
+		//
+		// Re-apply the Sony gyro cal byte last. On SIXAXIS / HW_CAL pads it
+		// occupies the large-motor slots, so rumble or LED writes must not
+		// be the last mutation of those bytes (issue #217).
+		// 
+		DsMotion_ApplyOutputCalByte(Context);
+
 		// 
 		// Timestamp arrival
 		//

--- a/driver/Trace.h
+++ b/driver/Trace.h
@@ -16,6 +16,7 @@
         WPP_DEFINE_BIT(TRACE_CONFIG)                                   \
         WPP_DEFINE_BIT(TRACE_IPC)                                      \
         WPP_DEFINE_BIT(TRACE_LED)                                      \
+        WPP_DEFINE_BIT(TRACE_MOTION)                                   \
         )                                                              \
 
 #define WPP_FLAG_LEVEL_LOGGER(flag, level)                              \

--- a/driver/dshidmini.vcxproj
+++ b/driver/dshidmini.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="DsHidMiniDrv.c" />
     <ClCompile Include="DsIdentification.c" />
     <ClCompile Include="DsLed.c" />
+    <ClCompile Include="DsMotion.c" />
     <ClCompile Include="DsUsb.c" />
     <ClCompile Include="HID.FeatureReport.c" />
     <ClCompile Include="HID.Reports.c" />
@@ -59,6 +60,7 @@
     <ClInclude Include="DsIdentification.h" />
     <ClInclude Include="DsInternal.h" />
     <ClInclude Include="DsLed.h" />
+    <ClInclude Include="DsMotion.h" />
     <ClInclude Include="DsUsb.h" />
     <ClInclude Include="HID.ReportHandlers.h" />
     <ClInclude Include="HID\01_SDF_Col1_GamePad.h" />

--- a/driver/dshidmini.vcxproj.filters
+++ b/driver/dshidmini.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClInclude Include="DsIdentification.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DsMotion.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Power.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -201,6 +204,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DsLed.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DsMotion.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Power.c">


### PR DESCRIPTION
Ship calibrated SIXAXIS telemetry through a backward-compatible IPC region and a ControlApp diagnostic viewer, with Bluetooth using the documented nominal fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added motion sensor support with accelerometer and gyroscope calibration.
  * Added live motion telemetry through the SDK, including compatibility with older drivers.
  * Added a ControlApp motion viewer with 3D orientation, sensor readouts, status details, pause/resume, and yaw recentering.
  * Added motion-path, calibration, tracking, and fallback status information.

* **Documentation**
  * Documented motion telemetry APIs, calibration behavior, compatibility, and current limitations.

* **Tests**
  * Added comprehensive coverage for motion processing, orientation, telemetry layouts, lifecycle behavior, and calibration tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->