### PR TITLE
Zero clone-heuristic PLAIN_ZERO gyro rest bias in software only.

### DIFF
--- a/ControlApp.Tests/MotionIpcLayoutTests.cs
+++ b/ControlApp.Tests/MotionIpcLayoutTests.cs
@@ -46,6 +46,7 @@ public class MotionIpcLayoutTests
         Assert.Equal(0x0002, (int)DsMotionSnapshotFlags.Fallback);
         Assert.Equal(0x0004, (int)DsMotionSnapshotFlags.HardwareCal);
         Assert.Equal(0x0008, (int)DsMotionSnapshotFlags.Tracker);
+        Assert.Equal(0x0010, (int)DsMotionSnapshotFlags.SoftwareZero);
     }
 
     [Fact]

--- a/ControlApp.Tests/MotionProcessingTests.cs
+++ b/ControlApp.Tests/MotionProcessingTests.cs
@@ -147,4 +147,41 @@ public class MotionProcessingTests
 
         Assert.True(everChanged || tracker.ZeroRef != 521);
     }
+
+    [Fact]
+    public void Tracker_SoftwareOnly_ObigbenRestCentersWithoutCalByte()
+    {
+        SonyGyroTracker tracker = new();
+        tracker.Initial(0x00, 512, softwareOnly: true);
+
+        for (int i = 0; i < 200; i++)
+        {
+            tracker.Runtime(500, out _);
+        }
+
+        Assert.Equal(500, tracker.ZeroRef);
+        Assert.Equal(512, tracker.Output);
+        Assert.Equal(0, tracker.CalByteRaw);
+    }
+
+    [Fact]
+    public void Tracker_SoftwareOnly_LargeOffsetCentersWhileStockLeavesResidual()
+    {
+        SonyGyroTracker stock = new();
+        stock.Initial(0x00, 512);
+        SonyGyroTracker soft = new();
+        soft.Initial(0x00, 512, softwareOnly: true);
+
+        for (int i = 0; i < 200; i++)
+        {
+            stock.Runtime(450, out _);
+            soft.Runtime(450, out _);
+        }
+
+        Assert.Equal(450, soft.ZeroRef);
+        Assert.Equal(512, soft.Output);
+        Assert.Equal(0, soft.CalByteRaw);
+        Assert.NotEqual(512, stock.Output);
+        Assert.NotEqual(0, stock.CalByteRaw);
+    }
 }

--- a/ControlApp.Tests/SonyGyroTracker.cs
+++ b/ControlApp.Tests/SonyGyroTracker.cs
@@ -39,6 +39,7 @@ internal sealed class SonyGyroTracker
     private int _ringIdx;
     private int _ringSum;
     private int _settleLeft;
+    private bool _softwareOnly;
     private int _zeroRef;
 
     public byte CalByte => unchecked((byte)_calByte);
@@ -53,8 +54,9 @@ internal sealed class SonyGyroTracker
 
     private static int Clamp10(int value) => value < 0 ? 0 : value > 1023 ? 1023 : value;
 
