### PR TITLE
Publish the HwCal tracker gyro so sub-step rest bias does not reach c…

### DIFF
--- a/ControlApp.Tests/MotionProcessingTests.cs
+++ b/ControlApp.Tests/MotionProcessingTests.cs
@@ -64,11 +64,21 @@ public class MotionProcessingTests
     }
 
     [Fact]
-    public void HwCalGyro_InvertsRawWithoutSoftwareZero()
+    public void HwCalGyro_SonyHidReport_InvertsRawWithoutSoftwareZero()
     {
-        // DS3-A2 idle 361 with factory cal applied
+        // sixaxis.sys HID report for field-0x07 pads: clamp(0x3FF - raw).
         Assert.Equal(0x3FF - 361, DsMotionMath.HwCalReportedGyro(361));
         Assert.Equal(512, DsMotionMath.HwCalReportedGyro(511));
+    }
+
+    [Fact]
+    public void HwCalGyro_PublishedValue_UsesTrackerZeroRef()
+    {
+        // DS3-A1b at rest: raw 496, tracker zeroRef 496. Sony HID would
+        // publish 527 (~10.7 deg/s); DsHidMini publishes the tracker output.
+        Assert.Equal(527, DsMotionMath.HwCalReportedGyro(496));
+        Assert.Equal(512, DsMotionMath.TrackedGyro(496, 496));
+        Assert.True(DsMotionMath.TrackedGyro(480, 496) > 512);
     }
 
     [Fact]
@@ -104,6 +114,22 @@ public class MotionProcessingTests
         byte sent = tracker.Initial(0, 200);
         Assert.Equal(unchecked((byte)tracker.CalByteRaw), sent);
         Assert.InRange(tracker.CalByteRaw, int.MinValue, int.MaxValue);
+    }
+
+    [Fact]
+    public void Tracker_SubStepRestBias_OutputCentersWithoutCalStep()
+    {
+        SonyGyroTracker tracker = new();
+        tracker.Initial(0x77, 521);
+
+        for (int i = 0; i < 200; i++)
+        {
+            tracker.Runtime(496, out _);
+        }
+
+        Assert.Equal(496, tracker.ZeroRef);
+        Assert.Equal(512, tracker.Output);
+        Assert.Equal(0x77, tracker.CalByte);
     }
 
     [Fact]

--- a/ControlApp/Models/Motion/DsMotionMath.cs
+++ b/ControlApp/Models/Motion/DsMotionMath.cs
@@ -55,6 +55,11 @@ internal static class DsMotionMath
         return Clamp10(0x3FF - raw);
     }
 
+    public static int TrackedGyro(int raw, int zeroRef)
+    {
+        return Clamp10(NominalZero + zeroRef - raw);
+    }
+
     public static int ToMilliG(int calibrated)
     {
         return ((calibrated - NominalZero) * 1000) / AccelGain;

--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -726,7 +726,7 @@ gyro paths, selected by the flags:
 | --- | --- | --- |
 | `PLAIN_ZERO` set, `HW_CAL` clear | B1, DS3-A1a, DS3-E, both counterfeits | `clamp(512 + eepromZero - raw)` - plain software zero against the EEPROM value, no tracker |
 | `PLAIN_ZERO` clear | SIXAXIS-1, SIXAXIS-2 | `clamp(512 + zeroRef - raw)` with the full auto-zero tracker driving `zeroRef` |
-| `HW_CAL` set | DS3-A1b, DS3-A2 | tracker runs (to keep the **hardware** trim converged and re-send cal bytes), but the reported value is just `clamp(0x3FF - raw)` |
+| `HW_CAL` set | DS3-A1b, DS3-A2 | tracker runs (to keep the **hardware** trim converged and re-send cal bytes). `sixaxis.sys` then reports `clamp(0x3FF - raw)`; DsHidMini publishes the tracker's `clamp(512 + zeroRef - raw)` so residuals smaller than one cal-byte step do not leak to consumers |
 
 All three **invert the gyro's sign relative to the raw value**, and the result is
 written back into the report as host-order u16.
@@ -757,7 +757,11 @@ both platforms, so on Linux it is not zeroed either.
 - **Gyro tracker**: `HW_CAL` and `SIXAXIS` USB pads run the Sony auto-zero
   tracker (`research/ds3-motion/probe/GyroCal.cs`). When the cal byte steps,
   the driver re-applies it on the next output report (unified `[5]/[6]` or
-  `[3]/[4]`). Sending the factory byte once is not enough.
+  `[3]/[4]`). Sending the factory byte once is not enough. For `HW_CAL`,
+  DsHidMini also publishes the tracker's software-zeroed output (same formula
+  as `SIXAXIS`) so a rest error below one ~26.4-count cal-byte step — e.g.
+  DS3-A1b's 16-count / ~10.7 deg/s leftover — does not appear as yaw bias on
+  IPC or SIXAXIS GetFeature.
 - **IPC**: the existing 60-byte raw HID slot is unchanged. A third
   allocation-granularity-aligned region publishes `IPC_MOTION_SNAPSHOT_MESSAGE`
   (80 bytes, version 1). `Nefarius.DsHidMini.IPC` maps it when present and
