### PR TITLE
Replace the CI kit MSI install with cached WDK NuGet restore.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,87 +99,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # windows-2025-vs2026 ships a WDK VS extension and SDK 26100, but not the
-      # WDK headers/libs (ntifs.h, UMDF). See runner-images#14263.
-      # The 26100 WDK MSI exits 0 on this image without laying down UMDF files
-      # (it is the VS 2022 kit). Install the VS 2026 pair: SDK + WDK 28000.
-      - name: 'Cache Windows kit installer layouts'
-        id: kits-layout
-        uses: actions/cache@v6
-        with:
-          path: |
-            sdk-layout
-            wdk-layout
-          key: windows-kits-28000-v1
-
-      - name: 'Download SDK and WDK installer layouts'
-        if: steps.kits-layout.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          function Invoke-KitLayout([string]$Uri, [string]$Name, [string]$Layout) {
-            $bootstrapper = Join-Path $env:RUNNER_TEMP $Name
-            Write-Output "Downloading $Name ..."
-            Invoke-WebRequest -Uri $Uri -OutFile $bootstrapper -UseBasicParsing
-            New-Item -ItemType Directory -Force -Path $Layout | Out-Null
-            $proc = Start-Process -FilePath $bootstrapper -ArgumentList '/layout', $Layout, '/quiet', '/ceip', 'off' -Wait -PassThru
-            if ($proc.ExitCode -notin 0, 3010) {
-              throw "$Name /layout failed with exit $($proc.ExitCode)"
-            }
-          }
-          Invoke-KitLayout 'https://go.microsoft.com/fwlink/?linkid=2366211' 'winsdksetup.exe' (Join-Path $env:GITHUB_WORKSPACE 'sdk-layout')
-          # Official current WDK for VS 2026 (10.0.28000.*).
-          Invoke-KitLayout 'https://go.microsoft.com/fwlink/?LinkId=2371554' 'wdksetup.exe' (Join-Path $env:GITHUB_WORKSPACE 'wdk-layout')
-
-      - name: 'Install SDK 28000 and WDK 28000'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $inc = 'C:\Program Files (x86)\Windows Kits\10\Include'
-          function Test-WdkHeaders {
-            Get-ChildItem $inc -Directory -ErrorAction SilentlyContinue |
-              Where-Object {
-                (Test-Path (Join-Path $_.FullName 'wdf\umdf')) -or
-                (Test-Path (Join-Path $_.FullName 'km\ntifs.h'))
-              } |
-              Select-Object -First 1
-          }
-          $present = Test-WdkHeaders
-          if ($present) {
-            Write-Output "WDK already present ($($present.Name))."
-            return
-          }
-
-          $sdkSetup = Join-Path $env:GITHUB_WORKSPACE 'sdk-layout\winsdksetup.exe'
-          $wdkSetup = Join-Path $env:GITHUB_WORKSPACE 'wdk-layout\wdksetup.exe'
-          if (-not (Test-Path -LiteralPath $sdkSetup)) { throw "SDK layout missing: $sdkSetup" }
-          if (-not (Test-Path -LiteralPath $wdkSetup)) { throw "WDK layout missing: $wdkSetup" }
-
-          Write-Output 'Installing Windows SDK 28000...'
-          $sdkArgs = @(
-            '/features',
-            'OptionId.DesktopCPPx86', 'OptionId.DesktopCPPx64', 'OptionId.DesktopCPParm64',
-            'OptionId.UWPCPP',
-            '/quiet', '/norestart', '/ceip', 'off'
-          )
-          $proc = Start-Process -FilePath $sdkSetup -ArgumentList $sdkArgs -Wait -PassThru
-          Write-Output "SDK installer exit $($proc.ExitCode)"
-          if ($proc.ExitCode -notin 0, 3010) { throw "SDK install failed with exit $($proc.ExitCode)" }
-
-          Write-Output 'Installing WDK 28000...'
-          $proc = Start-Process -FilePath $wdkSetup -ArgumentList '/features', '+', '/quiet', '/norestart', '/ceip', 'off' -Wait -PassThru
-          Write-Output "WDK installer exit $($proc.ExitCode)"
-          if ($proc.ExitCode -notin 0, 3010) { throw "WDK install failed with exit $($proc.ExitCode)" }
-
-          $present = Test-WdkHeaders
-          if (-not $present) {
-            Write-Output 'Include tree after install:'
-            Get-ChildItem $inc -Recurse -Depth 2 -ErrorAction SilentlyContinue |
-              Select-Object -ExpandProperty FullName
-            throw 'Kit installers finished but UMDF/km headers were not found.'
-          }
-          Write-Output "WDK installed ($($present.Name))."
-
       - name: 'Bootstrap vcpkg'
         shell: cmd
         run: .\XInputBridge\vcpkg\bootstrap-vcpkg.bat -disableMetrics