-    public byte Initial(ushort eepromCal, ushort eepromZero)
+    public byte Initial(ushort eepromCal, ushort eepromZero, bool softwareOnly = false)
     {
+        _softwareOnly = softwareOnly;
         _calByte = eepromCal;
         _lastRaw = eepromZero;
         _settleLeft = SettleInitial;
@@ -98,6 +100,13 @@ internal sealed class SonyGyroTracker
 
     private bool Retarget(int restAvg, out int zeroRef, out int calByte)
     {
+        if (_softwareOnly)
+        {
+            zeroRef = restAvg;
+            calByte = _calByte;
+            return false;
+        }
+
         int delta = (Target - restAvg) * 1024;
         if (-StepQ10 <= delta && delta <= StepQ10)
         {

--- a/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
+++ b/ControlApp/ViewModels/Windows/MotionViewerViewModel.cs
@@ -220,7 +220,8 @@ public sealed partial class MotionViewerViewModel : ObservableObject, IDisposabl
         GyroDpsText = $"{snapshot.GyroMilliDps / 1000.0:0.00} deg/s";
         EepromText =
             $"X {snapshot.AccelZeroX}/{snapshot.AccelOneGX}  Y {snapshot.AccelZeroY}/{snapshot.AccelOneGY}  Z {snapshot.AccelZeroZ}/{snapshot.AccelOneGZ}  G {snapshot.GyroZero}/{snapshot.GyroEepromCal}";
-        TrackerText = $"zero {snapshot.ZeroRef}  cal 0x{snapshot.CalByte:X2}  tracker {(snapshot.HasTracker ? "on" : "off")}";
+        TrackerText =
+            $"zero {snapshot.ZeroRef}  cal 0x{snapshot.CalByte:X2}  tracker {(snapshot.HasSoftwareZero ? "soft" : snapshot.HasTracker ? "on" : "off")}";
         SampleText = $"#{snapshot.SampleIndex}  QPC {snapshot.TimestampQpc}";
         RefreshPoseText();
     }

--- a/SDK/Nefarius.DsHidMini.IPC/Models/Public/MotionSnapshot.cs
+++ b/SDK/Nefarius.DsHidMini.IPC/Models/Public/MotionSnapshot.cs
@@ -33,9 +33,17 @@ public enum DsMotionSnapshotFlags : ushort
     HardwareCal = 0x0004,
 
     /// <summary>
-    ///     Sony's auto-zero tracker is running (<c>HW_CAL</c> / <c>SIXAXIS</c>).
+    ///     Sony's auto-zero tracker is running (<c>HW_CAL</c> / <c>SIXAXIS</c>
+    ///     hardware trim, or clone-heuristic <c>PLAIN_ZERO</c> software-only).
     /// </summary>
-    Tracker = 0x0008
+    Tracker = 0x0008,
+
+    /// <summary>
+    ///     The tracker is in software-only mode: <c>zeroRef</c> follows rest
+    ///     and the hardware cal byte is never stepped. Used for clone-heuristic
+    ///     <c>PLAIN_ZERO</c> pads whose EEPROM gyro zero is a template.
+    /// </summary>
+    SoftwareZero = 0x0010
 }
 
 /// <summary>
@@ -118,4 +126,6 @@ public struct DsMotionSnapshot
     public bool IsFallback => (Flags & DsMotionSnapshotFlags.Fallback) != 0;
 
     public bool HasTracker => (Flags & DsMotionSnapshotFlags.Tracker) != 0;
+
+    public bool HasSoftwareZero => (Flags & DsMotionSnapshotFlags.SoftwareZero) != 0;
 }

--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -724,9 +724,10 @@ gyro paths, selected by the flags:
 
 | Flags | Pads | Reported gyro |
 | --- | --- | --- |
-| `PLAIN_ZERO` set, `HW_CAL` clear | B1, DS3-A1a, DS3-E, both counterfeits | `clamp(512 + eepromZero - raw)` - plain software zero against the EEPROM value, no tracker |
+| `PLAIN_ZERO` set, `HW_CAL` clear | B1, DS3-A1a, DS3-E | `clamp(512 + eepromZero - raw)` - plain software zero against the EEPROM value, no tracker. Genuine EEPROM zeros are good to ~1.5 counts |
 | `PLAIN_ZERO` clear | SIXAXIS-1, SIXAXIS-2 | `clamp(512 + zeroRef - raw)` with the full auto-zero tracker driving `zeroRef` |
 | `HW_CAL` set | DS3-A1b, DS3-A2 | tracker runs (to keep the **hardware** trim converged and re-send cal bytes). `sixaxis.sys` then reports `clamp(0x3FF - raw)`. DsHidMini publishes `clamp(512 + zeroRef - raw)` only when the tracker is initialized (successful Feature `0xEF` page `0xA0`); after a failed or invalid EEPROM load it publishes `clamp(0x3FF - raw)` |
