### PR TITLE
Fix the motion viewer pose so a still pad stays still and pitch follo…

### DIFF
--- a/ControlApp.Tests/MotionOrientationTests.cs
+++ b/ControlApp.Tests/MotionOrientationTests.cs
@@ -32,21 +32,30 @@ public class MotionOrientationTests
     }
 
     [Fact]
-    public void RightGripDown_PitchesNegative()
+    public void RightGripDown_RollsNegative()
     {
         MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
         estimator.Update(Sample(1000, 0, 0, 0, 1, 1_000_000));
+
+        Assert.True(estimator.RollDegrees < -80);
+    }
+
+    [Fact]
+    public void UsbPortDown_PitchesNegative()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, -1000, 0, 0, 1, 1_000_000));
 
         Assert.True(estimator.PitchDegrees < -80);
     }
 
     [Fact]
-    public void TriggerEdgeDown_RollsNegative()
+    public void UsbPortUp_PitchesPositive()
     {
         MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
-        estimator.Update(Sample(0, -1000, 0, 0, 1, 1_000_000));
+        estimator.Update(Sample(0, 1000, 0, 0, 1, 1_000_000));
 
-        Assert.True(estimator.RollDegrees < -80);
+        Assert.True(estimator.PitchDegrees > 80);
     }
 
     [Fact]
@@ -65,11 +74,13 @@ public class MotionOrientationTests
         MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
         estimator.Update(Sample(0, -1000, 0, 90_000, 1, 0));
         estimator.Update(Sample(0, -1000, 0, 90_000, 2, 100_000));
+        double pitch = estimator.PitchDegrees;
         double roll = estimator.RollDegrees;
 
         estimator.Recenter();
 
         Assert.Equal(0, estimator.YawDegrees);
+        Assert.Equal(pitch, estimator.PitchDegrees);
         Assert.Equal(roll, estimator.RollDegrees);
     }
 
@@ -94,5 +105,25 @@ public class MotionOrientationTests
         estimator.Update(Sample(0, 0, -1000, 90_000, 2, 200_000));
 
         Assert.Equal(yaw, estimator.YawDegrees);
+    }
+
+    [Fact]
+    public void RestGyroBias_BelowDeadzone_DoesNotIntegrateYaw()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, 0, -1000, 2_000, 1, 0));
+        estimator.Update(Sample(0, 0, -1000, 2_000, 2, 100_000));
+
+        Assert.Equal(0, estimator.YawDegrees);
+    }
+
+    [Fact]
+    public void TurnRate_AboveDeadzone_IntegratesYaw()
+    {
+        MotionOrientationEstimator estimator = new(1_000_000, smoothing: 1.0);
+        estimator.Update(Sample(0, 0, -1000, 10_000, 1, 0));
+        estimator.Update(Sample(0, 0, -1000, 10_000, 2, 100_000));
+
+        Assert.InRange(estimator.YawDegrees, 0.99, 1.01);
     }
 }

