### PR TITLE
Stop treating a Defender Feature 0x14 ACK as a PS3 mode switch.

### DIFF
--- a/ControlApp.Tests/DefenderBtModeSwitcherTests.cs
+++ b/ControlApp.Tests/DefenderBtModeSwitcherTests.cs
@@ -1,0 +1,29 @@
+using Nefarius.DsHidMini.ControlApp.Models.Util;
+
+using Xunit;
+
+namespace Nefarius.DsHidMini.ControlApp.Tests;
+
+public class DefenderBtModeSwitcherTests
+{
+    [Theory]
+    [InlineData((ushort)0x054C, (ushort)0x05C4, (ushort)0x0221, true)]
+    [InlineData((ushort)0x054C, (ushort)0x05C4, (ushort)0x0100, false)]
+    [InlineData((ushort)0x054C, (ushort)0x0268, (ushort)0x0221, false)]
+    [InlineData((ushort)0x054C, (ushort)0x09CC, (ushort)0x0221, false)]
+    [InlineData((ushort)0x045E, (ushort)0x05C4, (ushort)0x0221, false)]
+    public void MatchesDs4Identity_RequiresDefenderBtVidPidAndBcdDevice(
+        ushort vendorId, ushort productId, ushort versionNumber, bool expected)
+    {
+        Assert.Equal(expected, DefenderBtModeSwitcher.MatchesDs4Identity(vendorId, productId, versionNumber));
+    }
+
+    [Fact]
+    public void DualShock3ProductId_MatchesSonyDs3()
+    {
+        Assert.Equal(0x054C, DefenderBtModeSwitcher.SonyVendorId);
+        Assert.Equal(0x0268, DefenderBtModeSwitcher.DualShock3ProductId);
+        Assert.Equal(0x05C4, DefenderBtModeSwitcher.DualShock4ProductId);
+        Assert.Equal(0x0221, DefenderBtModeSwitcher.DefenderBtVersionNumber);
+    }
+}

--- a/ControlApp.Tests/DefenderBtModeSwitcherTests.cs
+++ b/ControlApp.Tests/DefenderBtModeSwitcherTests.cs
@@ -26,4 +26,27 @@ public class DefenderBtModeSwitcherTests
         Assert.Equal(0x05C4, DefenderBtModeSwitcher.DualShock4ProductId);
         Assert.Equal(0x0221, DefenderBtModeSwitcher.DefenderBtVersionNumber);
     }
+
+    [Theory]
+    [InlineData(@"USB\VID_054C&PID_0268\6&4B29C3C&0&2", true)]
+    [InlineData(@"USB\VID_054C&PID_05C4\6&4B29C3C&0&2", false)]
+    [InlineData(@"USB\VID_054C&PID_042F\6&4B29C3C&0&2", false)]
+    [InlineData(null, false)]
+    public void IsDualShock3UsbInstanceId_RequiresSonyDs3VidPid(string? instanceId, bool expected)
+    {
+        Assert.Equal(expected, DefenderBtModeSwitcher.IsDualShock3UsbInstanceId(instanceId));
+    }
+
+    [Fact]
+    public void HasNewlyAppearedDualShock3Usb_IgnoresPreExistingIdentities()
+    {
+        string existing = @"USB\VID_054C&PID_0268\EXISTING";
+        string[] before = [existing];
+
+        Assert.False(DefenderBtModeSwitcher.HasNewlyAppearedDualShock3Usb([existing], before));
+        Assert.True(DefenderBtModeSwitcher.HasNewlyAppearedDualShock3Usb(
+            [existing, @"USB\VID_054C&PID_0268\NEW"], before));
+        Assert.False(DefenderBtModeSwitcher.HasNewlyAppearedDualShock3Usb(
+            [@"USB\VID_054C&PID_05C4\NEW"], before));
+    }
 }

--- a/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
+++ b/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
@@ -35,7 +35,7 @@ public enum DefenderBtModeSwitchResult
     Failed,
 
     /// <summary>
-    ///     The DualShock 4 identity disappeared and a DualShock 3 USB identity is present.
+    ///     The DualShock 4 identity disappeared and a new DualShock 3 USB identity appeared.
     /// </summary>
     Switched,
 
@@ -144,23 +144,62 @@ public static class DefenderBtModeSwitcher
     }
 
     /// <summary>
-    ///     True if a DualShock 3 USB identity (<c>VID_054C&amp;PID_0268</c>) is present on the bus.
+    ///     True if <paramref name="instanceId" /> is a DualShock 3 USB identity (<c>VID_054C&amp;PID_0268</c>).
     /// </summary>