+| DsHidMini only: `PLAIN_ZERO` + clone heuristic | Obigben, Fake DS3 | software-only tracker: `clamp(512 + zeroRef - raw)` with `zeroRef` following the observed rest average. The cal byte is never stepped or sent (clones ignore it; PLAIN_ZERO never places it). `sixaxis.sys` would still use the EEPROM formula on these pads |
 
 All three **invert the gyro's sign relative to the raw value**, and the result is
 written back into the report as host-order u16.
@@ -766,7 +767,12 @@ both platforms, so on Linux it is not zeroed either.
   output (same formula as `SIXAXIS`) so a rest error below one ~26.4-count
   cal-byte step — e.g. DS3-A1b's 16-count / ~10.7 deg/s leftover — does not
   appear as yaw bias. If EEPROM load fails, the tracker stays uninitialized
-  and both IPC and GetFeature fall back to `clamp(0x3FF - raw)`.
+  and both IPC and GetFeature fall back to `clamp(0x3FF - raw)`. Clone-heuristic
+  `PLAIN_ZERO` USB pads (Obigben, Fake DS3) seed the same tracker in
+  **software-only** mode on every `0xEF` outcome: `zeroRef` follows rest and
+  the cal byte is never stepped or sent. Genuine `PLAIN_ZERO` pads are
+  unchanged. The Obigben gyro is frozen at ~500, so this only removes the
+  false rest drift; yaw will not follow turns.
 - **IPC**: the existing 60-byte raw HID slot is unchanged. A third
   allocation-granularity-aligned region publishes `IPC_MOTION_SNAPSHOT_MESSAGE`
   (80 bytes, version 1) from the same `Motion.Sample` (`CalGyro` /
@@ -891,12 +897,13 @@ Shipped in this pass:
 3. Accel gain-113 with post-cal X mirror; `zero == oneG` passthrough. Applied to the SIXAXIS GetFeature report and IPC snapshot, not the 12-byte SIXAXIS input report.
 4. Gyro sign inverted; tracker + cal-byte resend on `HW_CAL`/`SIXAXIS` USB pads.
 5. IPC third region + `GetMotionSnapshot`; ControlApp Motion viewer.
+6. Clone-heuristic `PLAIN_ZERO` software-only auto-zero. The Obigben template EEPROM gyro zero of 512 versus a frozen idle of ~500 would otherwise publish `clamp(512 + 512 - 500) = 524` (~8.6 deg/s clockwise) at rest; `zeroRef` follows rest and the cal byte is never sent. Frozen-sensor detection (the Fake DS3) stays deferred.
 
 Still deferred:
 
-6. Counterfeit behavioural detection (frozen sensors). Keep `zero == oneG` as a blank-EEPROM guard only.
-7. DS4Windows motion-field mapping. Source frame is known; permutation + remaining signs still need a reference DS4 capture.
-8. Bluetooth `0xEF` over the BthPS3 HID control channel (unverified). Absolute gyro scale better than ~1.4 counts/(deg/s).
+7. Counterfeit behavioural detection (frozen sensors). Keep `zero == oneG` as a blank-EEPROM guard only.
+8. DS4Windows motion-field mapping. Source frame is known; permutation + remaining signs still need a reference DS4 capture.
+9. Bluetooth `0xEF` over the BthPS3 HID control channel (unverified). Absolute gyro scale better than ~1.4 counts/(deg/s).
 
 Headline remaining gaps: Bluetooth EEPROM, DS4 axis mapping, counterfeit freeze detection, and a turntable gyro scale. Historical discrepancies versus pre-#217 DsHidMini are listed under [Discrepancies](#discrepancies-a-driver-implementation-must-resolve).
 
@@ -921,6 +928,11 @@ Headline remaining gaps: Bluetooth EEPROM, DS4 axis mapping, counterfeit freeze 
 - 2026-09-06 — Sony `sixaxis.sys` decompiled; formula, `0xA0` layout, three gyro paths verified (`386da4c`).
 - 2026-09-06 — eight-pad matrix, measured yaw sign/scale, cal-byte 26.69 (`a8ab908`).
 - 2026-09-06 — research tree persisted under `research/ds3-motion/`.
+- 2026-09-12 — Obigben BB4401 on USB (Feature `0x01` firmware `03 00 05`,
+  `PLAIN_ZERO`, clone heuristic): gyro frozen at ~500, EEPROM zero 512, so
+  Sony's PLAIN_ZERO formula publishes 524 (~8.6 deg/s clockwise) at rest.
+  Rotating the pad does not change `RawGyro`. Software-only tracker for
+  clone-heuristic `PLAIN_ZERO` only; genuine paths unchanged.
 
 ## Open questions
 

--- a/driver/DsMotion.c
+++ b/driver/DsMotion.c
@@ -128,9 +128,7 @@ DsMotion_TrackerRetarget(
 	_Out_ PINT32 CalByte
 )
 {
-	const INT32 delta = (DS_MOTION_TARGET - RestAvg) * 1024;
-
-	if (delta >= -DS_MOTION_GYRO_STEP_Q10 && delta <= DS_MOTION_GYRO_STEP_Q10)
+	if (Tracker->SoftwareOnly)
 	{
 		*ZeroRef = RestAvg;
 		*CalByte = Tracker->CalByte;
@@ -138,10 +136,21 @@ DsMotion_TrackerRetarget(
 	}
 
 	{
-		const INT32 steps = delta / DS_MOTION_GYRO_STEP_Q10;
-		*ZeroRef = RestAvg + DsMotion_Q10(steps * DS_MOTION_GYRO_STEP_Q10);
-		*CalByte = Tracker->CalByte + steps;
-		return TRUE;
+		const INT32 delta = (DS_MOTION_TARGET - RestAvg) * 1024;
+
+		if (delta >= -DS_MOTION_GYRO_STEP_Q10 && delta <= DS_MOTION_GYRO_STEP_Q10)
+		{
+			*ZeroRef = RestAvg;
+			*CalByte = Tracker->CalByte;
+			return FALSE;
+		}
+
+		{
+			const INT32 steps = delta / DS_MOTION_GYRO_STEP_Q10;
+			*ZeroRef = RestAvg + DsMotion_Q10(steps * DS_MOTION_GYRO_STEP_Q10);
+			*CalByte = Tracker->CalByte + steps;
+			return TRUE;
+		}
 	}
 }
 
@@ -344,10 +353,12 @@ VOID
 DsMotion_TrackerInitial(
 	_Inout_ PDS_GYRO_TRACKER Tracker,
 	_In_ USHORT EepromCal,
-	_In_ USHORT EepromZero
+	_In_ USHORT EepromZero,
+	_In_ BOOLEAN SoftwareOnly
 )
 {
 	RtlZeroMemory(Tracker, sizeof(*Tracker));
+	Tracker->SoftwareOnly = SoftwareOnly;
 	Tracker->CalByte = (INT32)EepromCal;
 	Tracker->LastRaw = (INT32)EepromZero;
 	Tracker->SettleLeft = DS_MOTION_SETTLE_INITIAL;
@@ -421,6 +432,37 @@ DsMotion_ResolvePath(
 	}
 
 	return DsIdentificationMotionPathPlainZero;
+}
+
+static
+VOID
+DsMotion_MaybeStartCloneSoftwareZero(
+	_In_ PDEVICE_CONTEXT Context
+)
+{
+	PDS_MOTION_STATE motion = &Context->Motion;
+
+	if (motion->Tracker.Initialized ||
+		motion->Path != DsIdentificationMotionPathPlainZero ||
+		!Context->IdentificationPresent ||
+		!Context->Identification.CloneHeuristic)
+	{
+		return;
+	}
+
+	DsMotion_TrackerInitial(
+		&motion->Tracker,
+		motion->Gyro.OneG,
+		motion->Gyro.Zero,
+		TRUE
+	);
+
+	TraceInformation(
+		TRACE_MOTION,
+		"Clone-heuristic PLAIN_ZERO: software-only gyro tracker seeded (eeprom zero=%u cal=0x%02X)",
+		motion->Gyro.Zero,
+		(UCHAR)motion->Gyro.OneG
+	);
 }
 
 static
@@ -605,6 +647,7 @@ DsMotion_TryLoadUsbCalibration(
 			"SET Feature 0xEF page 0xA0 failed with %!STATUS!; using nominal calibration",
 			status
 		);
+		DsMotion_MaybeStartCloneSoftwareZero(pDevCtx);
 		FuncExitNoReturn(TRACE_MOTION);
 		return;
 	}
@@ -631,6 +674,7 @@ DsMotion_TryLoadUsbCalibration(
 			status,
 			transferred
 		);
+		DsMotion_MaybeStartCloneSoftwareZero(pDevCtx);
 		FuncExitNoReturn(TRACE_MOTION);
 		return;
 	}