@@ -807,8 +811,10 @@ Ordered by how visible they are to an application that expects `sixaxis.sys`:
 7. **Per-class behaviour is not just cosmetic.** The three gyro paths are keyed
    off the `Feature 0x01` calibration field list - *not* the type bytes, which
    SIXAXIS-2 gets wrong. Picking one path for all pads will be wrong for the
-   others. In particular a field-`0x07` DS3 must *not* be software-zeroed on top
-   of its hardware trim.
+   others. A field-`0x07` DS3 still needs the hardware cal-byte tracker for
+   large trim errors (DS3-A2). `sixaxis.sys` then reports `0x3FF - raw` and
+   leaves sub-step residuals in the HID report; DsHidMini publishes
+   `512 + zeroRef - raw` so those residuals do not reach consumers.
 8. **DS4Windows mode has no motion at all**, and the DS4 frame mapping is still
    only partly verified: the DS3 source frame is known (X to the left grip, Y to
    the trigger edge, Z down through the buttons) and the gyro is now measured at

--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -726,7 +726,7 @@ gyro paths, selected by the flags:
 | --- | --- | --- |
 | `PLAIN_ZERO` set, `HW_CAL` clear | B1, DS3-A1a, DS3-E, both counterfeits | `clamp(512 + eepromZero - raw)` - plain software zero against the EEPROM value, no tracker |
 | `PLAIN_ZERO` clear | SIXAXIS-1, SIXAXIS-2 | `clamp(512 + zeroRef - raw)` with the full auto-zero tracker driving `zeroRef` |
-| `HW_CAL` set | DS3-A1b, DS3-A2 | tracker runs (to keep the **hardware** trim converged and re-send cal bytes). `sixaxis.sys` then reports `clamp(0x3FF - raw)`; DsHidMini publishes the tracker's `clamp(512 + zeroRef - raw)` so residuals smaller than one cal-byte step do not leak to consumers |
+| `HW_CAL` set | DS3-A1b, DS3-A2 | tracker runs (to keep the **hardware** trim converged and re-send cal bytes). `sixaxis.sys` then reports `clamp(0x3FF - raw)`. DsHidMini publishes `clamp(512 + zeroRef - raw)` only when the tracker is initialized (successful Feature `0xEF` page `0xA0`); after a failed or invalid EEPROM load it publishes `clamp(0x3FF - raw)` |
 
 All three **invert the gyro's sign relative to the raw value**, and the result is
 written back into the report as host-order u16.
@@ -752,20 +752,27 @@ both platforms, so on Linux it is not zeroed either.
   Bluetooth uses the same formulas with the nominal fallback and does **not**
   send hardware cal bytes or attempt `0xEF`.
 - **SIXAXIS.SYS-compatible GetFeature** (`DSHM_ProcessHidInputReport`): the
-  49-byte feature report now carries the calibrated, host-order Sony values.
-  The 12-byte SIXAXIS input report still has no motion fields.
+  49-byte feature report now carries the calibrated, host-order values from
+  `Motion.Sample` (same `CalGyro` as IPC). For `HW_CAL` that is
+  `clamp(512 + zeroRef - raw)` when the tracker is initialized, otherwise
+  `clamp(0x3FF - raw)`. The 12-byte SIXAXIS input report still has no motion
+  fields.
 - **Gyro tracker**: `HW_CAL` and `SIXAXIS` USB pads run the Sony auto-zero