-    public static bool IsDualShock3UsbPresent()
+    internal static bool IsDualShock3UsbInstanceId(string? instanceId)
     {
+        return instanceId is not null &&
+               instanceId.Contains("VID_054C", StringComparison.OrdinalIgnoreCase) &&
+               instanceId.Contains("PID_0268", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    ///     Instance IDs of DualShock 3 USB identities currently on the bus. Snapshot this before a switch
+    ///     attempt so a pre-existing <c>054C:0268</c> is not mistaken for the Defender re-enumerating.
+    /// </summary>
+    public static IReadOnlyList<string> ListDualShock3UsbInstanceIds()
+    {
+        List<string> instanceIds = [];
         int instance = 0;
         while (Devcon.FindByInterfaceGuid(
                    DeviceInterfaceIds.UsbDevice, out string? _, out string? instanceId, instance++))
         {
-            if (instanceId is not null &&
-                instanceId.Contains("VID_054C", StringComparison.OrdinalIgnoreCase) &&
-                instanceId.Contains("PID_0268", StringComparison.OrdinalIgnoreCase))
+            if (IsDualShock3UsbInstanceId(instanceId))
+            {
+                instanceIds.Add(instanceId);
+            }
+        }
+
+        return instanceIds;
+    }
+
+    /// <summary>
+    ///     True if <paramref name="currentInstanceIds" /> contains a DualShock 3 USB identity that was not in
+    ///     <paramref name="instanceIdsBefore" />.
+    /// </summary>
+    internal static bool HasNewlyAppearedDualShock3Usb(
+        IEnumerable<string> currentInstanceIds,
+        IEnumerable<string> instanceIdsBefore)
+    {
+        HashSet<string> before = new(instanceIdsBefore, StringComparer.OrdinalIgnoreCase);
+        foreach (string instanceId in currentInstanceIds)
+        {
+            if (IsDualShock3UsbInstanceId(instanceId) && !before.Contains(instanceId))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///     True if a DualShock 3 USB identity has appeared since <paramref name="instanceIdsBefore" /> was
+    ///     captured.
+    /// </summary>
+    public static bool HasNewlyAppearedDualShock3Usb(IEnumerable<string> instanceIdsBefore)
+    {
+        return HasNewlyAppearedDualShock3Usb(ListDualShock3UsbInstanceIds(), instanceIdsBefore);
     }
 
     /// <summary>

--- a/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
+++ b/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
@@ -7,6 +7,9 @@ using Windows.Win32.Storage.FileSystem;
 
 using Microsoft.Win32.SafeHandles;
 
+using Nefarius.Utilities.DeviceManagement.Extensions;
+using Nefarius.Utilities.DeviceManagement.PnP;
+
 namespace Nefarius.DsHidMini.ControlApp.Models.Util;
 
 /// <summary>
@@ -21,15 +24,31 @@ public enum DefenderBtModeSwitchResult
     NotADefenderBt,
 
     /// <summary>
-    ///     The probe report was sent successfully; the device is expected to detach and re-enumerate as a
-    ///     DualShock 3 (<c>USB\VID_054C&amp;PID_0268</c>) shortly after.
+    ///     The probe report was written to the HID stack. This is not proof that the controller switched;
+    ///     a live Defender can ACK Feature 0x14 and stay on <c>054C:05C4</c>.
     /// </summary>
     Sent,
 
     /// <summary>
     ///     A matching device was found but sending the probe report failed.
     /// </summary>
-    Failed
+    Failed,
+
+    /// <summary>
+    ///     The DualShock 4 identity disappeared and a DualShock 3 USB identity is present.
+    /// </summary>
+    Switched,
+
+    /// <summary>
+    ///     The probe was delivered but the controller stayed in DualShock 4 mode.
+    /// </summary>
+    IgnoredByHardware,
+
+    /// <summary>
+    ///     A late probe was ignored and the USB port could not be reset. Replug, or run as administrator so the
+    ///     port can be cycled and the probe retried immediately after re-enumeration.
+    /// </summary>
+    NeedsReconnect
 }
 
 /// <summary>
@@ -44,6 +63,13 @@ public enum DefenderBtModeSwitchResult
 ///     periodically sends a real DualShock 4 as well (harmless no-op there), but detection/targeting still
 ///     requires the Defender-specific <see cref="DefenderBtVersionNumber" /> discriminator below (in addition
 ///     to VID/PID) so that a genuine DualShock 4 is never misidentified as, or targeted as, a Defender BT.
+///     <para>
+///         A successful <c>HidD_SetFeature</c> only means the USB SET_REPORT was ACKed. On Windows the
+///         Defender often ignores a late probe after interrupt IN is already streaming; the PS3 sent this
+///         report a few milliseconds after SET_IDLE. Callers must wait for the DualShock 4 identity to
+///         disappear (and preferably for <c>054C:0268</c> to appear) before reporting success, and should
+///         retry immediately after a USB port cycle or replug when a late probe is ignored.
+///     </para>
 /// </remarks>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
 public static class DefenderBtModeSwitcher
@@ -97,6 +123,16 @@ public static class DefenderBtModeSwitcher
     }
 
     /// <summary>
+    ///     True if VID/PID/version match the Defender-BT DualShock 4 identity (not a genuine DualShock 4).
+    /// </summary>
+    internal static bool MatchesDs4Identity(ushort vendorId, ushort productId, ushort versionNumber)
+    {
+        return vendorId == SonyVendorId &&
+               productId == DualShock4ProductId &&
+               versionNumber == DefenderBtVersionNumber;
+    }
+
+    /// <summary>
     ///     True if <paramref name="devicePath" /> points to a HID device currently reporting the Defender-BT
     ///     DualShock 4 identity (VID 0x054C, PID 0x05C4, VersionNumber 0x0221) - not just any DualShock 4.
     /// </summary>
@@ -104,7 +140,27 @@ public static class DefenderBtModeSwitcher
     {
         using SafeFileHandle handle = OpenDevice(devicePath);
         return !handle.IsInvalid && TryGetAttributes(handle, out HIDD_ATTRIBUTES attributes) &&
-               IsDefenderBtCandidate(attributes);
+               MatchesDs4Identity(attributes.VendorID, attributes.ProductID, attributes.VersionNumber);
+    }
+
+    /// <summary>
+    ///     True if a DualShock 3 USB identity (<c>VID_054C&amp;PID_0268</c>) is present on the bus.
+    /// </summary>
+    public static bool IsDualShock3UsbPresent()
+    {
+        int instance = 0;
+        while (Devcon.FindByInterfaceGuid(
+                   DeviceInterfaceIds.UsbDevice, out string? _, out string? instanceId, instance++))
+        {
+            if (instanceId is not null &&
+                instanceId.Contains("VID_054C", StringComparison.OrdinalIgnoreCase) &&
+                instanceId.Contains("PID_0268", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -116,7 +172,7 @@ public static class DefenderBtModeSwitcher
         using SafeFileHandle handle = OpenDevice(devicePath);
 
         if (handle.IsInvalid || !TryGetAttributes(handle, out HIDD_ATTRIBUTES attributes) ||
-            !IsDefenderBtCandidate(attributes))
+            !MatchesDs4Identity(attributes.VendorID, attributes.ProductID, attributes.VersionNumber))
         {
             return DefenderBtModeSwitchResult.NotADefenderBt;
         }
@@ -143,19 +199,58 @@ public static class DefenderBtModeSwitcher
     }
 
     /// <summary>
-    ///     True if <paramref name="attributes" /> match the Defender BT's known DualShock 4 identity signature
-    ///     (VID/PID plus the Defender-specific <see cref="DefenderBtVersionNumber" />), as opposed to a genuine
-    ///     DualShock 4, which shares the same VID/PID but reports a different version number.
+    ///     Power-cycles the USB hub port that owns <paramref name="hidDevicePath" /> so the next probe can be
+    ///     sent immediately after re-enumeration, matching the PS3's post-SET_IDLE timing.
     /// </summary>
-    private static bool IsDefenderBtCandidate(HIDD_ATTRIBUTES attributes)
+    /// <returns>False if the port could not be cycled (typically missing administrator rights).</returns>
+    public static bool TryCycleUsbPort(string hidDevicePath)
     {
-        return attributes.VendorID == SonyVendorId &&
-               attributes.ProductID == DualShock4ProductId &&
-               attributes.VersionNumber == DefenderBtVersionNumber;
+        try
+        {
+            PnPDevice? hidDevice = PnPDevice.GetDeviceByInterfaceId(hidDevicePath);
+            if (hidDevice is null)
+            {
+                Log.Logger.Warning("Could not resolve HID interface {DevicePath} for USB port cycle", hidDevicePath);
+                return false;
+            }
+
+            IPnPDevice? parent = hidDevice.Parent;
+            if (parent is null || string.IsNullOrEmpty(parent.InstanceId))
+            {
+                Log.Logger.Warning("HID interface {DevicePath} has no USB parent to cycle", hidDevicePath);
+                return false;
+            }
+
+            PnPDevice usbDevice = PnPDevice.GetDeviceByInstanceId(parent.InstanceId);
+            Log.Logger.Information("Cycling USB port for Defender BT parent {InstanceId}", usbDevice.InstanceId);
+            usbDevice.ToUsbPnPDevice().CyclePort();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Warning(ex, "USB port cycle failed for Defender BT candidate {DevicePath}", hidDevicePath);
+            return false;
+        }
     }
 
     private static SafeFileHandle OpenDevice(string devicePath)
     {
+        SafeFileHandle exclusive = PInvoke.CreateFile(
+            devicePath,
+            (uint)(FILE_ACCESS_RIGHTS.FILE_GENERIC_READ | FILE_ACCESS_RIGHTS.FILE_GENERIC_WRITE),
+            0,
+            null,
+            FILE_CREATION_DISPOSITION.OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_NORMAL,
+            null
+        );
+
+        if (!exclusive.IsInvalid)
+        {
+            return exclusive;
+        }
+
+        exclusive.Dispose();
         return PInvoke.CreateFile(
             devicePath,
             (uint)(FILE_ACCESS_RIGHTS.FILE_GENERIC_READ | FILE_ACCESS_RIGHTS.FILE_GENERIC_WRITE),

--- a/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
+++ b/ControlApp/Models/Util/DefenderBtModeSwitcher.cs
@@ -45,8 +45,9 @@ public enum DefenderBtModeSwitchResult
     IgnoredByHardware,
 
     /// <summary>
-    ///     A late probe was ignored and the USB port could not be reset. Replug, or run as administrator so the
-    ///     port can be cycled and the probe retried immediately after re-enumeration.
+    ///     The DualShock 4 identity is gone and no new DualShock 3 appeared: either the USB port cycle failed,
+    ///     or it succeeded without either identity coming back. Reconnect (or run as administrator so the port
+    ///     can be cycled) so the pending probe is retried immediately after re-enumeration.
     /// </summary>
     NeedsReconnect
 }

--- a/ControlApp/Services/AppSnackbarMessagesService.cs
+++ b/ControlApp/Services/AppSnackbarMessagesService.cs
@@ -137,8 +137,8 @@ public class AppSnackbarMessagesService
     public void ShowDefenderBtSwitchedToPs3ModeMessage()
     {
         _snackbarService.Show(
-            "Switch to PS3 mode requested",
-            "The controller should detach and reappear as a DualShock 3 in a moment. Use the normal pairing controls once it shows up.",
+            "Switched to PS3 mode",
+            "The controller re-enumerated as a DualShock 3. Use the normal pairing controls once it shows up.",
             ControlAppearance.Success,
             new SymbolIcon(SymbolRegular.CheckmarkCircle24),
             TimeSpan.FromSeconds(5)
@@ -153,6 +153,28 @@ public class AppSnackbarMessagesService
             ControlAppearance.Danger,
             new SymbolIcon(SymbolRegular.DismissCircle24),
             TimeSpan.FromSeconds(5)
+        );
+    }
+
+    public void ShowDefenderBtSwitchNeedsReconnectMessage()
+    {
+        _snackbarService.Show(
+            "PS3 mode switch did not take effect",
+            "The controller stayed in DualShock 4 mode. Unplug and replug it, or restart ControlApp as Administrator so the USB port can be reset and the probe retried immediately.",
+            ControlAppearance.Caution,
+            new SymbolIcon(SymbolRegular.Warning24),
+            TimeSpan.FromSeconds(8)
+        );
+    }
+
+    public void ShowDefenderBtSwitchIgnoredByHardwareMessage()
+    {
+        _snackbarService.Show(
+            "PS3 mode switch ignored by hardware",
+            "The probe was delivered and the USB port was reset, but the controller stayed in DualShock 4 mode. This firmware may not implement the PS3 identity switch.",
+            ControlAppearance.Caution,
+            new SymbolIcon(SymbolRegular.Warning24),
+            TimeSpan.FromSeconds(8)
         );
     }
 

--- a/ControlApp/Services/DefenderBtStatusService.cs
+++ b/ControlApp/Services/DefenderBtStatusService.cs
@@ -19,12 +19,29 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
     /// </summary>
     private static readonly TimeSpan RescanDebounce = TimeSpan.FromMilliseconds(250);
 
+    /// <summary>
+    ///     How long a late probe is given to make the DualShock 4 identity disappear before we treat it as ignored.
+    /// </summary>
+    private static readonly TimeSpan LateProbeWait = TimeSpan.FromMilliseconds(1500);
+
+    /// <summary>
+    ///     How long to wait after a USB port cycle for either DualShock 3 appearance or a DualShock 4 re-arrival
+    ///     that we can probe again.
+    /// </summary>
+    private static readonly TimeSpan ReenumerateWait = TimeSpan.FromSeconds(4);
+
     private DeviceNotificationListener? _listener;
 
     /// <summary>
     ///     HID device path (symbolic link) of the currently detected Defender BT in DualShock 4 mode, if any.
     /// </summary>
     private string? _detectedDevicePath;
+
+    /// <summary>
+    ///     When set, the next DualShock 4 arrival is probed immediately (no debounce), matching the PS3's
+    ///     post-SET_IDLE timing.
+    /// </summary>
+    private int _pendingImmediateSwitch;
 
     /// <summary>
     ///     Cancellation source for the pending debounced rescan, if any. Re-created (cancelling the previous
@@ -99,38 +116,110 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
     }
 
     /// <summary>
-    ///     Sends the PS3 mode-switch probe to the currently detected device, if any. Intended to be called from
-    ///     the UI thread (e.g. a button command), since it toggles <see cref="IsSwitching" />.
+    ///     Sends the PS3 mode-switch probe and, if the controller ignores a late probe, cycles the USB port so
+    ///     the next arrival can be probed immediately. Intended to be called from the UI thread.
     /// </summary>
-    public bool TrySwitchToPs3Mode()
+    public async Task<DefenderBtModeSwitchResult> SwitchToPs3ModeAsync()
     {
         if (_detectedDevicePath is null)
         {
-            return false;
+            return DefenderBtModeSwitchResult.NotADefenderBt;
         }
 
         IsSwitching = true;
+        OnPropertyChanged(nameof(CanSwitch));
 
         try
         {
-            DefenderBtModeSwitchResult result =
-                DefenderBtModeSwitcher.TrySwitchToPs3Mode(_detectedDevicePath);
-
+            string devicePath = _detectedDevicePath;
+            DefenderBtModeSwitchResult sent = DefenderBtModeSwitcher.TrySwitchToPs3Mode(devicePath);
             Log.Logger.Information(
-                "Defender BT PS3 mode-switch attempt for {DevicePath} resulted in {Result}",
-                _detectedDevicePath, result);
+                "Defender BT PS3 mode-switch probe for {DevicePath} resulted in {Result}",
+                devicePath, sent);
 
-            return result == DefenderBtModeSwitchResult.Sent;
+            if (sent != DefenderBtModeSwitchResult.Sent)
+            {
+                return sent;
+            }
+
+            if (await WaitForSwitchAsync(LateProbeWait).ConfigureAwait(true))
+            {
+                return DefenderBtModeSwitchResult.Switched;
+            }
+
+            Volatile.Write(ref _pendingImmediateSwitch, 1);
+            if (!DefenderBtModeSwitcher.TryCycleUsbPort(devicePath))
+            {
+                Log.Logger.Warning(
+                    "Defender BT stayed in DualShock 4 mode after a late probe; USB port cycle failed");
+                return DefenderBtModeSwitchResult.NeedsReconnect;
+            }
+
+            if (await WaitForSwitchAsync(ReenumerateWait).ConfigureAwait(true))
+            {
+                return DefenderBtModeSwitchResult.Switched;
+            }
+
+            Volatile.Write(ref _pendingImmediateSwitch, 0);
+            return DefenderBtModeSwitchResult.IgnoredByHardware;
         }
         finally
         {
             IsSwitching = false;
+            OnPropertyChanged(nameof(CanSwitch));
         }
     }
 
     private void OnListenerDevicesArrivedOrRemoved(DeviceEventArgs e)
     {
+        if (Volatile.Read(ref _pendingImmediateSwitch) != 0 ||
+            ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode)
+        {
+            TrySendImmediateProbe();
+        }
+
         QueueRescan();
+    }
+
+    /// <summary>
+    ///     Sends the probe as soon as a DualShock 4 identity is visible, without waiting for the UI debounce.
+    ///     The PS3 issued Feature 0x14 a few milliseconds after SET_IDLE; a 250 ms delay is already late.
+    /// </summary>
+    private void TrySendImmediateProbe()
+    {
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                string? path = FindDefenderBtCandidatePath();
+                if (path is null)
+                {
+                    return;
+                }
+
+                DefenderBtModeSwitchResult result = DefenderBtModeSwitcher.TrySwitchToPs3Mode(path);
+                Log.Logger.Information(
+                    "Immediate Defender BT PS3 mode-switch probe for {DevicePath} resulted in {Result}",
+                    path, result);
+
+                // One-shot: a failed button click arms this so the next plugin is probed
+                // even when auto-switch is off. Do not clear on a removal-only event.
+                Volatile.Write(ref _pendingImmediateSwitch, 0);
+
+                if (result == DefenderBtModeSwitchResult.Sent)
+                {
+                    Thread.Sleep(50);
+                    if (FindDefenderBtCandidatePath() is { } stillThere)
+                    {
+                        DefenderBtModeSwitcher.TrySwitchToPs3Mode(stillThere);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Warning(ex, "Immediate Defender BT PS3 mode-switch probe failed");
+            }
+        });
     }
 
     /// <summary>
@@ -169,28 +258,12 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
     }
 
     /// <summary>
-    ///     Runs on a thread-pool thread: enumerates HID devices, opens/queries each candidate, and - if a match
-    ///     is found and auto-switch is enabled - sends the mode-switch probe, all off the UI thread. Only the
-    ///     final observable state update is marshaled back to the dispatcher, guarded against staleness by
-    ///     <paramref name="generation" />.
+    ///     Runs on a thread-pool thread: enumerates HID devices and opens/queries each candidate. Immediate
+    ///     probes happen in <see cref="TrySendImmediateProbe" /> so this scan only updates UI state.
     /// </summary>
     private void RunScan(int generation)
     {
         string? foundPath = FindDefenderBtCandidatePath();
-
-        if (foundPath is not null && ApplicationConfiguration.Instance.AutoSwitchDefenderBtToPs3Mode)
-        {
-            // A newer scan superseded this one; do not act on a stale result.
-            if (generation != Volatile.Read(ref _scanGeneration))
-            {
-                return;
-            }
-
-            Log.Logger.Information(
-                "AutoSwitchDefenderBtToPs3Mode is enabled, automatically switching detected device");
-            DefenderBtModeSwitcher.TrySwitchToPs3Mode(foundPath);
-        }
-
         Application.Current?.Dispatcher.BeginInvoke(() => ApplyScanResult(generation, foundPath));
     }
 
@@ -207,6 +280,34 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
         }
 
         return null;