@@ -644,11 +688,14 @@ DsMotion_TryLoadUsbCalibration(
 		DsMotion_TrackerInitial(
 			&pDevCtx->Motion.Tracker,
 			pDevCtx->Motion.Gyro.OneG,
-			pDevCtx->Motion.Gyro.Zero
+			pDevCtx->Motion.Gyro.Zero,
+			FALSE
 		);
 		pDevCtx->Motion.SendHardwareCal = TRUE;
 		DsMotion_ApplyOutputCalByte(pDevCtx);
 	}
+
+	DsMotion_MaybeStartCloneSoftwareZero(pDevCtx);
 
 	TraceInformation(
 		TRACE_MOTION,
@@ -796,7 +843,14 @@ DsMotion_ProcessInputReport(
 
 	case DsIdentificationMotionPathPlainZero:
 	default:
-		calGyro = DsMotion_Clamp10(DS_MOTION_TARGET + (INT32)motion->Gyro.Zero - raw[3]);
+		if (motion->Tracker.Initialized)
+		{
+			calGyro = DsMotion_TrackerRuntime(&motion->Tracker, raw[3], &trackerChanged);
+		}
+		else
+		{
+			calGyro = DsMotion_Clamp10(DS_MOTION_TARGET + (INT32)motion->Gyro.Zero - raw[3]);
+		}
 		break;
 	}
 
@@ -878,6 +932,11 @@ DsMotion_FillIpcSnapshot(
 	if (motion->Tracker.Initialized)
 	{
 		flags |= DSHM_IPC_MOTION_FLAG_TRACKER;
+	}
+
+	if (motion->Tracker.Initialized && motion->Tracker.SoftwareOnly)
+	{
+		flags |= DSHM_IPC_MOTION_FLAG_SOFT_ZERO;
 	}
 
 	Snapshot->Flags = flags;

--- a/driver/DsMotion.h
+++ b/driver/DsMotion.h
@@ -12,6 +12,7 @@
 #define DSHM_IPC_MOTION_FLAG_FALLBACK        0x0002
 #define DSHM_IPC_MOTION_FLAG_HW_CAL          0x0004
 #define DSHM_IPC_MOTION_FLAG_TRACKER         0x0008
+#define DSHM_IPC_MOTION_FLAG_SOFT_ZERO       0x0010
 
 #define Ds3FeatureEeprom                     0x03EF
 
@@ -46,6 +47,7 @@ typedef struct _DS_GYRO_TRACKER
 	INT32 PendingZero;
 	INT32 PendingTol;
 	BOOLEAN Initialized;
+	BOOLEAN SoftwareOnly;
 } DS_GYRO_TRACKER, *PDS_GYRO_TRACKER;
 
 typedef struct _DS_MOTION_SAMPLE


### PR DESCRIPTION
Obigben template EEPROM zeros (512 vs idle ~500) published a constant ~8.6 deg/s clockwise yaw. Genuine HW_CAL, SIXAXIS, and PLAIN_ZERO paths stay on Sony's formulas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added software-only gyro tracking for supported clone motion devices.
  - Motion status now identifies when software zeroing is active.
  - Software zeroing centers rest and offset readings without changing hardware calibration data.

- **Documentation**
  - Updated motion documentation with software-zero behavior, fallback handling, supported devices, and measurement details.

- **Tests**
  - Added coverage for software-only tracking, calibration preservation, and motion flag values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->