-  tracker (`research/ds3-motion/probe/GyroCal.cs`). When the cal byte steps,
-  the driver re-applies it on the next output report (unified `[5]/[6]` or
-  `[3]/[4]`). Sending the factory byte once is not enough. For `HW_CAL`,
-  DsHidMini also publishes the tracker's software-zeroed output (same formula
-  as `SIXAXIS`) so a rest error below one ~26.4-count cal-byte step — e.g.
-  DS3-A1b's 16-count / ~10.7 deg/s leftover — does not appear as yaw bias on
-  IPC or SIXAXIS GetFeature.
+  tracker (`research/ds3-motion/probe/GyroCal.cs`) only after a successful
+  Feature `0xEF` page `0xA0` read. When the cal byte steps, the driver
+  re-applies it on the next output report (unified `[5]/[6]` or `[3]/[4]`).
+  Sending the factory byte once is not enough. For `HW_CAL` with an
+  initialized tracker, DsHidMini also publishes the tracker's software-zeroed
+  output (same formula as `SIXAXIS`) so a rest error below one ~26.4-count
+  cal-byte step — e.g. DS3-A1b's 16-count / ~10.7 deg/s leftover — does not
+  appear as yaw bias. If EEPROM load fails, the tracker stays uninitialized
+  and both IPC and GetFeature fall back to `clamp(0x3FF - raw)`.
 - **IPC**: the existing 60-byte raw HID slot is unchanged. A third
   allocation-granularity-aligned region publishes `IPC_MOTION_SNAPSHOT_MESSAGE`
-  (80 bytes, version 1). `Nefarius.DsHidMini.IPC` maps it when present and
-  exposes `GetMotionSnapshot`.
+  (80 bytes, version 1) from the same `Motion.Sample` (`CalGyro` /
+  `GyroMilliDps` follow the `HW_CAL` tracker-or-`0x3FF` rule above).
+  `Nefarius.DsHidMini.IPC` maps it when present and exposes
+  `GetMotionSnapshot`.
 - **ControlApp**: per-device Motion viewer with numeric readout and a
   diagnostic HelixToolkit pose (gravity pitch/roll, integrated yaw).
 - **DS4Windows-compatible mode** (`driver/DsHid.c`, `DS3_RAW_TO_DS4WINDOWS_HID_INPUT_REPORT`):
@@ -814,7 +821,9 @@ Ordered by how visible they are to an application that expects `sixaxis.sys`:
    others. A field-`0x07` DS3 still needs the hardware cal-byte tracker for
    large trim errors (DS3-A2). `sixaxis.sys` then reports `0x3FF - raw` and
    leaves sub-step residuals in the HID report; DsHidMini publishes
-   `512 + zeroRef - raw` so those residuals do not reach consumers.
+   `512 + zeroRef - raw` when the tracker is initialized so those residuals
+   do not reach consumers, and `0x3FF - raw` if Feature `0xEF` failed and the
+   tracker was never started.
 8. **DS4Windows mode has no motion at all**, and the DS4 frame mapping is still
    only partly verified: the DS3 source frame is known (X to the left grip, Y to
    the trigger edge, Z down through the buttons) and the gyro is now measured at

--- a/driver/DsMotion.c
+++ b/driver/DsMotion.c
@@ -766,10 +766,20 @@ DsMotion_ProcessInputReport(
 	switch (motion->Path)
 	{
 	case DsIdentificationMotionPathHwCal:
-		calGyro = DsMotion_Clamp10(0x3FF - raw[3]);
 		if (motion->Tracker.Initialized)
 		{
-			(void)DsMotion_TrackerRuntime(&motion->Tracker, raw[3], &trackerChanged);
+			// Publish the tracker's software-zeroed rate. sixaxis.sys leaves
+			// clamp(0x3FF - raw) in the HID report, so residuals smaller than
+			// one cal-byte step (~26.4 counts) leak as a constant yaw bias.
+			// The tracker already computes TARGET + zeroRef - raw; use it so
+			// IPC, GetFeature, and future mappings see a still pad at rest.
+			// The cal-byte path still runs inside TrackerRuntime for large
+			// hardware-trim errors (DS3-A2).
+			calGyro = DsMotion_TrackerRuntime(&motion->Tracker, raw[3], &trackerChanged);
+		}
+		else
+		{
+			calGyro = DsMotion_Clamp10(0x3FF - raw[3]);
 		}
 		break;
 


### PR DESCRIPTION
…onsumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hardware-calibrated motion output now uses software-zeroed gyro readings for improved accuracy.
  - Small residual rest-position errors are suppressed while preserving calibration data.
  - Uninitialized motion handling continues to provide inverted raw gyro output as a fallback.

- **Documentation**
  - Clarified the distinction between tracker-based software-zeroed readings and raw hardware gyro values.
  - Documented calibration loading, tracker initialization, fallback output, and calibrated reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->