+    }
+
+    private async Task<bool> WaitForSwitchAsync(TimeSpan timeout)
+    {
+        TimeSpan poll = TimeSpan.FromMilliseconds(100);
+        TimeSpan elapsed = TimeSpan.Zero;
+
+        while (elapsed < timeout)
+        {
+            await Task.Delay(poll).ConfigureAwait(true);
+            elapsed += poll;
+
+            bool ds4Gone = FindDefenderBtCandidatePath() is null;
+            if (!ds4Gone)
+            {
+                continue;
+            }
+
+            if (DefenderBtModeSwitcher.IsDualShock3UsbPresent())
+            {
+                Volatile.Write(ref _pendingImmediateSwitch, 0);
+                return true;
+            }
+
+            // Port cycle drops 05C4 briefly before it reappears. Keep waiting unless a DS3 showed up.
+        }
+
+        return FindDefenderBtCandidatePath() is null && DefenderBtModeSwitcher.IsDualShock3UsbPresent();
     }
 
     /// <summary>
@@ -227,7 +328,7 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
         {
             StatusTitle = "Retro Fighters Defender BT detected in DualShock 4 mode";
             StatusMessage =
-                "Switch it to PS3 (DualShock 3) mode so DsHidMini can bind to it and Bluetooth pairing becomes available.";
+                "Switch it to PS3 (DualShock 3) mode so DsHidMini can bind to it and Bluetooth pairing becomes available. If a late switch is ignored, the USB port is reset and the probe is retried immediately after re-enumeration.";
             Severity = InfoBarSeverity.Informational;
         }
         else