@@ -197,6 +116,32 @@ jobs:
           echo "vcpkg-sha=$vcpkgSha" >> $env:GITHUB_OUTPUT
           echo "image-version=$imageVersion" >> $env:GITHUB_OUTPUT
           Write-Output "DMF $dmfSha / vcpkg $vcpkgSha (ImageVersion=$imageVersion)"
+
+      # windows-2025-vs2026 ships a WDK VS extension and SDK 26100, but not the
+      # WDK headers/libs (ntifs.h, UMDF). See runner-images#14263. x64/ARM64
+      # restore the 28000 WDK+SDK NuGet packages instead of running the MSI
+      # installers. x86 does not build the driver or DMF and uses the image SDK.
+      - name: 'Setup NuGet'
+        if: matrix.platform != 'x86'
+        uses: NuGet/setup-nuget@v2
+
+      - name: 'Cache WDK NuGet packages'
+        if: matrix.platform != 'x86'
+        id: wdk-nuget
+        uses: actions/cache@v6
+        with:
+          path: packages
+          key: wdk-nuget-v1-${{ hashFiles('build/wdk-packages.config') }}-${{ steps.cache-keys.outputs.image-version }}
+
+      - name: 'Restore WDK NuGet packages'
+        if: matrix.platform != 'x86' && steps.wdk-nuget.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # nuget.exe only accepts the filename packages.config
+          $config = Join-Path $env:RUNNER_TEMP 'packages.config'
+          Copy-Item -LiteralPath 'build\wdk-packages.config' -Destination $config -Force
+          nuget restore $config -PackagesDirectory packages -NonInteractive
 
       - name: 'Cache NuGet packages'
         uses: actions/cache@v6
@@ -261,33 +206,22 @@ jobs:
           dotnet vpatch --stamp-version "%BUILD_VERSION%" --target-file ".\XInputBridge\XInputBridge.rc" --resource.file-version --resource.product-version
 
       - name: 'Restore managed projects'
-        # msbuild's /t:Rebuild over the whole solution does not implicitly restore SDK-style
-        # projects; these two dotnet restore calls also transitively restore the SDK project
-        # referenced by both. Mirrors appveyor.yml's former before_build steps.
+        # PublishControlApp and ControlApp.Tests run on x64 only. ARM64/x86 no longer
+        # solution-build ControlApp, installer, or ipctest.
+        if: matrix.platform == 'x64'
         shell: cmd
         run: |
           dotnet restore .\ControlApp\
           dotnet restore .\ControlApp.Tests\
-          dotnet restore .\ipctest\
 
       - name: 'Test ControlApp'
         if: matrix.platform == 'x64'
         shell: cmd
         run: dotnet test .\ControlApp.Tests\ControlApp.Tests.csproj --configuration Release --no-restore
 
-      - name: 'Test config parser'
-        if: matrix.platform == 'x64'
-        shell: cmd
-        run: .\build.cmd TestConfigParser --target-platform x64
-
-      - name: 'Test release pipeline'
-        if: matrix.platform == 'x64'
-        shell: cmd
-        run: .\build.cmd TestReleasePipeline
-
       - name: 'Build'
         shell: cmd
-        run: .\build.cmd Compile ${{ matrix.platform == 'x64' && 'PublishControlApp' || '' }} --target-platform ${{ matrix.platform }} ${{ steps.dmf-cache.outputs.cache-hit == 'true' && '--skip BuildDmf' || '' }}
+        run: .\build.cmd ${{ matrix.platform == 'x64' && 'TestConfigParser TestReleasePipeline Compile PublishControlApp' || 'Compile' }} --target-platform ${{ matrix.platform }} ${{ steps.dmf-cache.outputs.cache-hit == 'true' && '--skip BuildDmf' || '' }}
 
       - name: 'Pack driver CAB'
         if: matrix.platform != 'x86'

--- a/.gitignore
+++ b/.gitignore
@@ -350,6 +350,7 @@ healthchecksdb
 /vcpkg-archives
 /wdk-layout
 /sdk-layout