--- a/ControlApp.Tests/MotionViewerRotationTests.cs
+++ b/ControlApp.Tests/MotionViewerRotationTests.cs
@@ -1,0 +1,59 @@
+using Nefarius.DsHidMini.ControlApp.Models.Motion;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class MotionViewerRotationTests
+{
+    [Fact]
+    public void FromEuler_MapsFaceOnAxesAndYawSign()
+    {
+        MotionViewerRotation.FromEuler(
+            -90,
+            -80,
+            15,
+            out MotionViewerAxisAngle pitch,
+            out MotionViewerAxisAngle roll,
+            out MotionViewerAxisAngle yaw);
+
+        Assert.Equal(1, pitch.AxisX);
+        Assert.Equal(0, pitch.AxisY);
+        Assert.Equal(0, pitch.AxisZ);
+        Assert.Equal(90, pitch.AngleDegrees);
+
+        Assert.Equal(0, roll.AxisX);
+        Assert.Equal(1, roll.AxisY);
+        Assert.Equal(0, roll.AxisZ);
+        Assert.Equal(-80, roll.AngleDegrees);
+
+        Assert.Equal(0, yaw.AxisX);
+        Assert.Equal(0, yaw.AxisY);
+        Assert.Equal(1, yaw.AxisZ);
+        Assert.Equal(-15, yaw.AngleDegrees);
+    }
+
+    [Fact]
+    public void Pitch_UsesXAxisNegated()
+    {
+        MotionViewerAxisAngle mapped = MotionViewerRotation.Pitch(-90);
+
+        Assert.Equal((1, 0, 0, 90), (mapped.AxisX, mapped.AxisY, mapped.AxisZ, mapped.AngleDegrees));
+    }
+
+    [Fact]
+    public void Roll_UsesYAxisUnflipped()
+    {
+        MotionViewerAxisAngle mapped = MotionViewerRotation.Roll(-80);
+
+        Assert.Equal((0, 1, 0, -80), (mapped.AxisX, mapped.AxisY, mapped.AxisZ, mapped.AngleDegrees));
+    }
+
+    [Fact]
+    public void Yaw_UsesZAxisNegated()
+    {
+        MotionViewerAxisAngle mapped = MotionViewerRotation.Yaw(15);
+
+        Assert.Equal((0, 0, 1, -15), (mapped.AxisX, mapped.AxisY, mapped.AxisZ, mapped.AngleDegrees));
+    }
+}

--- a/ControlApp/Models/Motion/MotionOrientationEstimator.cs
+++ b/ControlApp/Models/Motion/MotionOrientationEstimator.cs
@@ -3,12 +3,18 @@ using Nefarius.DsHidMini.IPC.Models.Public;
 namespace Nefarius.DsHidMini.ControlApp.Models.Motion;
 
 /// <summary>