--- a/ControlApp/Services/DefenderBtStatusService.cs
+++ b/ControlApp/Services/DefenderBtStatusService.cs
@@ -132,6 +132,7 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
         try
         {
             string devicePath = _detectedDevicePath;
+            IReadOnlyList<string> ds3Before = DefenderBtModeSwitcher.ListDualShock3UsbInstanceIds();
             DefenderBtModeSwitchResult sent = DefenderBtModeSwitcher.TrySwitchToPs3Mode(devicePath);
             Log.Logger.Information(
                 "Defender BT PS3 mode-switch probe for {DevicePath} resulted in {Result}",
@@ -142,7 +143,7 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
                 return sent;
             }
 
-            if (await WaitForSwitchAsync(LateProbeWait).ConfigureAwait(true))
+            if (await WaitForSwitchAsync(LateProbeWait, ds3Before).ConfigureAwait(true))
             {
                 return DefenderBtModeSwitchResult.Switched;
             }
@@ -155,13 +156,20 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
                 return DefenderBtModeSwitchResult.NeedsReconnect;
             }
 
-            if (await WaitForSwitchAsync(ReenumerateWait).ConfigureAwait(true))
+            if (await WaitForSwitchAsync(ReenumerateWait, ds3Before).ConfigureAwait(true))
             {
                 return DefenderBtModeSwitchResult.Switched;
             }
 