+/packages
 **/*.g.wxs
 /XInputBridge/exports
 **/*_OTEL

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -52,7 +52,28 @@ partial class Build : NukeBuild
 
     AbsolutePath DmfSolution => Solution.Directory / "DMF/Dmf.sln";
 
+    AbsolutePath CppForceImport => RootDirectory / "build" / "CiCpp.props";
+
     AbsolutePath ResolvedArtifactsPath => (AbsolutePath)Path.GetFullPath(Path.Combine(RootDirectory, ArtifactsPath));
+
+    /// <summary>
+    /// CI builds only the native artifacts that job uploads. ControlApp is published separately
+    /// on x64; installer/ipctest/SDK are not CI outputs. Local builds still Rebuild the solution.
+    /// </summary>
+    IEnumerable<(AbsolutePath project, MSBuildTargetPlatform platform)> CiCompileProjects()
+    {
+        MSBuildTargetPlatform platform = string.Equals(TargetPlatform, "x86", StringComparison.OrdinalIgnoreCase)
+            ? MSBuildTargetPlatform.Win32
+            : (MSBuildTargetPlatform)TargetPlatform;
+
+        if (!string.Equals(TargetPlatform, "x86", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(TargetPlatform, "Win32", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return (RootDirectory / "driver" / "dshidmini.vcxproj", platform);
+        }
+
+        yield return (RootDirectory / "XInputBridge" / "XInputBridge.vcxproj", platform);
+    }
 
     /// <summary>
     /// Version stamp propagated from CI (BUILD_VERSION env var, set from github.run_number). Empty for local builds.
@@ -179,8 +200,10 @@ partial class Build : NukeBuild
                     .SetNodeReuse(IsLocalBuild)
                     .SetVerbosity(MSBuildVerbosity.Minimal)
                     // VS 2026's STL errors on DMF's /await experimental coroutine modules unless silenced.
-                    .SetProperty("ForceImportBeforeCppTargets",
-                        RootDirectory / "build" / "SilenceExperimentalCoroutines.props")
+                    // DsHidMiniImportWdkNuget: DMF sets PlatformToolset after Default.props, so
+                    // WdkNuget.props cannot key off the toolset and must be opted in here.
+                    .SetProperty("ForceImportBeforeCppTargets", CppForceImport)
+                    .SetProperty("DsHidMiniImportWdkNuget", "true")
                 );
             }
         });