-///     Diagnostic pad pose: smoothed gravity for pitch/roll, integrated yaw from
-///     the single SIXAXIS gyro. Yaw drifts; call <see cref="Recenter" /> to zero it.
+///     Diagnostic pad pose: smoothed gravity for pitch (USB/trigger edge) and
+///     roll (left/right grips), integrated yaw from
+///     the single SIXAXIS gyro. Rest bias below
+///     <see cref="DefaultYawRestDeadzoneDps" /> is ignored. Call
+///     <see cref="Recenter" /> to zero accumulated yaw.
 /// </summary>
 internal sealed class MotionOrientationEstimator
 {
+    public const double DefaultYawRestDeadzoneDps = 4.0;
+
     private readonly double _smoothing;
+    private readonly double _yawRestDeadzoneDps;
     private bool _hasGravity;
     private bool _hasTiming;
     private ulong _lastQpc;
@@ -17,10 +23,14 @@ internal sealed class MotionOrientationEstimator
     private double _smoothZ;
     private uint _lastSampleIndex;
 
-    public MotionOrientationEstimator(double qpcFrequency, double smoothing = 0.18)
+    public MotionOrientationEstimator(
+        double qpcFrequency,
+        double smoothing = 0.18,
+        double yawRestDeadzoneDps = DefaultYawRestDeadzoneDps)
     {
         QpcFrequency = qpcFrequency > 0 ? qpcFrequency : 10_000_000;
         _smoothing = Math.Clamp(smoothing, 0.01, 1.0);
+        _yawRestDeadzoneDps = Math.Max(0, yawRestDeadzoneDps);
     }
 
     public double QpcFrequency { get; }
@@ -91,15 +101,21 @@ internal sealed class MotionOrientationEstimator
         double az = _smoothZ / 1000.0;
         double horiz = Math.Sqrt((ay * ay) + (az * az));
 
-        PitchDegrees = Math.Atan2(-ax, horiz) * (180.0 / Math.PI);
-        RollDegrees = Math.Atan2(ay, -az) * (180.0 / Math.PI);
+        // Aviation/gamepad frame: USB/trigger edge is the nose (pitch from Y),
+        // grips are the wings (roll from X). Sony +1 g is axis-up.
+        PitchDegrees = Math.Atan2(ay, -az) * (180.0 / Math.PI);
+        RollDegrees = Math.Atan2(-ax, horiz) * (180.0 / Math.PI);
 
         if (_hasTiming && snapshot.TimestampQpc > _lastQpc)
         {
             double dt = (snapshot.TimestampQpc - _lastQpc) / QpcFrequency;
             if (dt > 0 && dt < 0.25)
             {
-                YawDegrees += (snapshot.GyroMilliDps / 1000.0) * dt;
+                double dps = snapshot.GyroMilliDps / 1000.0;
+                if (Math.Abs(dps) >= _yawRestDeadzoneDps)
+                {
+                    YawDegrees += dps * dt;
+                }
             }
         }
 

--- a/ControlApp/Models/Motion/MotionViewerRotation.cs
+++ b/ControlApp/Models/Motion/MotionViewerRotation.cs
@@ -1,0 +1,51 @@
+namespace Nefarius.DsHidMini.ControlApp.Models.Motion;
+
+/// <summary>
+///     One Helix axis-angle applied to the face-on diagnostic pad
+///     (X right, Y up, Z toward the camera).
+/// </summary>
+internal readonly record struct MotionViewerAxisAngle(
+    double AxisX,
+    double AxisY,
+    double AxisZ,
+    double AngleDegrees);
+
+/// <summary>
+///     Maps estimator Euler angles onto the face-on Helix pad: pitch (USB/trigger)
+///     nods about X (negated), roll (grips) banks about Y, yaw spins about the
+///     face normal (negated).
+/// </summary>
+internal static class MotionViewerRotation
+{
+    public static MotionViewerAxisAngle Pitch(double pitchDegrees)
+    {
+        // +X is right; right-hand positive nods the USB/trigger edge away
+        // from the camera, so estimator nose-up is a negative Helix angle.
+        return new MotionViewerAxisAngle(1, 0, 0, -pitchDegrees);
+    }
+
+    public static MotionViewerAxisAngle Roll(double rollDegrees)
+    {
+        return new MotionViewerAxisAngle(0, 1, 0, rollDegrees);
+    }
+
+    public static MotionViewerAxisAngle Yaw(double yawDegrees)
+    {
+        // +Z faces the camera; right-hand positive is CCW on screen, so
+        // clockwise-from-above (positive estimator yaw) is a negative angle.
+        return new MotionViewerAxisAngle(0, 0, 1, -yawDegrees);
+    }
+
+    public static void FromEuler(
+        double pitchDegrees,
+        double rollDegrees,
+        double yawDegrees,
+        out MotionViewerAxisAngle pitch,
+        out MotionViewerAxisAngle roll,
+        out MotionViewerAxisAngle yaw)
+    {
+        pitch = Pitch(pitchDegrees);
+        roll = Roll(rollDegrees);
+        yaw = Yaw(yawDegrees);
+    }
+}

--- a/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
+++ b/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
@@ -80,8 +80,11 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
     private string _sampleText = "—";
 
     [ObservableProperty]
+    private string _poseText = "—";
+
+    [ObservableProperty]
     private string _yawNote =
-        "Yaw is integrated from the single SIXAXIS gyro and will drift. Use Recenter after holding the pad still.";
+        "Yaw is integrated from the single SIXAXIS gyro and will drift during turns. Rest bias below a few deg/s is ignored. Use Recenter after a large heading change.";
 
     public CancellationToken SessionToken => _cts.Token;
 
@@ -96,6 +99,7 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
     private void Recenter()
     {
         _estimator.Recenter();
+        RefreshPoseText();
         PoseChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -218,6 +222,13 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
             $"X {snapshot.AccelZeroX}/{snapshot.AccelOneGX}  Y {snapshot.AccelZeroY}/{snapshot.AccelOneGY}  Z {snapshot.AccelZeroZ}/{snapshot.AccelOneGZ}  G {snapshot.GyroZero}/{snapshot.GyroEepromCal}";
         TrackerText = $"zero {snapshot.ZeroRef}  cal 0x{snapshot.CalByte:X2}  tracker {(snapshot.HasTracker ? "on" : "off")}";
         SampleText = $"#{snapshot.SampleIndex}  QPC {snapshot.TimestampQpc}";
+        RefreshPoseText();
+    }
+
+    private void RefreshPoseText()
+    {
+        PoseText =
+            $"{_estimator.PitchDegrees:0.0}  {_estimator.RollDegrees:0.0}  {_estimator.YawDegrees:0.0} deg";
     }
 
     private void PublishUnavailable(string message)

--- a/ControlApp/Views/Windows/MotionViewerWindow.xaml
+++ b/ControlApp/Views/Windows/MotionViewerWindow.xaml
@@ -60,6 +60,8 @@
                         <ui:TextBlock Text="{Binding TrackerText}" />
                         <ui:TextBlock Margin="0,8,0,0" Text="Sample" />
                         <ui:TextBlock Text="{Binding SampleText}" />
+                        <ui:TextBlock Margin="0,8,0,0" Text="Pitch / roll / yaw" />
+                        <ui:TextBlock Text="{Binding PoseText}" />
                         <ui:TextBlock
                             Margin="0,12,0,0"
                             TextWrapping="Wrap"

--- a/ControlApp/Views/Windows/MotionViewerWindow.xaml.cs
+++ b/ControlApp/Views/Windows/MotionViewerWindow.xaml.cs
@@ -3,15 +3,16 @@ using System.Windows.Media.Media3D;
 
 using HelixToolkit.Wpf;
 
+using Nefarius.DsHidMini.ControlApp.Models.Motion;
 using Nefarius.DsHidMini.ControlApp.ViewModels.Windows;
 
 namespace Nefarius.DsHidMini.ControlApp.Views.Windows;
 
 public partial class MotionViewerWindow
 {
-    private readonly AxisAngleRotation3D _pitch = new(new Vector3D(0, 0, 1), 0);
-    private readonly AxisAngleRotation3D _roll = new(new Vector3D(1, 0, 0), 0);
-    private readonly AxisAngleRotation3D _yaw = new(new Vector3D(0, 1, 0), 0);
+    private readonly AxisAngleRotation3D _pitch = CreateRotation(MotionViewerRotation.Pitch(0));
+    private readonly AxisAngleRotation3D _roll = CreateRotation(MotionViewerRotation.Roll(0));
+    private readonly AxisAngleRotation3D _yaw = CreateRotation(MotionViewerRotation.Yaw(0));
     private readonly MotionViewerViewModel _viewModel;
 
     public MotionViewerWindow(MotionViewerViewModel viewModel)
@@ -29,11 +30,25 @@ public partial class MotionViewerWindow
         viewModel.Start();
     }
 
+    private static AxisAngleRotation3D CreateRotation(MotionViewerAxisAngle mapped)
+    {
+        return new AxisAngleRotation3D(
+            new Vector3D(mapped.AxisX, mapped.AxisY, mapped.AxisZ),
+            mapped.AngleDegrees);
+    }
+
     private void OnPoseChanged(object? sender, EventArgs e)
     {
-        _yaw.Angle = _viewModel.Estimator.YawDegrees;
-        _pitch.Angle = _viewModel.Estimator.PitchDegrees;
-        _roll.Angle = _viewModel.Estimator.RollDegrees;
+        MotionViewerRotation.FromEuler(
+            _viewModel.Estimator.PitchDegrees,
+            _viewModel.Estimator.RollDegrees,
+            _viewModel.Estimator.YawDegrees,
+            out MotionViewerAxisAngle pitch,
+            out MotionViewerAxisAngle roll,
+            out MotionViewerAxisAngle yaw);
+        _pitch.Angle = pitch.AngleDegrees;
+        _roll.Angle = roll.AngleDegrees;
+        _yaw.Angle = yaw.AngleDegrees;
     }
 
     private void BuildPadModel()


### PR DESCRIPTION
…ws the USB edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live pitch, roll, and yaw readouts to the motion viewer.
  * Motion viewer rotations now reflect detected device orientation across all three axes.
  * Added configurable yaw-rest deadzone behavior, defaulting to 4 degrees per second.

* **Bug Fixes**
  * Corrected pitch and roll orientation mapping.
  * Prevented minor gyro drift from accumulating as yaw.
  * Recentered views now immediately refresh displayed orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->