-            Volatile.Write(ref _pendingImmediateSwitch, 0);
-            return DefenderBtModeSwitchResult.IgnoredByHardware;
+            if (FindDefenderBtCandidatePath() is not null)
+            {
+                Volatile.Write(ref _pendingImmediateSwitch, 0);
+                return DefenderBtModeSwitchResult.IgnoredByHardware;
+            }
+
+            // Port cycle or unplug left neither identity on the bus. Keep the immediate-retry
+            // latch so the next DualShock 4 arrival is probed without requiring another click.
+            return DefenderBtModeSwitchResult.NeedsReconnect;
         }
         finally
         {
@@ -282,7 +290,7 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
         return null;
     }
 
-    private async Task<bool> WaitForSwitchAsync(TimeSpan timeout)
+    private async Task<bool> WaitForSwitchAsync(TimeSpan timeout, IReadOnlyList<string> ds3Before)
     {
         TimeSpan poll = TimeSpan.FromMilliseconds(100);
         TimeSpan elapsed = TimeSpan.Zero;
@@ -298,16 +306,17 @@ public partial class DefenderBtStatusService : ObservableObject, IDisposable
                 continue;
             }
 
-            if (DefenderBtModeSwitcher.IsDualShock3UsbPresent())
+            if (DefenderBtModeSwitcher.HasNewlyAppearedDualShock3Usb(ds3Before))
             {
                 Volatile.Write(ref _pendingImmediateSwitch, 0);
                 return true;
             }
 