@@ -191,6 +214,48 @@ partial class Build : NukeBuild
         {
             Logging.Level = LogLevel.Normal;
 
+            if (!IsLocalBuild)
+            {
+                if (string.IsNullOrWhiteSpace(TargetPlatform))
+                {
+                    throw new InvalidOperationException(
+                        "TargetPlatform must be set on CI, e.g. --target-platform x64.");
+                }
+
+                foreach ((AbsolutePath project, MSBuildTargetPlatform platform) in CiCompileProjects())
+                {
+                    Log.Information("Building {Project} {Configuration} | {Platform}", project.Name, Configuration, platform);
+                    MSBuildTasks.MSBuild(s =>
+                    {
+                        MSBuildSettings settings = s
+                            .SetProcessToolPath(MSBuildPath)
+                            .SetTargetPath(project)
+                            .SetTargets("Build")
+                            .SetConfiguration(Configuration)
+                            .SetTargetPlatform(platform)
+                            .SetMaxCpuCount(Environment.ProcessorCount)
+                            .SetNodeReuse(false)
+                            .SetVerbosity(MSBuildVerbosity.Minimal)
+                            .SetProperty("ForceImportBeforeCppTargets", CppForceImport)
+                            .SetProperty("SignMode", "Off")
+                            .SetProperty("SolutionDir", RootDirectory.ToString().TrimEnd('\\', '/') + "\\");
+
+                        if (!string.IsNullOrWhiteSpace(BuildVersionStamp))
+                        {
+                            settings = settings
+                                .SetProperty("Version", BuildVersionStamp)
+                                .SetProperty("AssemblyVersion", BuildVersionStamp)
+                                .SetProperty("FileVersion", BuildVersionStamp)
+                                .SetProperty("InformationalVersion", BuildVersionStamp);
+                        }
+
+                        return settings;
+                    });
+                }
+
+                return;
+            }
+
             MSBuildTasks.MSBuild(s =>
             {
                 MSBuildSettings settings = s
@@ -200,38 +265,13 @@ partial class Build : NukeBuild
                     .SetConfiguration(Configuration)
                     .SetMaxCpuCount(Environment.ProcessorCount)
                     .SetNodeReuse(IsLocalBuild)
-                    .SetVerbosity(MSBuildVerbosity.Minimal);
+                    .SetVerbosity(MSBuildVerbosity.Minimal)
+                    .SetProperty("ForceImportBeforeCppTargets", CppForceImport);
 
-                // On CI, MSBuild must be told the solution platform explicitly. AppVeyor's "platform:" matrix
-                // axis set a $env:PLATFORM variable that MSBuild picks up implicitly for the unset Platform
-                // property; GitHub Actions has no such variable, so without this MSBuild falls back to
-                // "Any CPU", which dshidmini.sln maps to a Release|x64 build of the driver project for every
-                // leg (including x86), pulling in a DMF x64 lib that BuildDmf never produced for that leg.
-                if (!IsLocalBuild)
-                {
-                    if (string.IsNullOrWhiteSpace(TargetPlatform))
-                    {
-                        throw new InvalidOperationException(
-                            "TargetPlatform must be set on CI, e.g. --target-platform x64.");
-                    }
+                string noWarn =
+                    "CS0219;CS1587;CS1591;CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8619;CS8622;CS8625;CS8629;CS8765;CS8767;CS8981";
+                settings = settings.SetProperty("NoWarn", noWarn.Replace(";", "%3B"));
 
-                    settings = settings
-                        .SetTargetPlatform((MSBuildTargetPlatform)TargetPlatform)
-                        // Compile produces unsigned driver DLLs. The partner-cab job EV-signs
-                        // those binaries immediately before packing the submission CAB.
-                        .SetProperty("SignMode", "Off");
-                }
-
-                // Aggressively silence C# warnings for local Nuke builds (nullability, CS8981, XML docs, etc.)
-                if (IsLocalBuild)
-                {
-                    string noWarn =
-                        "CS0219;CS1587;CS1591;CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8619;CS8622;CS8625;CS8629;CS8765;CS8767;CS8981";
-                    settings = settings.SetProperty("NoWarn", noWarn.Replace(";", "%3B"));
-                }
-
-                // Stamps managed projects (ControlApp, SDK, ipctest, installer) with the CI build version,
-                // replacing AppVeyor's dotnet_csproj auto-patching. C++ projects ignore unknown properties.
                 if (!string.IsNullOrWhiteSpace(BuildVersionStamp))
                 {
                     settings = settings

--- a/build/CiCpp.props
+++ b/build/CiCpp.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="SilenceExperimentalCoroutines.props" />
+  <Import Project="WdkNuget.props" />
+</Project>

--- a/build/WdkNuget.props
+++ b/build/WdkNuget.props
@@ -1,0 +1,29 @@
+<Project>
+  <!-- WDK/SDK 28000 from NuGet. No-op when packages/ is absent so a local MSI WDK still works.
+       Imported only for the driver project (by name) or when NUKE sets DsHidMiniImportWdkNuget
+       (DMF): ForceImportBeforeCppTargets runs before DMF sets PlatformToolset. -->
+  <PropertyGroup>
+    <DsHidMiniWdkKitVersion Condition="'$(DsHidMiniWdkKitVersion)' == ''">10.0.28000.2526</DsHidMiniWdkKitVersion>
+    <DsHidMiniWdkPackagesDir Condition="'$(DsHidMiniWdkPackagesDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\packages'))</DsHidMiniWdkPackagesDir>
+    <DsHidMiniUseWdkNuget Condition="'$(DsHidMiniImportWdkNuget)' == 'true' or '$(MSBuildProjectName)' == 'dshidmini'">true</DsHidMiniUseWdkNuget>
+  </PropertyGroup>
+
+  <Import Project="$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.WDK.x64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.WDK.x64.props"
+          Condition="'$(DsHidMiniUseWdkNuget)' == 'true' and '$(Platform)' == 'x64' and Exists('$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.WDK.x64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.WDK.x64.props')" />
+  <Import Project="$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.WDK.arm64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.WDK.arm64.props"
+          Condition="'$(DsHidMiniUseWdkNuget)' == 'true' and '$(Platform)' == 'ARM64' and Exists('$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.WDK.arm64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.WDK.arm64.props')" />
+  <Import Project="$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.SDK.CPP.x64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.SDK.cpp.x64.props"
+          Condition="'$(DsHidMiniUseWdkNuget)' == 'true' and '$(Platform)' == 'x64' and Exists('$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.SDK.CPP.x64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.SDK.cpp.x64.props')" />
+  <Import Project="$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.SDK.CPP.arm64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.SDK.cpp.arm64.props"
+          Condition="'$(DsHidMiniUseWdkNuget)' == 'true' and '$(Platform)' == 'ARM64' and Exists('$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.SDK.CPP.arm64.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.SDK.cpp.arm64.props')" />
+  <Import Project="$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.SDK.CPP.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.SDK.cpp.props"
+          Condition="'$(DsHidMiniUseWdkNuget)' == 'true' and Exists('$(DsHidMiniWdkPackagesDir)\Microsoft.Windows.SDK.CPP.$(DsHidMiniWdkKitVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />
+
+  <!-- WDK NuGet sets WDKContentRoot to ...\c without a trailing slash. The kit
+       targets then concatenate $(WDKContentRoot)build\... into ...\cbuild\... -->
+  <PropertyGroup Condition="'$(DsHidMiniUseWdkNuget)' == 'true'">
+    <WDKContentRoot Condition="'$(WDKContentRoot)' != '' and !HasTrailingSlash('$(WDKContentRoot)')">$(WDKContentRoot)\</WDKContentRoot>
+    <WindowsSdkDir Condition="'$(WindowsSdkDir)' != '' and !HasTrailingSlash('$(WindowsSdkDir)')">$(WindowsSdkDir)\</WindowsSdkDir>
+    <WindowsSdkDir_10 Condition="'$(WindowsSdkDir_10)' != '' and !HasTrailingSlash('$(WindowsSdkDir_10)')">$(WindowsSdkDir_10)\</WindowsSdkDir_10>
+  </PropertyGroup>
+</Project>

--- a/build/wdk-packages.config
+++ b/build/wdk-packages.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.28000.2526" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.28000.2526" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.28000.2526" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.28000.2526" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.arm64" version="10.0.28000.2526" targetFramework="native" />
+</packages>

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -24,7 +24,7 @@ Non-tag CI (master / pull request) stamps binaries `0.0.0.(2000 + run_number)` a
 Local machine:
 
 - Windows, `gh` authenticated (`gh auth login`, `repo` scope)
-- Visual Studio 2026 / MSBuild 18 and Windows SDK/WDK 10.0.28000 (same pair CI installs)
+- Visual Studio 2026 / MSBuild 18 and Windows SDK/WDK 10.0.28000 (classic MSI pair locally; CI restores the matching WDK NuGet packages)
 - EV code-signing certificate whose subject contains `Nefarius Software Solutions e.U.`
 - SignTool on PATH via WDK, or pass `--sign-tool-path`
 - Maintainer-supplied `igfilter` packages (private; not built or downloaded by this repository)

--- a/driver/README.md
+++ b/driver/README.md
@@ -38,7 +38,7 @@ Designed for **Windows 10** version 1809 or newer (**x64**, **ARM64**). Dependen
 ### Prerequisites
 
 - Visual Studio 2026 (MSBuild 18). CI uses the `windows-2025-vs2026` image
-- Windows SDK and WDK **10.0.28000** (the pair installed by the Build workflow)
+- Windows SDK and WDK **10.0.28000**. Local builds use the classic MSI pair; CI restores `Microsoft.Windows.WDK.*` / `Microsoft.Windows.SDK.CPP*` 10.0.28000.2526 via [build/wdk-packages.config](../build/wdk-packages.config)
 - [Driver Module Framework (DMF)](https://github.com/microsoft/DMF) via the `DMF/` submodule (`nefarius` branch). `.\build.cmd Compile` builds `DmfU` automatically
 
 ### Building


### PR DESCRIPTION
The windows-2025-vs2026 image still lacks UMDF headers, so every platform job spent about three minutes running SDK/WDK installers. Restore pinned 28000 packages on x64/ARM64 instead and skip kits on x86.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & CI**
  * Improved Windows build reliability across x64, ARM64, and x86 platforms.
  * CI now restores required Windows development packages automatically.
  * x64 builds include configuration-parser and release-pipeline tests.
  * ARM64 and x86 builds focus on compilation.

* **Documentation**
  * Clarified local Windows development prerequisites and CI package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->