-            // Port cycle drops 05C4 briefly before it reappears. Keep waiting unless a DS3 showed up.
+            // Port cycle drops 05C4 briefly before it reappears. Keep waiting unless a new DS3 showed up.
         }
 
-        return FindDefenderBtCandidatePath() is null && DefenderBtModeSwitcher.IsDualShock3UsbPresent();
+        return FindDefenderBtCandidatePath() is null &&
+               DefenderBtModeSwitcher.HasNewlyAppearedDualShock3Usb(ds3Before);
     }
 
     /// <summary>

--- a/ControlApp/ViewModels/Pages/DevicesViewModel.cs
+++ b/ControlApp/ViewModels/Pages/DevicesViewModel.cs
@@ -140,15 +140,23 @@ public partial class DevicesViewModel : ObservableObject, INavigationAware
     }
 
     [RelayCommand]
-    private void SwitchDefenderBtToPs3Mode()
+    private async Task SwitchDefenderBtToPs3Mode()
     {
-        if (DefenderBt.TrySwitchToPs3Mode())
+        DefenderBtModeSwitchResult result = await DefenderBt.SwitchToPs3ModeAsync();
+        switch (result)
         {
-            _appSnackbarMessagesService.ShowDefenderBtSwitchedToPs3ModeMessage();
-        }
-        else
-        {
-            _appSnackbarMessagesService.ShowDefenderBtSwitchToPs3ModeFailedMessage();
+            case DefenderBtModeSwitchResult.Switched:
+                _appSnackbarMessagesService.ShowDefenderBtSwitchedToPs3ModeMessage();
+                break;
+            case DefenderBtModeSwitchResult.NeedsReconnect:
+                _appSnackbarMessagesService.ShowDefenderBtSwitchNeedsReconnectMessage();
+                break;
+            case DefenderBtModeSwitchResult.IgnoredByHardware:
+                _appSnackbarMessagesService.ShowDefenderBtSwitchIgnoredByHardwareMessage();
+                break;
+            default:
+                _appSnackbarMessagesService.ShowDefenderBtSwitchToPs3ModeFailedMessage();
+                break;
         }
     }
 

--- a/ControlApp/ViewModels/Pages/SettingsViewModel.cs
+++ b/ControlApp/ViewModels/Pages/SettingsViewModel.cs
@@ -107,8 +107,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     /// <summary>
     ///     When enabled, a Retro Fighters Defender Bluetooth Edition detected in DualShock 4 mode is switched
-    ///     into PS3 (DualShock 3) mode automatically instead of requiring the "Switch to PS3 mode" button on the
-    ///     Devices page (see issue #282).
+    ///     into PS3 (DualShock 3) mode immediately on arrival (see issue #282). A late button click is less
+    ///     reliable because the PS3 sent the probe a few milliseconds after SET_IDLE.
     /// </summary>
     public bool AutoSwitchDefenderBtToPs3Mode
     {

--- a/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
+++ b/ControlApp/ViewModels/UserControls/DeviceViewModel.cs
@@ -1107,7 +1107,7 @@ public partial class DeviceViewModel : ObservableObject, IDisposable
 
                           ➤ If in "To this PC" mode, the PC's bluetooth adapter must be enabled and turned ON for pairing to succeed.
 
-                          ➤ Retro Fighters Defender Bluetooth Edition owners: plug the controller in via USB, then use the "Switch to PS3 mode" button on the Devices page (shown when it's detected in DualShock 4 mode) before pairing.
+                          ➤ Retro Fighters Defender Bluetooth Edition owners: plug the controller in via USB. Prefer enabling "Automatically switch Retro Fighters Defender BT to PS3 mode" in Settings, then replug, so the probe is sent immediately after enumeration. The Devices page button can also reset the USB port and retry. The controller must reappear as a DualShock 3 before pairing.
                           """,
                 PrimaryButtonText = "I need more help!",
                 CloseButtonText = "Close"

--- a/ControlApp/Views/Pages/SettingsPage.xaml
+++ b/ControlApp/Views/Pages/SettingsPage.xaml
@@ -45,7 +45,7 @@
             <TextBlock
                 MaxWidth="600"
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Text="When enabled, a Retro Fighters Defender Bluetooth Edition detected in DualShock 4 mode is switched into PS3 (DualShock 3) mode automatically, instead of requiring the 'Switch to PS3 mode' button on the Devices page."
+                Text="When enabled, a Retro Fighters Defender Bluetooth Edition detected in DualShock 4 mode is switched into PS3 (DualShock 3) mode automatically on arrival. Sending the probe immediately after plugin is more reliable than clicking the Devices page button after the pad is already streaming."
                 TextWrapping="Wrap" />
 
             <CheckBox

--- a/docs/PS3_USB_STARTUP.md
+++ b/docs/PS3_USB_STARTUP.md
@@ -132,14 +132,34 @@ quirk work does not need to re-derive them from the pcaps.
   Windows-side tool is harmless to real DS4 controllers.
   `2024-05-04_Windows-PC-plugin-capture.pcapng` confirms Windows itself
   never sends `Feature 0x14`, which is the only reason the Defender BT
-  never leaves DS4 mode when plugged into a PC; cycling the controller to
-  DS4 mode (hold Home ~3 s, per the manual) and then replaying the same
-  `0x14` report via `HidD_SetFeature` from user mode is enough to make it
-  re-enumerate as `USB\VID_054C&PID_0268`, which DsHidMini already binds
-  to via the existing `dshidmini.inf` entry. ControlApp's
-  `DefenderBtModeSwitcher` (see issue #282) automates exactly this replay
-  so Bluetooth pairing becomes reachable on Windows without resorting to a
-  PS3-first-pairing + MAC-spoofing workaround.
+  never leaves DS4 mode when plugged into a PC. Replaying that report via
+  `HidD_SetFeature` is the right USB packet (Feature, report ID `0x14`,
+  17 bytes starting `14 02 …`), but a successful `HidD_SetFeature` only
+  means the transfer was ACKed. A live Defender in DS4 mode (`054C:05C4`
+  `bcdDevice 0x0221`) can ACK the report and stay on the bus; GET Feature
+  `0x14` times out (`ERROR_SEM_TIMEOUT` / 121). The PS3 sent the probe a
+  few milliseconds after `SET_IDLE`, before sustained interrupt IN. A
+  late probe from an already-streaming Windows session is often ignored.
+  ControlApp therefore treats disappearance of the DS4 identity plus
+  appearance of `USB\VID_054C&PID_0268` as the only success signal, sends
+  the probe immediately on HID arrival (auto-switch or a pending retry),
+  and cycles the USB port (administrator) when a late button click is
+  ignored so the next enumeration can be probed while it still looks like
+  a PS3 attach. `dshidmini.inf` already binds the DS3 identity.
+  A follow-up on the same capture pads, with `054C:05C4` `REV_0221`
+  Zadig-bound to WinUSB (service `WinUSB`, no HidUsb child, no interrupt
+  IN started), sent the PS3 EP0 sequence with
+  `research/ds3-motion/probe/WinUsbRaw.cs`: `SET_PROTOCOL` (report
+  protocol), `SET_IDLE`, then Feature `0x14` (17 bytes `14 02 00…`).
+  `WinUsb_ControlTransfer` succeeded for that sequence and for the
+  variants Feature `0x14` alone, `SET_PROTOCOL` + `0x14`, and one
+  interrupt IN (64-byte DS4 input starting `01 80 80 80…`) then `0x14`.
+  None of them detached the DualShock 4 identity or produced
+  `USB\VID_054C&PID_0268`. So a late Windows host - even when it owns
+  EP0 and does not start HID polling - is not equivalent to the PS3
+  attach window. The remaining gap is whatever Windows already sent
+  during the original hidusb / Zadig enumeration (and possibly
+  `bcdUSB 2.00` vs the PS3 session), not a mangled `0x14` payload.
 
   The relevant `tshark` filters used against the captures above (run
   locally; see the `analyze_pcap` limitation note below):


### PR DESCRIPTION
HidD_SetFeature succeeds on a live 054C:05C4 pad without re-enumeration. Wait for the DualShock 3 identity, retry immediately after plugin or a USB port cycle, and document that a late Windows host ignores the PS3 probe even when WinUSB owns EP0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved automatic switching of supported Defender Bluetooth controllers to PS3 mode immediately after connection.
  - Improved detection of controller identities and confirmation of mode-switch results based on reconnection and newly detected USB devices.
  - Added USB port reset and retry handling when a controller does not switch immediately.
  - Added clearer status messages for successful switches, required reconnection, hardware-ignored requests, and failures.

- **Documentation**
  - Updated setup guidance to recommend automatic PS3-mode switching and explain USB reset and retry options.
  - Clarified that successful switching is confirmed by controller reconnection, not merely an acknowledgment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->